### PR TITLE
test: follow the empty overview's own call to action

### DIFF
--- a/frontend/src/pages/EnvironmentOverviewPage.test.tsx
+++ b/frontend/src/pages/EnvironmentOverviewPage.test.tsx
@@ -84,7 +84,11 @@ describe("EnvironmentOverviewPage", () => {
     mockState = { status: empty, statusState: "success", statusError: "" };
     renderPage();
     expect(screen.getByText("尚未安装任何 Agent")).toBeTruthy();
-    fireEvent.click(screen.getByRole("button", { name: "安装命令行 Agent" }));
+    // The header's "安装命令行 Agent" is deliberately absent here: with nothing
+    // installed the empty state owns the call to action, as its own primary
+    // button, rather than repeating it in the toolbar.
+    expect(screen.queryByRole("button", { name: "安装命令行 Agent" })).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "安装 Agent" }));
     expect(await screen.findByRole("heading", { name: "onboarding" })).toBeTruthy();
     // A second run must not inherit the previous Agent, model or log.
     expect(dispatch).toHaveBeenCalledWith({ type: "START_SETUP" });


### PR DESCRIPTION
`main` 上有 1 个前端测试失败，是 #17 留下的。新 CI 在 #17 合并时还没生效，所以没拦住。

## 不是代码的问题，是测试过期了

`refactor: use step-by-step guide for desktop agents` 把顶部的「安装命令行 Agent」按钮加了条件：

```tsx
{installed.length || desktopInstalled ? (
  <button ... onClick={startSetup}>{t("安装命令行 Agent")}</button>
) : null}
```

这是**有意的**——什么都没装时，空状态自己有一个 primary 按钮「安装 Agent」承担引导，顶部工具栏不必重复一遍。但 `EnvironmentOverviewPage.test.tsx:87` 仍然去点顶部那个，于是 `Unable to find an accessible element with the role "button" and name "安装命令行 Agent"`。

改成点空状态实际渲染的那个按钮，并额外断言顶部那个**不存在**——把 #17 选择的这个布局钉住，而不是留给下一个人重新发现。

做了变异测试确认它仍然有效：把空状态按钮的 `onClick` 断开，测试立刻失败。

## 验证

`go vet` 无输出、`go test -race ./...` 全过、前端 `pnpm run build` 通过、`pnpm run test` **156/156**。

修完这个，`main` 三道门全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)