### PR TITLE
chore: pin the built-in default model to deepseek/deepseek-v4-pro

### DIFF
--- a/frontend/src/i18n.tsx
+++ b/frontend/src/i18n.tsx
@@ -57,7 +57,7 @@ const english = {
   "或手动输入模型 ID": "Or enter a model ID",
   "手动输入模型 ID": "Enter a model ID",
   "例如 gpt-4.1": "For example, gpt-4.1",
-  "例如 deepseek/deepseek-v3": "For example, deepseek/deepseek-v3",
+  "例如 deepseek/deepseek-v4-pro": "For example, deepseek/deepseek-v4-pro",
   "例如 siliconflow": "For example, siliconflow",
   "例如 team-ppio": "For example, team-ppio",
   "留空则使用 Profile ID": "Leave blank to use the Profile ID",

--- a/frontend/src/pages/AgentProfilePage.tsx
+++ b/frontend/src/pages/AgentProfilePage.tsx
@@ -211,7 +211,7 @@ export function AgentProfilePage() {
             </div>
             <div className="field-stack profile-editor-wide">
               <label htmlFor="agent-profile-model">{t("模型")}</label>
-              <input id="agent-profile-model" value={draft.model} onChange={(event) => setDraft({ ...draft, model: event.target.value })} placeholder={t("例如 deepseek/deepseek-v3")} required />
+              <input id="agent-profile-model" value={draft.model} onChange={(event) => setDraft({ ...draft, model: event.target.value })} placeholder={t("例如 deepseek/deepseek-v4-pro")} required />
             </div>
           </div>
           <p className="profile-key-hint">

--- a/frontend/src/pages/ProfilesPage.tsx
+++ b/frontend/src/pages/ProfilesPage.tsx
@@ -257,7 +257,7 @@ export function ProfilesPage() {
             </div>
             <div className="field-stack profile-editor-wide">
               <label htmlFor="profile-model">{t("模型")}</label>
-              <input id="profile-model" value={editor.model} onChange={(event) => setEditor({ ...editor, model: event.target.value })} placeholder={t("例如 deepseek/deepseek-v3")} required />
+              <input id="profile-model" value={editor.model} onChange={(event) => setEditor({ ...editor, model: event.target.value })} placeholder={t("例如 deepseek/deepseek-v4-pro")} required />
             </div>
             {/* The key is the Provider's, so this only reports whether that
                 Provider has one and links to where it is set. */}

--- a/frontend/src/pages/ProviderKeyPage.tsx
+++ b/frontend/src/pages/ProviderKeyPage.tsx
@@ -130,7 +130,7 @@ export function ProviderKeyPage() {
             className="text-field"
             value={state.probeModel}
             onChange={(event) => dispatch({ type: "SET_PROBE_MODEL", value: event.target.value })}
-            placeholder={t("例如 deepseek/deepseek-v3")}
+            placeholder={t("例如 deepseek/deepseek-v4-pro")}
             spellCheck={false}
           />
           <small>{t("可选，仅用于测试连接；实际配置模型在下一步选择")}</small>

--- a/manifests/providers.lock.json
+++ b/manifests/providers.lock.json
@@ -1,13 +1,13 @@
 {
   "schema_version": 1,
-  "default_fallback_probe_model": "deepseek/deepseek-v3",
+  "default_fallback_probe_model": "deepseek/deepseek-v4-pro",
   "providers": {
     "ppio": {
       "name": "PPIO",
       "home": "https://ppio.com/",
       "base_url": "https://api.ppio.com/openai",
       "anthropic_base_url": "https://api.ppio.com/anthropic",
-      "fallback_probe_model": "deepseek/deepseek-v3",
+      "fallback_probe_model": "deepseek/deepseek-v4-pro",
       "relationship": "sponsor",
       "disclosure": "PPIO sponsors OneAgent development. Sponsorship does not affect Agent rank, compatibility conclusions, default selection, or connection tests.",
       "referral_url": "",
@@ -23,7 +23,7 @@
       "home": "https://novita.ai/",
       "base_url": "https://api.novita.ai/openai",
       "anthropic_base_url": "https://api.novita.ai/anthropic",
-      "fallback_probe_model": "deepseek/deepseek_v3",
+      "fallback_probe_model": "deepseek/deepseek-v4-pro",
       "relationship": "sponsor",
       "disclosure": "Novita sponsors OneAgent development. Sponsorship does not affect Agent rank, compatibility conclusions, default selection, or connection tests.",
       "referral_url": "",


### PR DESCRIPTION
Advances the pinned built-in default model from `deepseek/deepseek-v3` to `deepseek/deepseek-v4-pro`. Groundwork for #76, which asks that a PPIO or Novita user only supply a key — pre-filling a model that is four releases behind would make the staleness visible to every new user on their first screen.

## Why this value is load-bearing

Despite the field name, `fallback_probe_model` is not probe-only. `internal/app/provider.go:260` (`resolveProviderModel`) and `internal/app/install.go:187` both fall back to it, so it is the model written into a real Agent config whenever the user does not pick one.

## v4 removes a trap

PPIO published v3 as `deepseek/deepseek-v3` and Novita as `deepseek/deepseek_v3` — one hyphen versus one underscore, so the two entries could never share a constant. Both now publish `deepseek/deepseek-v4-pro`. Verified present in each `/v1/models` listing (PPIO 108 models, Novita 145; both answer anonymously).

This makes #76's acceptance criterion "assert the two defaults are distinct strings" obsolete; that issue has been updated.

## Why `v4-pro`

`v4-flash-0731` has the newest `created` timestamp but is a dated snapshot — pinning it means going stale the moment the next snapshot ships. `v4-flash` and `v4-pro` are both rolling aliases from the same date.

Chose pro over flash because this value reaches real configs, where coding capability outweighs the per-token saving. The gap is worth knowing: on PPIO pro costs 3× flash (30000/60000 vs 10000/20000 per M), on Novita 11× (16000/32000 vs 1400/2800). If first-run cost matters more than capability, switching to `v4-flash` is three lines in the lock file.

## Scope

`providers.lock.json` — `default_fallback_probe_model` plus both providers' `fallback_probe_model`.

The i18n key `例如 deepseek/deepseek-v3` and its three call sites (`ProviderKeyPage.tsx:133`, `ProfilesPage.tsx:260`, `AgentProfilePage.tsx:214`). i18n is Chinese-source, so the key itself moves.

`ModelPicker.tsx:52` keeps its neutral `例如 gpt-4.1` — that is the free-text box, where a vendor-neutral example is more appropriate than promoting one provider's model.

## Verification

`go test ./...` — all packages pass. Note `internal/catalog/catalog_test.go:68` asserts the public provider projection contains no `"deepseek"` substring; that still holds because `PublicProviders` zeroes `fallbackModel`.

`pnpm run test` — 26 files, 205 tests pass. `pnpm run build` (which runs `tsc --noEmit` first) succeeds.

Also confirmed upstream that `deepseek/deepseek-v4-pro` is a live model id on both providers, not just newer-looking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
