### PR TITLE
feat: pre-fill a Provider's default model and open its key page

### DIFF
--- a/cmd/oneagent/main.go
+++ b/cmd/oneagent/main.go
@@ -274,8 +274,13 @@ func resolveCLIKey(options installCLIFlags, stderr io.Writer) (string, error) {
 	}
 	registration := options.RegisterURL
 	if registration == "" {
-		if home, ok := catalog.ProviderByID(options.Provider); ok {
-			registration = home.Home
+		if meta, ok := catalog.ProviderByID(options.Provider); ok {
+			// Same precedence as the desktop OpenRegistration: the key page is
+			// where a key is actually created, Home is the fallback.
+			registration = meta.KeyManagementURL
+			if registration == "" {
+				registration = meta.Home
+			}
 		} else {
 			registration, _ = provider.ProviderHome("ppio")
 		}

--- a/docs/public-site-operations.md
+++ b/docs/public-site-operations.md
@@ -28,6 +28,20 @@ Provider's `relationship`, `disclosure`, and `referral_url` are maintained here,
 must not influence Agent rank, compatibility conclusions, default selection, or connection
 tests. That boundary belongs to this repository; the site only displays the result.
 
+**Those fields are not read by the application, and that is enforced by omission.**
+`relationship`, `disclosure`, `referral_url`, `order`, and `protocols` have no counterpart
+in `providerFileEntry` (`internal/catalog/providers.go`), so `json.Unmarshal` discards
+them. Filling in `referral_url` therefore changes nothing in the desktop app or the CLI —
+it is published for the site to render, and the "get a key" button will keep opening
+`key_management_url` (falling back to `home`) regardless. Routing users through a referral
+link would be a product decision requiring the field to be parsed and given an explicit
+precedence, not a matter of setting a value here.
+
+The reverse also holds: `key_management_url` and `default_model` are read by the app. They
+are not disclosure fields and are not subject to the paragraph above; `default_model` is
+the model pre-filled for a user who has not chosen one, so changing it changes what gets
+written into a real Agent configuration.
+
 **Changing a lock file does not change the site.** The site vendors `agents.lock.json`
 and `providers.lock.json` into its own `data/` directory, refreshed from release tags
 rather than tracking this repository's `main`. This is deliberate: the site describes what

--- a/frontend/bindings/github.com/MaimoryLab/OneAgent/internal/catalog/models.ts
+++ b/frontend/bindings/github.com/MaimoryLab/OneAgent/internal/catalog/models.ts
@@ -40,8 +40,16 @@ export interface Mirror {
 export interface Provider {
     "name": string;
     "home": string;
+
+    /**
+     * KeyManagementURL and DefaultModel are public on purpose: the frontend
+     * needs both to spare a first-time user from hunting for a key page and
+     * inventing a model ID. Contrast fallbackModel below.
+     */
+    "key_management_url"?: string;
     "base_url": string;
     "anthropic_base_url"?: string;
+    "default_model"?: string;
     "custom"?: boolean;
     "has_key"?: boolean;
     "created_at"?: string;

--- a/frontend/bindings/github.com/MaimoryLab/OneAgent/internal/provider/models.ts
+++ b/frontend/bindings/github.com/MaimoryLab/OneAgent/internal/provider/models.ts
@@ -9,6 +9,15 @@ export interface Entry {
     "id": string;
     "name": string;
     "home": string;
+
+    /**
+     * Both derived from the built-in catalog, not user-editable: a user who adds
+     * a Provider supplies Home, and a custom endpoint has no model we can vouch
+     * for. Serialized so the frontend can pre-fill the model field and aim the
+     * key button at a key page instead of a marketing site.
+     */
+    "key_management_url"?: string;
+    "default_model"?: string;
     "base_url": string;
     "anthropic_base_url": string;
     "api_key": string;

--- a/frontend/src/i18n.tsx
+++ b/frontend/src/i18n.tsx
@@ -139,7 +139,10 @@ const english = {
   "连接模型服务": "Connect a model provider",
   "Key 不会进入日志、URL 或前端持久化状态": "The key is never written to logs, URLs, or persistent frontend state",
   "继续选择模型": "Continue to model selection",
-  "注册并获取 Key": "Register and get a key",
+  // The button opens the Provider's key management page, which needs an account
+  // the user may not have yet. "Register and get a key" promised the sign-up
+  // flow; this wording covers both arriving signed in and having to sign up.
+  "获取 API Key": "Get an API key",
   "自定义模型名称（可选）": "Custom model name (optional)",
   "填写后将用此模型测试连接；留空时自动选择": "When provided, this model is used for the connection test. Leave blank to select automatically",
   "可选，仅用于测试连接；实际配置模型在下一步选择": "Optional; used only for the connection test. Choose the configured model in the next step",

--- a/frontend/src/pages/ProfilesPage.test.tsx
+++ b/frontend/src/pages/ProfilesPage.test.tsx
@@ -235,6 +235,39 @@ describe("ProfilesPage", () => {
     expect(save).not.toHaveBeenCalled();
   });
 
+  it("pre-fills the model from the Provider and leaves it editable", () => {
+    // The whole point of the field being pre-filled is that a first-time user
+    // never has to invent a model ID, so this asserts the value is present
+    // before any typing -- and that typing still replaces it.
+    mockState = {
+      status: {
+        ...statusWith([]),
+        providers: { ppio: { name: "PPIO", home: "https://ppio.com/", base_url: "https://api.ppio.com/openai", default_model: "ppio/default-model" } },
+      },
+      statusState: "success",
+    };
+    dispatch.mockClear();
+    render(
+      <MemoryRouter initialEntries={["/profiles"]}>
+        <Routes>
+          <Route path="/profiles" element={<ProfilesPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "新增 Profile" }));
+    expect(screen.getByLabelText("模型")).toHaveValue("ppio/default-model");
+    fireEvent.change(screen.getByLabelText("模型"), { target: { value: "mine" } });
+    expect(screen.getByLabelText("模型")).toHaveValue("mine");
+  });
+
+  it("leaves the model empty for a Provider with no default", () => {
+    // A user-added Provider is an endpoint we know nothing about; guessing a
+    // model for it would write a config that fails on the first request.
+    renderPage([]);
+    fireEvent.click(screen.getByRole("button", { name: "新增 Profile" }));
+    expect(screen.getByLabelText("模型")).toHaveValue("");
+  });
+
   it("applies one Profile to all of its Agents", async () => {
     const install = vi.spyOn(api, "install").mockResolvedValue({
       ok: true,

--- a/frontend/src/pages/ProfilesPage.tsx
+++ b/frontend/src/pages/ProfilesPage.tsx
@@ -75,7 +75,10 @@ export function ProfilesPage() {
       id,
       label: `${providerMeta?.name || provider} Profile`,
       provider,
-      model: "",
+      // Pre-filled from the Provider so a first-time user is not asked to invent
+      // a model ID. Empty for a custom Provider, whose endpoint we know nothing
+      // about, which leaves the field required exactly as before.
+      model: providerMeta?.default_model || "",
       protocol: "",
       originalId: "",
     });
@@ -84,6 +87,19 @@ export function ProfilesPage() {
   const providerForProtocol = (protocol: string, current: ProviderId) => {
     if (!protocol || (status.providers[current] && (protocol === "anthropic" ? status.providers[current].anthropic_base_url : status.providers[current].base_url))) return current;
     return byProviderCreatedAt(status.providers).find(([, provider]) => protocol === "anthropic" ? provider.anthropic_base_url : provider.base_url)?.[0] || current;
+  };
+
+  // Switching Provider re-seeds the model, but only when the field still holds
+  // the old Provider's default or nothing at all. A model the user typed is
+  // theirs to keep -- silently replacing it would be the more annoying bug, and
+  // model IDs are not portable between Providers, so leaving a stale default
+  // behind would be equally wrong.
+  const changeProvider = (draft: ProfileDraft, provider: ProviderId): ProfileDraft => {
+    const previous = status.providers[draft.provider]?.default_model || "";
+    const model = draft.model.trim() && draft.model !== previous
+      ? draft.model
+      : status.providers[provider]?.default_model || "";
+    return { ...draft, provider, model };
   };
 
   const save = async (event: FormEvent) => {
@@ -238,7 +254,7 @@ export function ProfilesPage() {
                   id="profile-protocol"
                   label={t("API 类型")}
                   value={editor.protocol}
-                  onChange={(protocol) => setEditor({ ...editor, protocol, provider: providerForProtocol(protocol, editor.provider) })}
+                  onChange={(protocol) => setEditor({ ...changeProvider(editor, providerForProtocol(protocol, editor.provider)), protocol })}
                   options={[
                     { value: "", label: t("请选择 API 类型") },
                     ...(Object.keys(PROTOCOL_LABELS) as ProtocolId[]).map((protocol) => ({ value: protocol, label: PROTOCOL_LABELS[protocol] })),
@@ -251,7 +267,7 @@ export function ProfilesPage() {
                 value={editor.provider}
                 providers={status.providers}
                 onAdd={() => navigate(`/providers/new?returnTo=${encodeURIComponent("/profiles")}`)}
-                onChange={(provider) => setEditor({ ...editor, provider })}
+                onChange={(provider) => setEditor(changeProvider(editor, provider))}
                 protocol={editor.protocol as ProtocolId}
               />
             </div>

--- a/frontend/src/pages/ProviderKeyPage.test.tsx
+++ b/frontend/src/pages/ProviderKeyPage.test.tsx
@@ -14,7 +14,7 @@ const dispatch = vi.fn((action: WizardAction) => {
 });
 
 const status = {
-  providers: { ppio: { name: "PPIO", home: "", base_url: "https://api.ppinfra.com/openai", has_key: true } },
+  providers: { ppio: { name: "PPIO", home: "", base_url: "https://api.ppio.com/openai", has_key: true } },
   catalog: [],
 } as unknown as StatusResponse;
 
@@ -71,5 +71,33 @@ describe("ProviderKeyPage", () => {
     render(<MemoryRouter><ProviderKeyPage /></MemoryRouter>);
 
     expect(screen.getByRole("button", { name: "继续选择模型" })).not.toBeDisabled();
+  });
+
+  it("offers the key button for a Provider with only a key page", () => {
+    // No home URL, so the pre-change guard would have hidden the button. The
+    // backend picks the URL; the page only decides whether to offer the action.
+    state = {
+      ...initialWizardState,
+      status: {
+        ...status,
+        providers: { ppio: { ...status.providers.ppio, home: "", key_management_url: "https://ppio.com/settings/key-management" } },
+      } as unknown as StatusResponse,
+      statusState: "success",
+      hasApiKey: true,
+    };
+    const open = vi.spyOn(api, "openRegister").mockResolvedValue({ ok: true, url: "", message: "" });
+    render(<MemoryRouter><ProviderKeyPage /></MemoryRouter>);
+
+    fireEvent.click(screen.getByRole("button", { name: "获取 API Key" }));
+    // No URL is passed: the backend re-resolves it, so a tampered frontend
+    // cannot choose what gets opened.
+    expect(open).toHaveBeenCalledWith("ppio", expect.anything());
+  });
+
+  it("hides the key button when the Provider publishes neither URL", () => {
+    state = { ...initialWizardState, status, statusState: "success", hasApiKey: true };
+    render(<MemoryRouter><ProviderKeyPage /></MemoryRouter>);
+
+    expect(screen.queryByRole("button", { name: "获取 API Key" })).toBeNull();
   });
 });

--- a/frontend/src/pages/ProviderKeyPage.tsx
+++ b/frontend/src/pages/ProviderKeyPage.tsx
@@ -73,7 +73,9 @@ export function ProviderKeyPage() {
   };
 
   const openRegistration = async () => {
-    if (!providerMeta?.home) return;
+    // Either URL is enough; the backend applies the same precedence and does the
+    // scheme validation, so no URL is passed from here.
+    if (!providerMeta?.key_management_url && !providerMeta?.home) return;
     try {
       await api.openRegister(state.provider, probeAgentIds);
     } catch (error) {
@@ -115,10 +117,10 @@ export function ProviderKeyPage() {
             <strong>{providerMeta?.name}</strong>
             <span>{providerMeta?.base_url}</span>
           </div>
-          {providerMeta?.home ? (
+          {providerMeta?.key_management_url || providerMeta?.home ? (
             <button className="button button-secondary" type="button" onClick={() => void openRegistration()}>
               <ExternalLink size={15} />
-              {t("注册并获取 Key")}
+              {t("获取 API Key")}
             </button>
           ) : null}
         </div>

--- a/frontend/src/state/wizardReducer.test.ts
+++ b/frontend/src/state/wizardReducer.test.ts
@@ -321,3 +321,74 @@ describe("wizardReducer", () => {
     expect(after).toBe(before);
   });
 });
+
+describe("provider default model", () => {
+  // Two Providers with different defaults, plus one with none, which is what a
+  // user-added Provider looks like.
+  const withDefaults = {
+    ...status,
+    providers: {
+      ppio: { name: "PPIO", home: "https://ppio.com/", base_url: "https://api.ppio.com/openai", default_model: "ppio/model-a" },
+      novita: { name: "Novita", home: "https://novita.ai/", base_url: "https://api.novita.ai/openai", default_model: "novita/model-b" },
+      acme: { name: "Acme", home: "https://acme.test/", base_url: "https://api.acme.test/openai", custom: true },
+    },
+  } satisfies StatusResponse;
+
+  it("seeds the model from the Provider and re-seeds when the Provider changes", () => {
+    let state = wizardReducer({ ...initialWizardState, status: withDefaults, provider: "ppio" }, { type: "SET_PROVIDER", value: "ppio" });
+    expect(state.model).toBe("ppio/model-a");
+    state = wizardReducer(state, { type: "SET_PROVIDER", value: "novita" });
+    // Not carried over: a model ID from one Provider is rarely valid at another.
+    expect(state.model).toBe("novita/model-b");
+  });
+
+  it("leaves the model empty for a Provider that publishes no default", () => {
+    // A custom endpoint gets no guess, so the field stays required as before.
+    const state = wizardReducer({ ...initialWizardState, status: withDefaults }, { type: "SET_PROVIDER", value: "acme" });
+    expect(state.model).toBe("");
+  });
+
+  it("keeps a probe model the user typed instead of the seeded default", () => {
+    const seeded = wizardReducer({ ...initialWizardState, status: withDefaults }, { type: "SET_PROVIDER", value: "ppio" });
+    const typed = wizardReducer(seeded, { type: "SET_PROBE_MODEL", value: "ppio/hand-picked" });
+    const state = wizardReducer(typed, {
+      type: "MODELS_RESULT",
+      result: { ok: true, reachable: true, status: 200, message: "", error_code: null, retryable: false, models: ["ppio/discovered"] } satisfies ModelsResponse,
+    });
+    expect(state.model).toBe("ppio/hand-picked");
+  });
+
+  it("keeps a model chosen on the model step when discovery finishes later", () => {
+    // The seeded default must not win over an explicit pick, which is the trap
+    // in resolving this with a plain `state.model ||` now that it is never empty.
+    const seeded = wizardReducer({ ...initialWizardState, status: withDefaults }, { type: "SET_PROVIDER", value: "ppio" });
+    const chosen = wizardReducer(seeded, { type: "SET_MODEL", value: "ppio/chosen" });
+    const state = wizardReducer(chosen, {
+      type: "MODELS_RESULT",
+      result: { ok: true, reachable: true, status: 200, message: "", error_code: null, retryable: false, models: ["ppio/discovered"] } satisfies ModelsResponse,
+    });
+    expect(state.model).toBe("ppio/chosen");
+  });
+
+  it("seeds on first status load and on starting a new run", () => {
+    // byProviderCreatedAt puts user-added Providers ahead of built-ins, so the
+    // initially selected Provider here is the one without a default. The point
+    // is that the seed follows whichever Provider was picked, not that it is
+    // always non-empty.
+    const builtInOnly = { ...withDefaults, providers: { ppio: withDefaults.providers.ppio, novita: withDefaults.providers.novita } } satisfies StatusResponse;
+    const loaded = wizardReducer(initialWizardState, { type: "STATUS_LOADED", status: builtInOnly });
+    expect(loaded.model).toBe(builtInOnly.providers[loaded.provider as "ppio" | "novita"].default_model);
+    // Starting over resets to the default rather than to an empty field.
+    const restarted = wizardReducer({ ...loaded, model: "leftover" }, { type: "START_SETUP" });
+    expect(restarted.model).toBe(loaded.model);
+    const fresh = wizardReducer({ ...loaded, model: "leftover" }, { type: "START_NEW_PROFILE" });
+    expect(fresh.model).toBe(loaded.model);
+  });
+
+  it("does not overwrite a model the user is editing when status refreshes", () => {
+    // A refresh re-enters STATUS_LOADED; seeding there must be first-load only.
+    const loaded = wizardReducer(initialWizardState, { type: "STATUS_LOADED", status: withDefaults });
+    const editing = wizardReducer({ ...loaded, model: "half-typed" }, { type: "STATUS_LOADED", status: withDefaults });
+    expect(editing.model).toBe("half-typed");
+  });
+});

--- a/frontend/src/state/wizardReducer.ts
+++ b/frontend/src/state/wizardReducer.ts
@@ -86,6 +86,13 @@ function latestProvider(status: StatusResponse | null, protocol?: string): Provi
   return byProviderCreatedAt(status?.providers ?? {}).find(([, provider]) => !protocol || (protocol === "anthropic" ? provider.anthropic_base_url : provider.base_url))?.[0] || "ppio";
 }
 
+/** The model a Provider suggests, so the wizard can arrive at the model step
+ * already filled in. Empty for a custom Provider: we have never seen its
+ * endpoint, and a guessed model ID would only fail on the first request. */
+function providerDefaultModel(status: StatusResponse | null, provider: ProviderId): string {
+  return status?.providers[provider]?.default_model || "";
+}
+
 export type WizardAction =
   | { type: "STATUS_LOADING" }
   | { type: "STATUS_LOADED"; status: StatusResponse }
@@ -160,29 +167,46 @@ export function wizardReducer(state: WizardState, action: WizardAction): WizardS
         status: action.status,
         statusState: "success",
         statusError: "",
-        ...(state.status === null ? { provider: latestProvider(action.status) } : {}),
+        // First load only, and only when the user has not typed a model yet:
+        // this is where the initial Provider is chosen, so it is also where the
+        // very first default has to be seeded. A refresh must not overwrite a
+        // model the user is in the middle of editing.
+        ...(state.status === null
+          ? {
+              provider: latestProvider(action.status),
+              ...(state.model ? {} : { model: providerDefaultModel(action.status, latestProvider(action.status)) }),
+            }
+          : {}),
       };
     case "STATUS_FAILED":
       return { ...state, statusState: "error", statusError: action.message };
     case "START_DESKTOP_SETUP":
-      return {
-        ...initialWizardState,
-        status: state.status,
-        statusState: state.statusState,
-        statusError: state.statusError,
-        setupKind: "desktop",
-        provider: latestProvider(state.status),
-      };
+      {
+        const provider = latestProvider(state.status);
+        return {
+          ...initialWizardState,
+          status: state.status,
+          statusState: state.statusState,
+          statusError: state.statusError,
+          setupKind: "desktop",
+          provider,
+          model: providerDefaultModel(state.status, provider),
+        };
+      }
     case "SELECT_AGENT":
       // Single select, and re-clicking the current row keeps it selected: the
       // step cannot continue with nothing chosen, so a toggle-off would only
       // ever produce a dead end.
       {
         const changed = state.selectedAgentIds[0] !== action.agentId;
+        // Selecting an Agent can change the Provider, because the Agent's
+        // protocol decides which Providers can serve it. The model is seeded
+        // from whichever Provider that lands on, below.
+        const provider = latestProvider(state.status, state.status?.catalog.find((item) => item.id === action.agentId)?.protocol || undefined);
         return {
           ...state,
           selectedAgentIds: [action.agentId],
-          provider: latestProvider(state.status, state.status?.catalog.find((item) => item.id === action.agentId)?.protocol || undefined),
+          provider,
           desktopProfileId: state.selectedAgentIds[0] === action.agentId ? state.desktopProfileId : "",
           // Profile IDs and labels are derived from the selected Agent and
           // Provider. Do not carry a prior run's profile into a new pairing.
@@ -198,7 +222,7 @@ export function wizardReducer(state: WizardState, action: WizardAction): WizardS
             models: [],
             modelsState: "idle" as const,
             modelsMessage: "",
-            model: "",
+            model: providerDefaultModel(state.status, provider),
           } : {}),
         };
       }
@@ -207,7 +231,7 @@ export function wizardReducer(state: WizardState, action: WizardAction): WizardS
     case "SET_PROFILE_LABEL":
       return { ...state, profileLabel: action.value };
     case "START_NEW_PROFILE":
-      return { ...state, profileId: "", profileLabel: "", model: "", reusedProfile: false, keyVerified: false, connection: null, connectionState: "idle", models: [], modelsState: "idle", modelsMessage: "" };
+      return { ...state, profileId: "", profileLabel: "", model: providerDefaultModel(state.status, state.provider), reusedProfile: false, keyVerified: false, connection: null, connectionState: "idle", models: [], modelsState: "idle", modelsMessage: "" };
     case "SET_PROFILE_STEP_SKIPPED":
       return { ...state, profileStepSkipped: action.value };
     case "SELECT_PROFILE":
@@ -227,17 +251,22 @@ export function wizardReducer(state: WizardState, action: WizardAction): WizardS
       return { ...state, desktopProfileId: action.value };
     case "START_SETUP":
       // Entering onboarding from the overview or the Profile page must not
-      // inherit a previous run's Agent, model or install log.
-      return {
-        ...initialWizardState,
-        status: state.status,
-        statusState: state.statusState,
-        statusError: state.statusError,
-        setupKind: "cli",
-        provider: latestProvider(state.status),
-        profileId: action.profileId ?? "",
-        profileLabel: action.profileLabel ?? "",
-      };
+      // inherit a previous run's Agent, model or install log. The model resets
+      // to the Provider's default rather than to nothing.
+      {
+        const provider = latestProvider(state.status);
+        return {
+          ...initialWizardState,
+          status: state.status,
+          statusState: state.statusState,
+          statusError: state.statusError,
+          setupKind: "cli",
+          provider,
+          model: providerDefaultModel(state.status, provider),
+          profileId: action.profileId ?? "",
+          profileLabel: action.profileLabel ?? "",
+        };
+      }
     case "SET_PROVIDER":
       return {
         ...state,
@@ -252,7 +281,10 @@ export function wizardReducer(state: WizardState, action: WizardAction): WizardS
         models: [],
         modelsState: "idle",
         modelsMessage: "",
-        model: "",
+        // Seeded from the new Provider rather than cleared. Model IDs do not
+        // carry across Providers, so the previous value could not be kept, but
+        // clearing it put every user back in front of an empty required field.
+        model: providerDefaultModel(state.status, action.value),
       };
     case "SET_PROBE_MODEL":
       return {
@@ -299,15 +331,23 @@ export function wizardReducer(state: WizardState, action: WizardAction): WizardS
     case "MODELS_LOADING":
       return { ...state, modelsState: "loading", modelsMessage: "" };
     case "MODELS_RESULT":
-      return {
-        ...state,
-        models: action.result.models,
-        modelsState: action.result.ok ? "success" : "error",
-        modelsMessage: action.result.message,
-        // Keep a model manually entered for the connection probe; it is often
-        // the only valid model when discovery is incomplete or unsupported.
-        model: state.model || state.probeModel.trim() || action.result.models[0] || "",
-      };
+      {
+        // Precedence, most explicit first. A model typed for the probe outranks
+        // the seeded default: the user named it, and it is often the only model
+        // that works when discovery is incomplete. But it must not outrank a
+        // model chosen on this step, hence the seeded check rather than a plain
+        // `state.model ||`, which would let the default win over everything now
+        // that it is never empty for a built-in Provider.
+        const seeded = providerDefaultModel(state.status, state.provider);
+        const chosen = state.model && state.model !== seeded ? state.model : "";
+        return {
+          ...state,
+          models: action.result.models,
+          modelsState: action.result.ok ? "success" : "error",
+          modelsMessage: action.result.message,
+          model: chosen || state.probeModel.trim() || seeded || action.result.models[0] || "",
+        };
+      }
     case "MODELS_FAILED":
       return {
         ...state,

--- a/internal/app/testdata/status-empty-linux-arm64.json
+++ b/internal/app/testdata/status-empty-linux-arm64.json
@@ -261,14 +261,18 @@
     "novita": {
       "name": "Novita",
       "home": "https://novita.ai/",
+      "key_management_url": "https://novita.ai/settings/key-management",
       "base_url": "https://api.novita.ai/openai",
-      "anthropic_base_url": "https://api.novita.ai/anthropic"
+      "anthropic_base_url": "https://api.novita.ai/anthropic",
+      "default_model": "deepseek/deepseek-v4-pro"
     },
     "ppio": {
       "name": "PPIO",
       "home": "https://ppio.com/",
+      "key_management_url": "https://ppio.com/settings/key-management",
       "base_url": "https://api.ppio.com/openai",
-      "anthropic_base_url": "https://api.ppio.com/anthropic"
+      "anthropic_base_url": "https://api.ppio.com/anthropic",
+      "default_model": "deepseek/deepseek-v4-pro"
     }
   },
   "mirrors": [

--- a/internal/binding/services.go
+++ b/internal/binding/services.go
@@ -258,17 +258,28 @@ func (s *ProviderService) OpenRegistration(ctx context.Context, request OpenRegi
 		return OpenRegistrationResponse{}, notReady("Provider service is not configured")
 	}
 	entry, err := s.core.GetProvider(ctx, request.Provider)
-	if err != nil || entry.Home == "" {
+	if err != nil {
+		return OpenRegistrationResponse{}, oneerrors.New(oneerrors.InvalidRequest, "Registration is only available for a configured Provider")
+	}
+	// Prefer the key page: it is where a user actually obtains a key, whereas
+	// Home is a marketing site they then have to navigate. Home remains the
+	// fallback so a Provider without a published key page still opens something,
+	// and so a user-added Provider keeps working unchanged.
+	target := entry.KeyManagementURL
+	if target == "" {
+		target = entry.Home
+	}
+	if target == "" {
 		return OpenRegistrationResponse{}, oneerrors.New(oneerrors.InvalidRequest, "Registration is only available for a Provider with a home URL")
 	}
-	parsed, err := url.Parse(entry.Home)
+	parsed, err := url.Parse(target)
 	if err != nil || parsed.User != nil || (parsed.Scheme != "http" && parsed.Scheme != "https") || parsed.Host == "" {
 		return OpenRegistrationResponse{}, oneerrors.New(oneerrors.InvalidRequest, "Provider registration URL is invalid")
 	}
-	if err := s.opener(entry.Home); err != nil {
+	if err := s.opener(target); err != nil {
 		return OpenRegistrationResponse{}, oneerrors.New(oneerrors.InternalError, "Unable to open Provider registration", oneerrors.WithStatus(500), oneerrors.WithRetryable(true), oneerrors.WithCause(err))
 	}
-	return OpenRegistrationResponse{OK: true, URL: entry.Home, Message: "Provider registration opened"}, nil
+	return OpenRegistrationResponse{OK: true, URL: target, Message: "Provider registration opened"}, nil
 }
 
 type AgentService struct {

--- a/internal/binding/services_test.go
+++ b/internal/binding/services_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/MaimoryLab/OneAgent/internal/app"
+	"github.com/MaimoryLab/OneAgent/internal/catalog"
 	oneerrors "github.com/MaimoryLab/OneAgent/internal/errors"
 	"github.com/MaimoryLab/OneAgent/internal/platform"
 	"github.com/MaimoryLab/OneAgent/internal/provider"
@@ -97,13 +98,47 @@ func TestOpenRegistrationUsesConfiguredProviderURL(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if opened != "https://ppio.com/" || response.URL != opened {
-		t.Fatalf("unexpected registration URL: opened=%q response=%#v", opened, response)
+	// The key page, not Home: a user pressing this button wants a key, and
+	// landing them on the marketing site leaves them to find it themselves.
+	want := catalog.KeyManagementURL("ppio")
+	if want == "" {
+		t.Fatal("ppio has no key management URL to open")
+	}
+	if opened != want || response.URL != opened {
+		t.Fatalf("unexpected registration URL: opened=%q want=%q response=%#v", opened, want, response)
 	}
 
 	_, err = service.OpenRegistration(context.Background(), OpenRegistrationRequest{Provider: "https://example.com"})
 	if err == nil || oneerrors.As(err).Code != oneerrors.InvalidRequest {
 		t.Fatalf("arbitrary URL was not rejected: %v", err)
+	}
+}
+
+// A user-added Provider has no key page, only whatever Home they typed. The
+// button has to keep working for them, so absence falls back rather than
+// disabling the affordance.
+func TestOpenRegistrationFallsBackToHomeWithoutAKeyPage(t *testing.T) {
+	home := t.TempDir()
+	core := app.NewUseCases(app.StatusOptions{
+		Home: home, Platform: platform.For("linux", "amd64"),
+		Lookup: func(string) (string, bool) { return "", false },
+	})
+	if _, err := core.SaveProvider(context.Background(), provider.Entry{
+		ID: "acme", Name: "Acme", Home: "https://acme.example.com/", BaseURL: "https://api.acme.example.com/openai",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	var opened string
+	service := NewProviderService(core, func(value string) error {
+		opened = value
+		return nil
+	})
+	response, err := service.OpenRegistration(context.Background(), OpenRegistrationRequest{Provider: "acme"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if opened != "https://acme.example.com/" || response.URL != opened {
+		t.Fatalf("custom Provider did not fall back to its home URL: opened=%q response=%#v", opened, response)
 	}
 }
 

--- a/internal/catalog/catalog_test.go
+++ b/internal/catalog/catalog_test.go
@@ -53,20 +53,88 @@ func TestEmbeddedProvidersMatchCurrentCatalogContract(t *testing.T) {
 		if provider.Name == "" || provider.BaseURL == "" || provider.fallbackModel == "" {
 			t.Fatalf("provider %q is incomplete: %#v", id, provider)
 		}
+		if provider.DefaultModel == "" {
+			t.Fatalf("provider %q has no default model to pre-fill: %#v", id, provider)
+		}
 	}
 	if got := FallbackProbeModel("unknown"); got != manifest.DefaultFallbackProbeModel {
 		t.Fatalf("unknown fallback = %q, want %q", got, manifest.DefaultFallbackProbeModel)
 	}
 }
 
+// Reads both values from the manifest rather than comparing against literals.
+// PPIO and Novita spelled the same DeepSeek release differently at v3 (hyphen
+// versus underscore) and identically at v4, so a literal would encode whichever
+// happened to be true when it was written. What must hold is that each Provider
+// names its own model and that nothing invents one for an endpoint we have never
+// seen.
+func TestDefaultModelIsPerProviderAndAbsentForUnknownProviders(t *testing.T) {
+	manifest, err := LoadEmbeddedProviders()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for id, provider := range manifest.Providers {
+		if got := DefaultModel(id); got != provider.DefaultModel {
+			t.Fatalf("DefaultModel(%q) = %q, want the manifest value %q", id, got, provider.DefaultModel)
+		}
+	}
+	// Unlike FallbackProbeModel, which falls back to a manifest-wide default,
+	// this must stay empty: a custom endpoint gets no guessed model, because a
+	// guess would produce a config that fails on the user's first request.
+	for _, id := range []string{"custom", "unknown"} {
+		if got := DefaultModel(id); got != "" {
+			t.Fatalf("DefaultModel(%q) = %q, want empty", id, got)
+		}
+	}
+}
+
+// The key page is what the UI opens, so an unreachable or downgraded URL is a
+// user-visible failure. Scheme is enforced at parse time; this pins the
+// contract that absence is allowed and falls back to Home.
+func TestKeyManagementURLIsHTTPSOrAbsent(t *testing.T) {
+	manifest, err := LoadEmbeddedProviders()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for id, provider := range manifest.Providers {
+		if got := KeyManagementURL(id); got != provider.KeyManagementURL {
+			t.Fatalf("KeyManagementURL(%q) = %q, want %q", id, got, provider.KeyManagementURL)
+		}
+		if provider.KeyManagementURL != "" && !httpsURL(provider.KeyManagementURL) {
+			t.Fatalf("provider %q key page is not HTTPS: %q", id, provider.KeyManagementURL)
+		}
+		if provider.KeyManagementURL == "" && provider.Home == "" {
+			t.Fatalf("provider %q has neither a key page nor a home URL", id)
+		}
+	}
+	if got := KeyManagementURL("unknown"); got != "" {
+		t.Fatalf("KeyManagementURL(unknown) = %q, want empty", got)
+	}
+}
+
+// The assertion is on the probe model's own value, not on the substring
+// "deepseek": default_model is public and legitimately names a DeepSeek model,
+// so a vendor-name check would fail on correct output while still passing if
+// the probe model were renamed. Comparing against what the manifest actually
+// holds is what makes this test mean "the internal field did not leak".
 func TestPublicProjectionDoesNotExposeFallbackModel(t *testing.T) {
 	providers := PublicProviders()
 	data, err := json.Marshal(providers)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if string(data) == "" || contains(string(data), "fallback") || contains(string(data), "deepseek") {
+	if string(data) == "" || contains(string(data), "fallback") {
 		t.Fatalf("internal provider fields leaked: %s", data)
+	}
+	for id, provider := range providers {
+		if provider.fallbackModel != "" {
+			t.Fatalf("provider %q kept its probe model in the public projection: %q", id, provider.fallbackModel)
+		}
+		// Guards the case the substring check cannot see: a probe model that
+		// happens to equal the default model would leak without appearing to.
+		if probe := FallbackProbeModel(id); probe != "" && contains(string(data), probe) {
+			t.Fatalf("probe model %q for %q reached the public projection: %s", probe, id, data)
+		}
 	}
 }
 
@@ -82,16 +150,65 @@ func TestParseRejectsInvalidManifest(t *testing.T) {
 }
 
 func TestParseProvidersRejectsInvalidEntries(t *testing.T) {
-	tests := []string{
-		`{"schema_version":2,"providers":{}}`,
-		`{"schema_version":1,"default_fallback_probe_model":"m","providers":{"bad id":{"name":"Bad","home":"https://example.com","base_url":"https://api.example.com","fallback_probe_model":"m"}}}`,
-		`{"schema_version":1,"default_fallback_probe_model":"m","providers":{"ok":{"name":"OK","home":"http://example.com","base_url":"https://api.example.com","fallback_probe_model":"m"}}}`,
-		`{"schema_version":1,"default_fallback_probe_model":"m","providers":{"ok":{"name":"OK","home":"https://example.com","base_url":"https://api.example.com","fallback_probe_model":""}}}`,
+	// Every case carries a complete entry apart from the one defect it is named
+	// for. Otherwise adding a required field makes each case fail for the new
+	// omission instead of the flaw it was written to catch, and the test keeps
+	// passing while testing nothing.
+	tests := map[string]string{
+		"unsupported schema":  `{"schema_version":2,"providers":{}}`,
+		"invalid provider id": `{"schema_version":1,"default_fallback_probe_model":"m","providers":{"bad id":{"name":"Bad","home":"https://example.com","base_url":"https://api.example.com","default_model":"m","fallback_probe_model":"m"}}}`,
+		"plaintext home":      `{"schema_version":1,"default_fallback_probe_model":"m","providers":{"ok":{"name":"OK","home":"http://example.com","base_url":"https://api.example.com","default_model":"m","fallback_probe_model":"m"}}}`,
+		"empty probe model":   `{"schema_version":1,"default_fallback_probe_model":"m","providers":{"ok":{"name":"OK","home":"https://example.com","base_url":"https://api.example.com","default_model":"m","fallback_probe_model":""}}}`,
+		"empty default model": `{"schema_version":1,"default_fallback_probe_model":"m","providers":{"ok":{"name":"OK","home":"https://example.com","base_url":"https://api.example.com","default_model":"","fallback_probe_model":"m"}}}`,
+		// The key page is opened in the user's browser, so a downgraded scheme
+		// is rejected rather than silently carried through.
+		"plaintext key page": `{"schema_version":1,"default_fallback_probe_model":"m","providers":{"ok":{"name":"OK","home":"https://example.com","key_management_url":"http://example.com/keys","base_url":"https://api.example.com","default_model":"m","fallback_probe_model":"m"}}}`,
 	}
-	for _, data := range tests {
+	for name, data := range tests {
 		if _, err := ParseProviders([]byte(data)); err == nil {
-			t.Errorf("ParseProviders(%s) unexpectedly succeeded", data)
+			t.Errorf("ParseProviders unexpectedly succeeded for %s: %s", name, data)
 		}
+	}
+}
+
+// docs/public-site-operations.md states that the commercial-disclosure fields
+// are published for the site and deliberately not read by the app. That claim is
+// currently true only because providerFileEntry omits them, which is invisible
+// at the call site: someone adding a field would not know it was load-bearing.
+// This pins it, so wiring one up has to be a deliberate edit here too.
+func TestSiteOnlyProviderFieldsAreNotParsed(t *testing.T) {
+	// Every field carries a value that would be obvious if it leaked.
+	data := `{"schema_version":1,"default_fallback_probe_model":"m","providers":{"ok":{
+		"name":"OK","home":"https://example.com","base_url":"https://api.example.com",
+		"default_model":"m","fallback_probe_model":"m",
+		"relationship":"LEAKED","disclosure":"LEAKED","referral_url":"https://leaked.example.com",
+		"order":9,"protocols":{"openai":"LEAKED"}}}}`
+	manifest, err := ParseProviders([]byte(data))
+	if err != nil {
+		t.Fatal(err)
+	}
+	encoded, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, field := range []string{"LEAKED", "relationship", "disclosure", "referral", "order", "protocols"} {
+		if contains(string(encoded), field) {
+			t.Fatalf("site-only field %q reached the parsed manifest: %s", field, encoded)
+		}
+	}
+}
+
+// The key page is optional, so this must parse. Without it, making the field
+// required by accident would only show up as a released build that refuses to
+// start on a Provider that has no key page.
+func TestParseProvidersAcceptsAnAbsentKeyManagementURL(t *testing.T) {
+	data := `{"schema_version":1,"default_fallback_probe_model":"m","providers":{"ok":{"name":"OK","home":"https://example.com","base_url":"https://api.example.com","default_model":"m","fallback_probe_model":"m"}}}`
+	manifest, err := ParseProviders([]byte(data))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := manifest.Providers["ok"].KeyManagementURL; got != "" {
+		t.Fatalf("KeyManagementURL = %q, want empty", got)
 	}
 }
 

--- a/internal/catalog/providers.go
+++ b/internal/catalog/providers.go
@@ -18,10 +18,20 @@ const ProviderSchemaVersion = 1
 var providerDefinitions, defaultFallbackProbeModel = mustLoadEmbeddedProviders()
 
 type providerFileEntry struct {
-	Name               string `json:"name"`
-	Home               string `json:"home"`
-	BaseURL            string `json:"base_url"`
-	AnthropicBaseURL   string `json:"anthropic_base_url"`
+	Name string `json:"name"`
+	Home string `json:"home"`
+	// Where a signed-in user creates or copies a key. Distinct from Home,
+	// which is the marketing site and stays the target of the "Website" link.
+	KeyManagementURL string `json:"key_management_url"`
+	BaseURL          string `json:"base_url"`
+	AnthropicBaseURL string `json:"anthropic_base_url"`
+	// DefaultModel is user-facing: it pre-fills the model field so a first-time
+	// user does not have to invent a model ID. FallbackProbeModel is internal
+	// and answers a different question -- the cheapest model that proves the
+	// endpoint and key work. They are deliberately separate fields because the
+	// cheapest model to test with is not the best one to hand someone for
+	// coding, and neither should silently become the other.
+	DefaultModel       string `json:"default_model"`
 	FallbackProbeModel string `json:"fallback_probe_model"`
 }
 
@@ -64,8 +74,10 @@ func ParseProviders(data []byte) (ProviderManifest, error) {
 		manifest.Providers[id] = Provider{
 			Name:             entry.Name,
 			Home:             entry.Home,
+			KeyManagementURL: entry.KeyManagementURL,
 			BaseURL:          entry.BaseURL,
 			AnthropicBaseURL: entry.AnthropicBaseURL,
+			DefaultModel:     entry.DefaultModel,
 			fallbackModel:    entry.FallbackProbeModel,
 		}
 	}
@@ -94,6 +106,18 @@ func validateProviders(source providerFile) error {
 		}
 		if entry.AnthropicBaseURL != "" && !httpsURL(entry.AnthropicBaseURL) {
 			return invalidProvider(id, "anthropic_base_url must use HTTPS")
+		}
+		// Optional: a built-in Provider without a dedicated key page falls back
+		// to Home. Required to be HTTPS when present, like every other URL here,
+		// because this one is opened in the user's browser.
+		if entry.KeyManagementURL != "" && !httpsURL(entry.KeyManagementURL) {
+			return invalidProvider(id, "key_management_url must use HTTPS")
+		}
+		// Required, unlike KeyManagementURL: this is the field that spares a
+		// first-time user from inventing a model ID, and a built-in Provider
+		// that cannot name one working model is not ready to ship.
+		if strings.TrimSpace(entry.DefaultModel) == "" {
+			return invalidProvider(id, "default_model is required")
 		}
 		if strings.TrimSpace(entry.FallbackProbeModel) == "" {
 			return invalidProvider(id, "fallback_probe_model is required")

--- a/internal/catalog/public.go
+++ b/internal/catalog/public.go
@@ -56,6 +56,21 @@ func FallbackProbeModel(providerID string) string {
 	return defaultFallbackProbeModel
 }
 
+// DefaultModel is the model a Provider suggests when the user has not chosen
+// one. Unlike FallbackProbeModel there is no global default: a custom Provider
+// is an endpoint we know nothing about, and guessing a model ID for it would
+// produce a config that fails on first use. An empty result means the caller
+// must ask.
+func DefaultModel(providerID string) string {
+	return providerDefinitions[providerID].DefaultModel
+}
+
+// KeyManagementURL is where a signed-in user creates an API key. Empty when the
+// Provider publishes no such page, in which case callers fall back to Home.
+func KeyManagementURL(providerID string) string {
+	return providerDefinitions[providerID].KeyManagementURL
+}
+
 func PublicProviders() map[string]Provider {
 	result := make(map[string]Provider, len(providerDefinitions))
 	for id, provider := range providerDefinitions {

--- a/internal/catalog/types.go
+++ b/internal/catalog/types.go
@@ -69,14 +69,21 @@ type Group struct {
 }
 
 type Provider struct {
-	Name             string `json:"name"`
-	Home             string `json:"home"`
+	Name string `json:"name"`
+	Home string `json:"home"`
+	// KeyManagementURL and DefaultModel are public on purpose: the frontend
+	// needs both to spare a first-time user from hunting for a key page and
+	// inventing a model ID. Contrast fallbackModel below.
+	KeyManagementURL string `json:"key_management_url,omitempty"`
 	BaseURL          string `json:"base_url"`
 	AnthropicBaseURL string `json:"anthropic_base_url,omitempty"`
+	DefaultModel     string `json:"default_model,omitempty"`
 	Custom           bool   `json:"custom,omitempty"`
 	HasKey           bool   `json:"has_key,omitempty"`
 	CreatedAt        string `json:"created_at,omitempty"`
-	fallbackModel    string
+	// Unexported, and cleared again by PublicProviders: which model we probe
+	// with is an internal implementation detail, not a recommendation.
+	fallbackModel string
 }
 
 type Mirror struct {

--- a/internal/provider/store.go
+++ b/internal/provider/store.go
@@ -22,14 +22,22 @@ var userProviderIDPattern = regexp.MustCompile(`^[a-z0-9][a-z0-9-]{0,63}$`)
 // Entry is the editable local Provider record. APIKey is returned only by the
 // explicit Provider CRUD service; status projections expose HasKey instead.
 type Entry struct {
-	ID               string `json:"id"`
-	Name             string `json:"name"`
-	Home             string `json:"home"`
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	Home string `json:"home"`
+	// Both derived from the built-in catalog, not user-editable: a user who adds
+	// a Provider supplies Home, and a custom endpoint has no model we can vouch
+	// for. Serialized so the frontend can pre-fill the model field and aim the
+	// key button at a key page instead of a marketing site.
+	KeyManagementURL string `json:"key_management_url,omitempty"`
+	DefaultModel     string `json:"default_model,omitempty"`
 	BaseURL          string `json:"base_url"`
 	AnthropicBaseURL string `json:"anthropic_base_url"`
 	APIKey           string `json:"api_key"`
 	BuiltIn          bool   `json:"built_in"`
-	FallbackModel    string `json:"-"`
+	// Excluded from JSON: the probe model is an internal detail and must not
+	// reach the frontend, where it would read as a recommendation.
+	FallbackModel string `json:"-"`
 }
 
 type storedProvider struct {
@@ -73,7 +81,9 @@ func (s Store) Get(id string) (Entry, error) {
 		return Entry{
 			ID: id, Name: builtIn.Name, Home: builtIn.Home, BaseURL: builtIn.BaseURL,
 			AnthropicBaseURL: builtIn.AnthropicBaseURL, BuiltIn: true,
-			FallbackModel: catalog.FallbackProbeModel(id),
+			KeyManagementURL: catalog.KeyManagementURL(id),
+			DefaultModel:     catalog.DefaultModel(id),
+			FallbackModel:    catalog.FallbackProbeModel(id),
 		}, nil
 	}
 	return Entry{}, oneerrors.New(oneerrors.InvalidRequest, "Unknown Provider: "+id)
@@ -86,6 +96,9 @@ func (s Store) Resolve(id, explicitBase string) (Entry, error) {
 		if err != nil {
 			return Entry{}, err
 		}
+		// No DefaultModel: "custom" is an endpoint we know nothing about, so the
+		// user still has to name a model. FallbackModel resolves to the manifest
+		// default, which is only ever used to probe.
 		return Entry{ID: id, Name: "Custom", BaseURL: base, FallbackModel: catalog.FallbackProbeModel(id)}, nil
 	}
 	entry, err := s.Get(id)
@@ -117,6 +130,11 @@ func (s Store) Public() (map[string]catalog.Provider, error) {
 		result[id] = catalog.Provider{
 			Name: saved.Name, Home: saved.Home, BaseURL: saved.BaseURL,
 			AnthropicBaseURL: saved.AnthropicBaseURL, Custom: !builtIn, HasKey: saved.APIKey != "", CreatedAt: saved.CreatedAt,
+			// This overlay replaces the catalog entry wholesale, so the manifest
+			// fields have to be re-read here or a built-in Provider silently
+			// loses its default model the moment the user saves a key against it.
+			KeyManagementURL: catalog.KeyManagementURL(id),
+			DefaultModel:     catalog.DefaultModel(id),
 		}
 	}
 	return result, nil
@@ -147,6 +165,8 @@ func (s Store) Save(ctx context.Context, entry Entry) (Entry, error) {
 		return Entry{}, err
 	}
 	_, entry.BuiltIn = catalog.ProviderByID(entry.ID)
+	entry.KeyManagementURL = catalog.KeyManagementURL(entry.ID)
+	entry.DefaultModel = catalog.DefaultModel(entry.ID)
 	entry.FallbackModel = catalog.FallbackProbeModel(entry.ID)
 	return entry, nil
 }
@@ -242,6 +262,11 @@ func entryFromStored(id string, saved storedProvider, builtIn bool) Entry {
 	return Entry{
 		ID: id, Name: saved.Name, Home: saved.Home, BaseURL: saved.BaseURL,
 		AnthropicBaseURL: saved.AnthropicBaseURL, APIKey: saved.APIKey, BuiltIn: builtIn,
-		FallbackModel: catalog.FallbackProbeModel(id),
+		// Read from the catalog rather than the stored record, so a user overlay
+		// on a built-in Provider keeps the manifest's model and key page. Both
+		// resolve to empty for a purely user-added Provider.
+		KeyManagementURL: catalog.KeyManagementURL(id),
+		DefaultModel:     catalog.DefaultModel(id),
+		FallbackModel:    catalog.FallbackProbeModel(id),
 	}
 }

--- a/manifests/providers.lock.json
+++ b/manifests/providers.lock.json
@@ -1,13 +1,15 @@
 {
   "schema_version": 1,
-  "default_fallback_probe_model": "deepseek/deepseek-v4-pro",
+  "default_fallback_probe_model": "deepseek/deepseek-v4-flash",
   "providers": {
     "ppio": {
       "name": "PPIO",
       "home": "https://ppio.com/",
+      "key_management_url": "https://ppio.com/settings/key-management",
       "base_url": "https://api.ppio.com/openai",
       "anthropic_base_url": "https://api.ppio.com/anthropic",
-      "fallback_probe_model": "deepseek/deepseek-v4-pro",
+      "default_model": "deepseek/deepseek-v4-pro",
+      "fallback_probe_model": "deepseek/deepseek-v4-flash",
       "relationship": "sponsor",
       "disclosure": "PPIO sponsors OneAgent development. Sponsorship does not affect Agent rank, compatibility conclusions, default selection, or connection tests.",
       "referral_url": "",
@@ -21,9 +23,11 @@
     "novita": {
       "name": "Novita",
       "home": "https://novita.ai/",
+      "key_management_url": "https://novita.ai/settings/key-management",
       "base_url": "https://api.novita.ai/openai",
       "anthropic_base_url": "https://api.novita.ai/anthropic",
-      "fallback_probe_model": "deepseek/deepseek-v4-pro",
+      "default_model": "deepseek/deepseek-v4-pro",
+      "fallback_probe_model": "deepseek/deepseek-v4-flash",
       "relationship": "sponsor",
       "disclosure": "Novita sponsors OneAgent development. Sponsorship does not affect Agent rank, compatibility conclusions, default selection, or connection tests.",
       "referral_url": "",


### PR DESCRIPTION
Implements #76. **Stacked on #77** — review that one first; this branch contains its commit, so the base should be switched to `main` once #77 merges.

A first-time user on PPIO or Novita had to supply a model ID before anything worked, with no basis for choosing between `deepseek-v3.2` and `deepseek-v4-flash`. Onboarding is now sign in → paste key, with the model pre-filled and still editable.

## Two fields, not one

The value already existed as `fallback_probe_model` and already reached config writing via `resolveProviderModel`. It was unreadable from the frontend by design: `PublicProviders` zeroes it and a test asserted the public projection contained no `"deepseek"` at all.

Rather than un-hide it, this adds `default_model` and keeps the probe model internal, because they answer different questions. `default_model` is a recommendation the user sees and edits; the probe model is the cheapest way to prove a key works. Conflating them means either probing with the expensive model on every connection test or recommending the cheap one for daily coding.

So they now hold different values — `deepseek-v4-pro` for the default, `deepseek-v4-flash` for probing. That difference is also what makes a leak detectable: with identical values, no substring assertion could tell whether the probe model had escaped into the public projection. `TestPublicProjectionDoesNotExposeFallbackModel` now compares against the probe model's actual value instead of the string `"deepseek"`, which would otherwise fail on correct output while still passing if the probe model were renamed.

`default_model` is required per built-in Provider and deliberately has **no** global fallback, unlike `FallbackProbeModel`. A custom endpoint gets no guessed model — a guess produces a config that fails on the user's first request. `key_management_url` is optional and falls back to `home`, so user-added Providers keep working unchanged.

## Where the seeding lives

In the wizard reducer, next to the Provider selection it follows, rather than duplicated per page. Every path that changes the Provider re-seeds (`SET_PROVIDER`, `SELECT_AGENT`, `START_SETUP`, `START_DESKTOP_SETUP`, `START_NEW_PROFILE`, and first `STATUS_LOADED`), because a model ID from one Provider is rarely valid at another.

Two precedence traps surfaced while doing this, both now covered by tests:

`MODELS_RESULT` resolved the model as `state.model || state.probeModel.trim() || models[0]`. That was correct when `state.model` was usually empty; now that it is seeded, the default would silently outrank a probe model the user typed by hand. The check is now against the seeded value, so an explicit pick wins and the default is only a starting point.

`STATUS_LOADED` had to stay first-load-only. A status refresh re-enters that branch, and seeding there unconditionally would overwrite a model the user was midway through typing.

In `ProfilesPage`, switching Provider only replaces the model when the field still holds the previous Provider's default or nothing — a model the user typed is theirs to keep.

## A bug found on the way

`Store.Public` rebuilt the overlay record from scratch for any Provider with a saved user entry. Since a built-in Provider gets an entry the moment you save a key against it, PPIO would have lost its default model exactly when it started being useful. Fixed by re-reading both catalog fields in the overlay.

## Key affordance

`OpenRegistration` prefers `key_management_url`, falls back to `home`, and keeps the existing scheme/host/userinfo validation. The frontend still passes no URL — the backend re-resolves it, so a tampered frontend cannot choose what opens. The CLI's `promptForKey` uses the same precedence.

The button is relabelled from "Register and get a key" to "Get an API key": a key-management page needs an existing account, so the old wording promised a sign-up flow it no longer starts. Its render guard was `providerMeta?.home`, which would have hidden the button for a Provider that publishes only a key page.

**`ProvidersPage`'s plain `<a href>` is left as-is.** I flagged it in #76 as the one place a Provider URL reaches the browser unvalidated. It is not exploitable: `validateEntry` runs `ValidateBaseURL` on `home` at save time, and I verified it rejects `javascript:`, `data:`, `file:` and embedded credentials. It is a "Website" link, so `home` is the right target. Routing it through the opener would be churn for no security gain.

## Lock files

Audited all three. `agents.lock.json` and `runtimes.lock.json` have no unparsed fields. `providers.lock.json` has five that Go never reads — `relationship`, `disclosure`, `order`, `protocols`, `referral_url` — which `docs/public-site-operations.md` says are for the public site that vendors this file.

That is now documented explicitly, including the consequence: filling in `referral_url` changes nothing, because there is no such field on `providerFileEntry` and `json.Unmarshal` discards it. Routing users through a referral link would need the field parsed and given an explicit precedence, not just a value set. `TestSiteOnlyProviderFieldsAreNotParsed` pins this — the guarantee currently rests on a struct omitting fields, which is invisible to anyone adding one.

## Verification

`go test ./...`, `go test -race ./...`, `go vet ./...` all pass. `pnpm run test` is 215 passing, up from 205. `pnpm run typecheck` and `pnpm run build` pass. `python3 scripts/check-docs.py` reports 50 files, links resolve, language split holds. The desktop target compiles with `CGO_ENABLED=1 go build -tags wails`.

Bindings regenerated with the pinned Wails CLI (`v3.0.0-beta.4`, same flags as `build/Taskfile.yml`); the diff is confined to the two model files. `frontend/src/types/api.ts` needed no change — it re-exports `CatalogModels.Provider` and `ProviderModels.Entry` directly.

The frozen status fixture gained exactly the two new provider fields and nothing else drifted.

Three new tests were mutation-checked rather than assumed: reverting the `PublicProviders` zeroing, making `DefaultModel` fall back for unknown Providers, and wiring `referral_url` into `providerFileEntry` each fail the intended test and only that test.

## Not in scope

Loading the model list before a key is entered (part C of #76). Both `/v1/models` endpoints do answer anonymously, but the pre-fill makes the default visible without it, and depending on an unauthenticated endpoint a Provider is free to lock down deserves its own change. Also unchanged: `ModelPicker`'s `<small>OpenAI-compatible model</small>`, which is wrong for the Anthropic protocol, and any per-Agent model recommendation for Codex/Responses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
