### PR TITLE
fix: 不再强制填写后端会自动补齐的 Profile 名称

### DIFF
--- a/frontend/src/i18n.tsx
+++ b/frontend/src/i18n.tsx
@@ -44,6 +44,7 @@ const english = {
   "例如 deepseek/deepseek-v3": "For example, deepseek/deepseek-v3",
   "例如 siliconflow": "For example, siliconflow",
   "例如 team-ppio": "For example, team-ppio",
+  "留空则使用 Profile ID": "Leave blank to use the Profile ID",
   "例如 团队 PPIO": "For example, Team PPIO",
   "粘贴你的 API Key": "Paste your API key",
   "隐藏密钥": "Hide API key",

--- a/frontend/src/pages/ProfilesPage.test.tsx
+++ b/frontend/src/pages/ProfilesPage.test.tsx
@@ -145,6 +145,34 @@ describe("ProfilesPage", () => {
     })));
   });
 
+  it("saves a Profile whose name was left blank", async () => {
+    // The backend fills an empty label in from the existing value or the ID
+    // (internal/profile/write.go:71-74), so requiring one here was stricter than
+    // the write path and blocked a rename-to-nothing edit.
+    const save = vi.spyOn(api, "saveProfile").mockResolvedValue(profile());
+    renderPage([profile()]);
+    fireEvent.click(screen.getByRole("button", { name: "编辑 团队 PPIO" }));
+    const label = screen.getByLabelText("名称");
+    expect(label.hasAttribute("required")).toBe(false);
+    fireEvent.change(label, { target: { value: "" } });
+
+    const button = screen.getByRole("button", { name: "保存 Profile" });
+    expect(button.hasAttribute("disabled")).toBe(false);
+    fireEvent.click(button);
+    await waitFor(() => expect(save).toHaveBeenCalledWith(expect.objectContaining({ id: "team-ppio", label: "" })));
+  });
+
+  it("still refuses to save without a model", async () => {
+    // model has no backend fallback (write.go:50-53), so this one stays required.
+    const save = vi.spyOn(api, "saveProfile");
+    renderPage([profile()]);
+    fireEvent.click(screen.getByRole("button", { name: "编辑 团队 PPIO" }));
+    fireEvent.change(screen.getByLabelText("模型"), { target: { value: "" } });
+
+    expect(screen.getByRole("button", { name: "保存 Profile" }).hasAttribute("disabled")).toBe(true);
+    expect(save).not.toHaveBeenCalled();
+  });
+
   it("applies one Profile to all of its Agents", async () => {
     const install = vi.spyOn(api, "install").mockResolvedValue({
       ok: true,

--- a/frontend/src/pages/ProfilesPage.tsx
+++ b/frontend/src/pages/ProfilesPage.tsx
@@ -57,9 +57,9 @@ export function ProfilesPage() {
   const nameOf = (agentId: string) =>
     status.catalog.find((item) => item.id === agentId)?.name || agentId;
   const providerHasKey = Boolean(editor && status.providers[editor.provider]?.has_key);
-  const canSave = Boolean(
-    editor?.id.trim() && editor.label.trim() && editor.model.trim() && editor.agentIds.length,
-  );
+  // label is absent on purpose: the backend fills it in from the existing value
+  // or the ID, so demanding it here was stricter than the write path.
+  const canSave = Boolean(editor?.id.trim() && editor.model.trim() && editor.agentIds.length);
 
   // Creating a Profile goes through onboarding: it collects the Agent, key,
   // model and name in order, tests the connection, and the install writes the
@@ -163,7 +163,18 @@ export function ProfilesPage() {
             </div>
             <div className="field-stack">
               <label htmlFor="profile-label">{t("名称")}</label>
-              <input id="profile-label" value={editor.label} onChange={(event) => setEditor({ ...editor, label: event.target.value })} placeholder={t("例如 团队 PPIO")} required />
+              {/* Optional, matching the backend: an empty label falls back to the
+                  existing one, then to the ID (internal/profile/write.go:71-74).
+                  The hint says so, or a Profile saved without a name looks like it
+                  lost it. */}
+              <input
+                id="profile-label"
+                value={editor.label}
+                onChange={(event) => setEditor({ ...editor, label: event.target.value })}
+                placeholder={t("例如 团队 PPIO")}
+                aria-describedby="profile-label-hint"
+              />
+              <small id="profile-label-hint">{t("留空则使用 Profile ID")}</small>
             </div>
             <div className="profile-editor-wide">
               <ProviderSegment


### PR DESCRIPTION
Closes #7

## 改动

`ProfilesPage` 的名称输入去掉 `required`，`canSave` 门禁去掉 label 条件。

后端 `Store.Save` 本来就把 label 当可选：留空则沿用已存的 label，再退到 Profile ID（[internal/profile/write.go:71-74](internal/profile/write.go#L71-L74)）。前端却拦着不让保存，导致「把某个 Profile 的名字清空」这个操作根本做不到——尽管真正走到写入会成功。

补了一行提示说明留空的后果，否则用户保存后看到名字变成了 ID，会以为是丢了数据。

## 未改动的部分

`model` 保留 `required`。它在后端没有 fallback，空值直接被拒（`write.go:50-53`），放开会把前端拦截变成后端报错，体验更差。

`ProvidersPage` 的三个必填项（`id` / `name` / `base_url`）全部保留。核对后确认它们在 `internal/provider/store.go:208-216` 是真必填，放开会导致写入失败——那是回归而非改进。#7 里有完整的逐字段核对表。

## 验证

- 前端 119 个测试通过，`tsc --noEmit` 与生产构建通过
- `go test ./internal/profile/...` 通过
- 新增两个测试：名称留空可保存、缺 model 仍然拦住

后端的 label fallback 已有测试覆盖（`internal/profile/write_test.go:205`），没有重复添加。

🤖 Generated with [Claude Code](https://claude.com/claude-code)