### PR TITLE
feat: Qwen Code 从仅引导升级为可安装可配置

### DIFF
--- a/agents.lock.json
+++ b/agents.lock.json
@@ -226,15 +226,26 @@
     },
     "qwen-code": {
       "name": "Qwen Code",
-      "group": "ide",
+      "group": "auto",
       "command": "qwen",
-      "config_mode": "guide",
+      "config_mode": "auto",
+      "config_adapter": "qwen-code",
+      "config_path": ".qwen/.env",
+      "package": {
+        "manager": "npm",
+        "name": "@qwen-code/qwen-code",
+        "source": "https://github.com/QwenLM/qwen-code",
+        "license": "Apache-2.0",
+        "license_url": "https://github.com/QwenLM/qwen-code/blob/main/LICENSE"
+      },
+      "version_args": [
+        "--version"
+      ],
       "platforms": [
         "macos",
         "linux",
         "windows"
       ],
-      "guide": "Use the official Qwen Code setup and provider configuration.",
       "rank": 13
     },
     "kilo-vscode": {

--- a/internal/app/agent.go
+++ b/internal/app/agent.go
@@ -167,6 +167,8 @@ func writeManagedAgentConfig(ctx context.Context, writer configWriter.Writer, ag
 		return writer.WriteOpenAICompatible(ctx, path, "https://app.kilo.ai/config.json", providerName, baseURL, apiKey, model)
 	case "aider":
 		return writer.WriteAider(ctx, path, baseURL, apiKey)
+	case "qwen-code":
+		return writer.WriteQwen(ctx, path, baseURL, apiKey, model)
 	default:
 		return oneerrors.New(oneerrors.InvalidRequest, fmt.Sprintf("Unsupported auto-config Agent: %s", agentID))
 	}

--- a/internal/app/status_test.go
+++ b/internal/app/status_test.go
@@ -66,6 +66,56 @@ func TestStatusReportsExistingConfigWithoutWriting(t *testing.T) {
 	}
 }
 
+func TestStatusKeepsEveryAgentsInstallAndGuideClassification(t *testing.T) {
+	// Adding or promoting one Agent must not silently reclassify another. Both
+	// halves are asserted because they are independent: canInstall follows the
+	// package, guideOnly follows config_mode, and an edit to the derivation of
+	// either would otherwise pass unnoticed.
+	expected := map[string]struct{ canInstall, guideOnly bool }{
+		"codex":       {true, false},
+		"claude-code": {true, false},
+		"opencode":    {true, false},
+		"kilo-cli":    {true, false},
+		"aider":       {true, false},
+		"qwen-code":   {true, false},
+		"cursor":      {false, true},
+		"kiro":        {false, true},
+		"gemini-cli":  {false, true},
+		"cline":       {false, true},
+		"continue":    {false, true},
+		"kilo-vscode": {false, true},
+		"openclaw":    {false, true},
+		"hermes":      {false, true},
+	}
+	// Every manager resolves, so canInstall reflects the catalog rather than this
+	// machine's runtimes.
+	core := NewUseCases(StatusOptions{
+		Home:     t.TempDir(),
+		Platform: platform.For("linux", "amd64"),
+		Lookup:   func(command string) (string, bool) { return "/fake/" + command, true },
+	})
+	status, err := core.GetStatus(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(status.Agents) != len(expected) {
+		t.Fatalf("agent count = %d, want %d; update this table deliberately", len(status.Agents), len(expected))
+	}
+	for id, want := range expected {
+		agent, ok := status.Agents[id]
+		if !ok {
+			t.Errorf("%s is missing from status", id)
+			continue
+		}
+		if agent.CanInstall != want.canInstall {
+			t.Errorf("%s canInstall = %v, want %v", id, agent.CanInstall, want.canInstall)
+		}
+		if agent.GuideOnly != want.guideOnly {
+			t.Errorf("%s guideOnly = %v, want %v", id, agent.GuideOnly, want.guideOnly)
+		}
+	}
+}
+
 func TestStatusProjectsProfilesAndActiveEnvironmentWithoutSecrets(t *testing.T) {
 	home := t.TempDir()
 	oneagentDir := filepath.Join(home, ".oneagent")

--- a/internal/app/testdata/status-empty-linux-arm64.json
+++ b/internal/app/testdata/status-empty-linux-arm64.json
@@ -43,7 +43,8 @@
       "claude-code": "node",
       "codex": "node",
       "kilo-cli": "node",
-      "opencode": "node"
+      "opencode": "node",
+      "qwen-code": "node"
     }
   },
   "agents": {
@@ -229,9 +230,9 @@
     },
     "qwen-code": {
       "installed": false,
-      "config": "",
+      "config": "${HOME}/.qwen/.env",
       "configured": false,
-      "guideOnly": true,
+      "guideOnly": false,
       "version": null,
       "lockedVersion": null,
       "canInstall": false,
@@ -454,11 +455,11 @@
     {
       "id": "qwen-code",
       "name": "Qwen Code",
-      "group": "ide",
-      "configMode": "guide",
-      "guideOnly": true,
+      "group": "auto",
+      "configMode": "auto",
+      "guideOnly": false,
       "lockedVersion": null,
-      "protocol": null,
+      "protocol": "openai",
       "platforms": [
         "macos",
         "linux",
@@ -538,15 +539,17 @@
     "claude-code_config": "${HOME}/.claude/settings.json",
     "opencode_config": "${HOME}/.config/opencode/opencode.json",
     "kilo-cli_config": "${HOME}/.config/kilo/kilo.jsonc",
-    "aider_config": "${HOME}/.oneagent/aider.env"
+    "aider_config": "${HOME}/.oneagent/aider.env",
+    "qwen-code_config": "${HOME}/.qwen/.env"
   },
   "backups": {
-    "codex": false,
-    "claude-code": false,
-    "opencode": false,
-    "kilo-cli": false,
     "aider": false,
-    "profile": false
+    "claude-code": false,
+    "codex": false,
+    "kilo-cli": false,
+    "opencode": false,
+    "profile": false,
+    "qwen-code": false
   },
   "profiles": [],
   "activeProfile": null,
@@ -567,7 +570,7 @@
       "licenseUrl": "https://github.com/nodejs/node/blob/main/LICENSE",
       "source": "https://nodejs.org/dist/",
       "installPath": "${HOME}/.oneagent/runtimes/node/v24.18.1",
-      "requiredByHint": "Codex, Claude Code, OpenCode +1"
+      "requiredByHint": "Codex, Claude Code, OpenCode +2"
     },
     {
       "id": "uv",

--- a/internal/catalog/catalog_test.go
+++ b/internal/catalog/catalog_test.go
@@ -24,8 +24,11 @@ func TestEmbeddedManifestMatchesCurrentCatalogContract(t *testing.T) {
 			}
 		}
 	}
-	if automatic != 5 {
-		t.Fatalf("automatic Agent count = %d, want 5", automatic)
+	// Bump this deliberately when promoting an Agent to auto config. The count
+	// exists so a lock edit that flips config_mode by accident is caught; the
+	// per-Agent contract above is what actually has to hold.
+	if automatic != 6 {
+		t.Fatalf("automatic Agent count = %d, want 6", automatic)
 	}
 	items := PublicCatalog(manifest, "windows")
 	if len(items) != len(manifest.Agents) {

--- a/internal/config/discovery.go
+++ b/internal/config/discovery.go
@@ -95,18 +95,42 @@ func ReadOpenAICompatibleConfig(text string) Detected {
 }
 
 func ReadAiderConfig(text string) Detected {
-	baseURL := ""
+	return readDotenvConfig(text, "OPENAI_API_BASE", "")
+}
+
+// ReadQwenConfig reads the dotenv file Qwen Code loads from ~/.qwen/.env. The
+// endpoint variable is OPENAI_BASE_URL rather than Aider's OPENAI_API_BASE, and
+// the model is recorded too, so the overview can report drift on both.
+func ReadQwenConfig(text string) Detected {
+	return readDotenvConfig(text, "OPENAI_BASE_URL", "OPENAI_MODEL")
+}
+
+// readDotenvConfig picks the last assignment of each name, matching how a shell
+// sourcing the file would resolve a repeated variable. The three prefixes cover
+// a bare assignment, a POSIX export, and the PowerShell form OneAgent writes on
+// Windows. modelName may be empty for files that carry no model.
+func readDotenvConfig(text, baseURLName, modelName string) Detected {
+	detected := Detected{}
+	assignment := func(trimmed, name string) (string, bool) {
+		for _, prefix := range []string{name + "=", "export " + name + "=", "$env:" + name + " ="} {
+			if after, ok := strings.CutPrefix(trimmed, prefix); ok {
+				return unquoteShellValue(strings.TrimSpace(after)), true
+			}
+		}
+		return "", false
+	}
 	for line := range strings.SplitSeq(text, "\n") {
 		trimmed := strings.TrimSpace(line)
-		for _, prefix := range []string{"OPENAI_API_BASE=", "export OPENAI_API_BASE=", "$env:OPENAI_API_BASE ="} {
-			if !strings.HasPrefix(trimmed, prefix) {
-				continue
+		if value, ok := assignment(trimmed, baseURLName); ok {
+			detected.BaseURL = value
+		}
+		if modelName != "" {
+			if value, ok := assignment(trimmed, modelName); ok {
+				detected.Model = value
 			}
-			value := strings.TrimSpace(strings.TrimPrefix(trimmed, prefix))
-			baseURL = unquoteShellValue(value)
 		}
 	}
-	return Detected{BaseURL: baseURL}
+	return detected
 }
 
 // DetectFile returns nil only when the file is absent. Any present but empty,
@@ -155,6 +179,8 @@ func readerFor(adapter string, envVars map[string]string) reader {
 		return ReadOpenAICompatibleConfig
 	case "aider":
 		return ReadAiderConfig
+	case "qwen-code":
+		return ReadQwenConfig
 	default:
 		return nil
 	}

--- a/internal/config/discovery_test.go
+++ b/internal/config/discovery_test.go
@@ -58,6 +58,29 @@ func TestReadAiderNeverExecutesOrReturnsKey(t *testing.T) {
 	}
 }
 
+func TestReadQwenReadsItsOwnVariablesAndKeepsTheKeyOut(t *testing.T) {
+	detected := ReadQwenConfig("OPENAI_BASE_URL='https://hand.example/v1'\nOPENAI_API_KEY='sk-never-return'\nOPENAI_MODEL=qwen3-coder-plus\n")
+	if detected.BaseURL != "https://hand.example/v1" || detected.Model != "qwen3-coder-plus" {
+		t.Fatalf("Qwen detection = %#v", detected)
+	}
+	if strings.Contains(mustJSON(t, detected), "sk-never-return") {
+		t.Fatal("the key reached the detection projection")
+	}
+	// Aider's spelling is a legacy alias in Qwen Code, so a file carrying only
+	// that must not be reported as configured.
+	if got := ReadQwenConfig("OPENAI_API_BASE=https://aider.example/v1\n"); got.BaseURL != "" {
+		t.Errorf("read Aider's variable as Qwen's endpoint: %#v", got)
+	}
+	if got := ReadQwenConfig("$env:OPENAI_BASE_URL = \"https://win.example/v1\"\n"); got.BaseURL != "https://win.example/v1" {
+		t.Errorf("PowerShell form = %#v", got)
+	}
+	// A repeated variable resolves to the last assignment, the way a shell
+	// sourcing the file would.
+	if got := ReadQwenConfig("OPENAI_BASE_URL=https://first.example/v1\nexport OPENAI_BASE_URL=https://last.example/v1\n"); got.BaseURL != "https://last.example/v1" {
+		t.Errorf("repeated assignment = %#v", got)
+	}
+}
+
 func TestReadersReturnLocalDiagnosticsForMalformedOrWrongTypes(t *testing.T) {
 	for _, detected := range []Detected{
 		ReadCodexConfig("model_provider = \nbroken ["),

--- a/internal/config/write.go
+++ b/internal/config/write.go
@@ -127,6 +127,27 @@ func (w Writer) WriteAider(ctx context.Context, path, baseURL, apiKey string) er
 	return w.write(ctx, path, []byte(content), true)
 }
 
+// WriteQwen points Qwen Code at the Provider through the dotenv file it loads
+// from ~/.qwen/.env.
+//
+// The variable names are not the ones WriteAider uses: Qwen Code reads
+// OPENAI_BASE_URL, and treats OPENAI_API_BASE as a legacy spelling. Writing only
+// Aider's name would leave the CLI on its own default endpoint with a key that
+// does not belong to it, which fails as an auth error rather than a missing
+// configuration — the confusing kind.
+//
+// The model is written too, unlike Aider, because Qwen Code otherwise keeps its
+// built-in default and silently ignores the model the user chose.
+func (w Writer) WriteQwen(ctx context.Context, path, baseURL, apiKey, model string) error {
+	base := provider.OpenAIBaseURL(baseURL)
+	content := "OPENAI_BASE_URL=" + dotenvQuote(base) + "\n" +
+		"OPENAI_API_KEY=" + dotenvQuote(apiKey) + "\n"
+	if model != "" {
+		content += "OPENAI_MODEL=" + dotenvQuote(model) + "\n"
+	}
+	return w.write(ctx, path, []byte(content), true)
+}
+
 func (w Writer) write(ctx context.Context, path string, data []byte, secret bool) error {
 	if _, err := w.FS.AtomicWrite(ctx, path, data, secret); err != nil {
 		return err

--- a/internal/config/write_test.go
+++ b/internal/config/write_test.go
@@ -165,3 +165,50 @@ func TestWriteAiderQuotesSecretsOnUnixAndWindows(t *testing.T) {
 		t.Fatalf("Windows Aider config = %q", data)
 	}
 }
+
+func TestWriteQwenUsesItsOwnEndpointVariable(t *testing.T) {
+	home := t.TempDir()
+	writer := testWriter(t, home, "linux")
+	path := filepath.Join(home, ".qwen", ".env")
+	if err := writer.WriteQwen(context.Background(), path, "https://api.example/openai", "key'quoted", "qwen3-coder-plus"); err != nil {
+		t.Fatal(err)
+	}
+	data, _ := os.ReadFile(path)
+	text := string(data)
+	// Qwen Code reads OPENAI_BASE_URL. Writing Aider's OPENAI_API_BASE instead
+	// would leave the CLI on its default endpoint holding a key that does not
+	// belong to it, which surfaces as an auth error rather than a missing config.
+	if !strings.Contains(text, "OPENAI_BASE_URL=https://api.example/openai/v1") {
+		t.Errorf("endpoint variable is wrong or absent: %q", text)
+	}
+	if strings.Contains(text, "OPENAI_API_BASE=") {
+		t.Errorf("wrote Aider's variable name: %q", text)
+	}
+	if !strings.Contains(text, `'key\'quoted'`) {
+		t.Errorf("key was not quoted: %q", text)
+	}
+	// Without the model Qwen Code keeps its built-in default and ignores the one
+	// the user picked.
+	if !strings.Contains(text, "OPENAI_MODEL=qwen3-coder-plus") {
+		t.Errorf("model is absent: %q", text)
+	}
+
+	detected := ReadQwenConfig(text)
+	if detected.BaseURL != "https://api.example/openai/v1" || detected.Model != "qwen3-coder-plus" {
+		t.Errorf("round-trip through the reader = %#v", detected)
+	}
+}
+
+func TestWriteQwenOmitsAnEmptyModel(t *testing.T) {
+	// An empty OPENAI_MODEL= line would override the CLI's own default with
+	// nothing, which is worse than leaving the variable out.
+	home := t.TempDir()
+	path := filepath.Join(home, ".qwen", ".env")
+	if err := testWriter(t, home, "linux").WriteQwen(context.Background(), path, "https://api.example/openai", "k", ""); err != nil {
+		t.Fatal(err)
+	}
+	data, _ := os.ReadFile(path)
+	if strings.Contains(string(data), "OPENAI_MODEL") {
+		t.Errorf("empty model reached the file: %q", data)
+	}
+}


### PR DESCRIPTION
Closes #11

## 改动

`qwen-code` 原本是仅引导条目，但它有官方 npm 包、读 OpenAI 兼容端点、配置在一个 dotenv 文件里——正好是 OneAgent 已经在自动化的形态。现在它和另外五个一样能安装、检测、配置。

事实是从**已发布的 tarball 里直接读的**，不是从文档推断：许可证 Apache-2.0（npm 的 license 字段为空，但包内含 LICENSE 文件），端点变量是 `OPENAI_BASE_URL`——在代码里出现 21 次，而 `OPENAI_API_BASE` 只有 1 次。

## 为什么不能复用 aider 的 adapter

这个差异是关键。`WriteAider` 写的是 `OPENAI_API_BASE`，如果照搬，Qwen Code 会停在它自己的默认端点上、却持有一个不属于该端点的 key——表现为鉴权失败而不是"配置缺失"，是更难诊断的那种。

`WriteQwen` 还会写入 model，因为 Qwen Code 否则会保留内置默认值、静默忽略用户选的模型。

dotenv reader 也做了同样的泛化，否则 `readerFor` 返回 nil，这个配置会**永远显示"未配置"**。

## 两个既有测试是调整而非绕过

catalog 契约测试断言自动配置 Agent 数量为 5——那是个快照，提升条目时本就该动；它真正守护的逐条要求（有 package 且有 adapter）qwen-code 已满足。我把数字改为 6 并加注释说明它的意义。

新增一个测试钉住全部 14 个条目的 `canInstall` 与 `guideOnly`，这样以后再提升某个条目不会静默改变别的。做了变异测试确认它有效：把 qwen-code 改回 `guide` 立刻失败。

## 验证

- `go vet ./...`、`go test ./...` 通过，`-race` 在改动包上通过
- Windows 交叉编译通过（amd64 与 arm64）
- 前端 139 个测试通过，`tsc --noEmit` 通过（`types/api.ts` 是手写的，确认未受影响）
- golden fixture 已更新，差异全部只涉及 qwen-code（另有两处衍生字段：`backups` 多一项、node 的 `requiredByHint` 从 +1 变 +2）

**端到端实测**（隔离 HOME，未碰真实配置）：

```
OPENAI_BASE_URL=https://api.ppio.com/openai/v1
OPENAI_API_KEY=<已脱敏>
OPENAI_MODEL=qwen3-coder-plus
```

权限 `-rw-------` 仅所有者可读，base URL 自动补上 `/v1`。

## 不在本 PR 范围（原因记录在 #11）

`gemini-cli` 虽有官方 npm 包且仍在每日更新，但它走 **Gemini 原生协议**，`GOOGLE_GEMINI_BASE_URL` 指向的端点必须兼容 Gemini API 格式，而 OneAgent 的 Provider 全是 OpenAI/Anthropic 协议——接入需要中间加一层协议转换。

`cline` / `continue` 在目录里是 IDE 扩展条目，npm 上的同名包是各自的独立 CLI，是不同的东西；改动会改变条目语义，应另开 issue。

🤖 Generated with [Claude Code](https://claude.com/claude-code)