### PR TITLE
fix: make fixable install failures retryable

### DIFF
--- a/frontend/src/components/AgentProgressRow.test.tsx
+++ b/frontend/src/components/AgentProgressRow.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+// No I18nProvider here, so translate() returns the Chinese keys unchanged.
+import type { AgentInstallResult } from "../types/api";
+import { AgentProgressRow } from "./AgentProgressRow";
+
+const failed = (over: Partial<AgentInstallResult> = {}): AgentInstallResult => ({
+  agent: "codex",
+  status: "failed",
+  message: "npm is required to install Codex. Install the Node.js runtime first, then retry.",
+  retryable: true,
+  ...over,
+});
+
+describe("AgentProgressRow", () => {
+  it("offers the runtime install beside the retry when a runtime is missing", () => {
+    // Without this the row was terminal: the control that installs Node lives two
+    // wizard steps back, and this page never linked to it.
+    render(<AgentProgressRow name="Codex" result={failed()} loading={false} onRetry={vi.fn()} onInstallRuntime={vi.fn()} runtimeName="Node.js" />);
+    expect(screen.getByRole("button", { name: "安装 Node.js" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /重试/ })).toBeTruthy();
+  });
+
+  it("omits the runtime install when the caller offers none", () => {
+    // The caller decides: PREREQUISITE_MISSING also covers manifest problems that
+    // no download fixes, so the button must not appear for every failure.
+    render(<AgentProgressRow name="Codex" result={failed()} loading={false} onRetry={vi.fn()} />);
+    expect(screen.queryByRole("button", { name: /安装/ })).toBeNull();
+    expect(screen.getByRole("button", { name: /重试/ })).toBeTruthy();
+  });
+
+  it("falls back to a generic label when the runtime has no name", () => {
+    render(<AgentProgressRow name="Codex" result={failed()} loading={false} onInstallRuntime={vi.fn()} />);
+    expect(screen.getByRole("button", { name: "安装运行时" })).toBeTruthy();
+  });
+
+  it("shows no action on a row that succeeded", () => {
+    render(<AgentProgressRow name="Codex" result={{ agent: "codex", status: "configured", retryable: false }} loading={false} onInstallRuntime={vi.fn()} runtimeName="Node.js" />);
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+});

--- a/frontend/src/components/AgentProgressRow.tsx
+++ b/frontend/src/components/AgentProgressRow.tsx
@@ -1,4 +1,4 @@
-import { AlertTriangle, CheckCircle2, Circle, LoaderCircle, RotateCcw } from "lucide-react";
+import { AlertTriangle, CheckCircle2, Circle, Download, LoaderCircle, RotateCcw } from "lucide-react";
 
 import { useI18n } from "../i18n";
 import type { AgentInstallResult } from "../types/api";
@@ -9,11 +9,16 @@ export function AgentProgressRow({
   result,
   loading,
   onRetry,
+  onInstallRuntime,
+  runtimeName,
 }: {
   name: string;
   result?: AgentInstallResult;
   loading: boolean;
   onRetry?: () => void;
+  /** Offered when this row failed for a missing runtime the app can install. */
+  onInstallRuntime?: () => void;
+  runtimeName?: string;
 }) {
   const { t } = useI18n();
   const failed = result?.status === "failed";
@@ -36,6 +41,15 @@ export function AgentProgressRow({
         <strong>{name}</strong>
         <span>{loading ? t("正在处理") : result?.message || resultStatus || t("等待执行")}</span>
       </span>
+      {/* The runtime install comes first: when a row failed because Node or uv is
+          missing, installing it is the step that makes a retry worth pressing,
+          and the control for it otherwise lives two wizard steps back. */}
+      {failed && onInstallRuntime ? (
+        <button className="button button-compact" type="button" onClick={onInstallRuntime}>
+          <Download size={15} />
+          {runtimeName ? t("安装 {name}", { name: runtimeName }) : t("安装运行时")}
+        </button>
+      ) : null}
       {failed && onRetry ? (
         <button className="button button-compact" type="button" onClick={onRetry}>
           <RotateCcw size={15} />

--- a/frontend/src/i18n.tsx
+++ b/frontend/src/i18n.tsx
@@ -287,6 +287,7 @@ const english = {
   "本机已有": "Already on this machine",
   "安装": "Install",
   "安装 {name}": "Install {name}",
+  "安装运行时": "Install runtime",
   "应用 {profile} 到 {agent}": "Apply {profile} to {agent}",
   "安装中": "Installing",
   "运行时会安装到 {dir}，并写入登录 PATH，不需要管理员权限": "Runtimes install into {dir} and are added to your login PATH. No administrator rights needed",

--- a/frontend/src/pages/ActivationPage.tsx
+++ b/frontend/src/pages/ActivationPage.tsx
@@ -224,6 +224,35 @@ export function ActivationPage() {
     }
   }, [activate, state.activationRequested]);
 
+  /**
+   * The runtime a failed row is missing, when the app can install it.
+   *
+   * Gated on the error code rather than on message text: PREREQUISITE_MISSING
+   * also covers manifest problems no download would fix, so the runtime has to be
+   * one capabilities.missingRuntime actually names and that is not installed yet.
+   */
+  const missingRuntimeFor = (agentId: string, result?: AgentInstallResult) => {
+    if (result?.status !== "failed" || result.error_code !== "PREREQUISITE_MISSING") return undefined;
+    const runtimeId = state.status?.capabilities.missingRuntime?.[agentId];
+    if (!runtimeId) return undefined;
+    const runtime = state.status?.runtimes.find((item) => item.id === runtimeId);
+    return runtime && !runtime.installed && runtime.supported ? runtime : undefined;
+  };
+
+  const installMissingRuntime = async (runtimeId: string, name: string) => {
+    const id = taskKey("download", runtimeId);
+    if (!startTask({ id, kind: "download", target: runtimeId, title: t("安装 {name}", { name }), route, progressTarget: runtimeId })) return;
+    try {
+      const request = api.installRuntime(runtimeId);
+      setTaskCanceller(id, taskCanceller(request));
+      await request;
+      finishTask(id, { kind: "success", message: t("安装完成") });
+      await refreshStatus();
+    } catch (error) {
+      finishTask(id, { kind: "failure", message: describeError(error, t("运行时安装失败")).message });
+    }
+  };
+
   const retry = async (agentId: string) => {
     const startedTasks = startActivationTasks([agentId]);
     if (!startedTasks) return;
@@ -325,6 +354,8 @@ export function ActivationPage() {
           const result = cancelled
             ? { agent: agentId, status: "skipped" as const, message: t("已取消"), retryable: false }
             : state.activationResults.find((item) => item.agent === agentId);
+          const missingRuntime = missingRuntimeFor(agentId, result);
+          const runtimeBusy = Boolean(missingRuntime && taskFor(taskKey("download", missingRuntime.id))?.state === "running");
           return (
             <AgentProgressRow
               key={agentId}
@@ -334,6 +365,10 @@ export function ActivationPage() {
               // One retry at a time: concurrent retries each observe a stale
               // snapshot of the other rows and would skip the final cleanup.
               onRetry={result?.status === "failed" && result.retryable && !retrying ? () => void retry(agentId) : undefined}
+              onInstallRuntime={missingRuntime && !runtimeBusy && !retrying
+                ? () => void installMissingRuntime(missingRuntime.id, missingRuntime.name)
+                : undefined}
+              runtimeName={missingRuntime?.name}
             />
           );
         })}

--- a/internal/app/install.go
+++ b/internal/app/install.go
@@ -595,6 +595,9 @@ func installResultFor(agentID, status, path string, installed install.Result, ch
 		Installed: installed.Installed,
 		Version:   installed.Version,
 		Registry:  installed.Registry,
+		// Only success rows are built here; a failure goes through installRun.fail,
+		// which carries the error's own Retryable through. Nothing to retry on a
+		// row that succeeded.
 		Retryable: false,
 		checkOnly: checkOnly,
 	}

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -149,7 +149,10 @@ func InstallAgent(ctx context.Context, runtime Runtime, agent catalog.Agent, opt
 	case "npm":
 		npm, ok := runtime.Runner.LookPath("npm")
 		if !ok || npm == "" {
-			return Result{}, prerequisiteError(fmt.Sprintf("npm is required to install %s", agent.Name))
+			// Same wording as requirePrerequisites: this is the same condition
+			// reached by a second LookPath, and two different messages for it
+			// meant the one a user saw was not predictable from the UI.
+			return Result{}, missingToolError(npmPrerequisiteMessage(agent.Name))
 		}
 		// A managed Node has no writable system prefix, and a system Node often
 		// needs sudo for -g. Directing global installs at OneAgent's own prefix
@@ -174,7 +177,7 @@ func InstallAgent(ctx context.Context, runtime Runtime, agent catalog.Agent, opt
 	case "uv":
 		uv, ok := runtime.Runner.LookPath("uv")
 		if !ok || uv == "" {
-			return Result{}, prerequisiteError("uv is required to install Aider")
+			return Result{}, missingToolError(uvPrerequisiteMessage)
 		}
 		spec := packageName
 		if version != "" {
@@ -224,12 +227,12 @@ func requirePrerequisites(runtime Runtime, agent catalog.Agent) error {
 	}
 	if packageInfo.Manager == "npm" {
 		if _, ok := runtime.Runner.LookPath("npm"); !ok {
-			return prerequisiteError(fmt.Sprintf("npm is required to install %s. Install the Node.js runtime first.", agent.Name))
+			return missingToolError(npmPrerequisiteMessage(agent.Name))
 		}
 	}
 	if packageInfo.Manager == "uv" {
 		if _, ok := runtime.Runner.LookPath("uv"); !ok {
-			return prerequisiteError("uv is required to install Aider. Install the uv runtime first.")
+			return missingToolError(uvPrerequisiteMessage)
 		}
 	}
 	if runtime.Platform.OS == "windows" {
@@ -241,7 +244,7 @@ func requirePrerequisites(runtime Runtime, agent catalog.Agent) error {
 		}
 		if len(missing) > 0 {
 			sort.Strings(missing)
-			return prerequisiteError(fmt.Sprintf("%s is required for %s on Windows", missing[0], agent.Name))
+			return missingToolError(fmt.Sprintf("%s is required for %s on Windows. Install it, then retry.", missing[0], agent.Name))
 		}
 	}
 	return nil
@@ -303,8 +306,34 @@ func timeoutError(message string, cause error) error {
 	return oneerrors.New(oneerrors.Timeout, message, oneerrors.WithRetryable(true), oneerrors.WithCause(cause))
 }
 
+// The two runtime prerequisites are each reached from two places -- once in
+// requirePrerequisites and again at the LookPath in the manager switch -- so the
+// text lives here rather than being written twice with different wording.
+func npmPrerequisiteMessage(agentName string) string {
+	return fmt.Sprintf("npm is required to install %s. Install the Node.js runtime first, then retry.", agentName)
+}
+
+const uvPrerequisiteMessage = "uv is required to install Aider. Install the uv runtime first, then retry."
+
+// prerequisiteError reports a missing prerequisite the user cannot fix by
+// retrying: a manifest without an installation contract, an unsupported archive
+// format, a platform the Agent does not serve. Retrying runs the same code
+// against the same inputs, so the UI is right to offer no retry button.
 func prerequisiteError(message string) error {
 	return oneerrors.New(oneerrors.PrerequisiteMissing, message)
+}
+
+// missingToolError reports a prerequisite the user can supply, which is a
+// different outcome from the one above even though both are PrerequisiteMissing.
+//
+// Retryable drives whether a retry button is rendered at all
+// (ActivationPage.tsx gates on it), and these were the failures most likely to
+// be fixable by hand -- install Node, install uv, install the Windows
+// dependency -- while offering the least in-app recourse. Without the flag the
+// row was terminal: no retry, and no primary action either, because that only
+// appears once every Agent has finished.
+func missingToolError(message string) error {
+	return oneerrors.New(oneerrors.PrerequisiteMissing, message, oneerrors.WithRetryable(true))
 }
 
 func officialRegistry() string {

--- a/internal/install/install_test.go
+++ b/internal/install/install_test.go
@@ -177,6 +177,17 @@ func TestInstallPrerequisitesAndFailuresAreStableAndRedacted(t *testing.T) {
 	if err == nil || oneerrors.As(err).Code != oneerrors.PrerequisiteMissing || !strings.Contains(err.Error(), "npm") {
 		t.Fatalf("missing npm error = %v", err)
 	}
+	// Retryable is what decides whether the activation page renders a retry
+	// button at all. A missing runtime is the case a user can most easily fix by
+	// hand, and it used to be the one offering no way back.
+	if !oneerrors.As(err).Retryable {
+		t.Fatalf("missing npm should be retryable: %+v", oneerrors.As(err))
+	}
+	// The guidance is the whole reason this message differs from the bare one the
+	// manager switch used to raise.
+	if !strings.Contains(err.Error(), "Node.js") || !strings.Contains(err.Error(), "retry") {
+		t.Fatalf("missing npm message should name the runtime and the retry: %q", err.Error())
+	}
 
 	secret := "install-secret"
 	failing := &fakeInstallRunner{paths: map[string]string{"npm": "/fake/npm"}}
@@ -208,5 +219,32 @@ func TestInstallerFailureDetailLimitsLinesAndLength(t *testing.T) {
 	detail := installerFailureDetail(result, nil)
 	if strings.Contains(detail, "one") || !strings.Contains(detail, "four") || len([]rune(detail)) > 600 {
 		t.Fatalf("failure detail = %q", detail)
+	}
+}
+
+// A manifest problem and a missing tool are both PrerequisiteMissing, but only
+// one of them changes if the user does something and presses retry. The retry
+// button is gated on Retryable, so conflating them would either hide the button
+// where it helps or offer it where it cannot.
+func TestOnlyFixablePrerequisitesAreRetryable(t *testing.T) {
+	manifest := mustManifest()
+	agent := manifest.Agents["codex"]
+
+	missingTool := &fakeInstallRunner{paths: map[string]string{}}
+	_, err := InstallAgent(context.Background(), runtimeForInstall(missingTool, "linux", nil), agent, Options{})
+	if err == nil || !oneerrors.As(err).Retryable {
+		t.Fatalf("a missing runtime is fixable, so it must be retryable: %v", err)
+	}
+
+	// No package contract: retrying runs the same code over the same manifest.
+	noContract := agent
+	noContract.Package = nil
+	_, err = InstallAgent(context.Background(), runtimeForInstall(missingTool, "linux", nil), noContract, Options{})
+	converted := oneerrors.As(err)
+	if err == nil || converted.Code != oneerrors.PrerequisiteMissing {
+		t.Fatalf("missing package contract error = %v", err)
+	}
+	if converted.Retryable {
+		t.Fatalf("a manifest without an install contract cannot be fixed by retrying: %+v", converted)
 	}
 }

--- a/internal/securefs/securefs.go
+++ b/internal/securefs/securefs.go
@@ -316,8 +316,13 @@ func checkContext(ctx context.Context) error {
 	return nil
 }
 
+// Retryable because every failure that reaches here is a condition outside the
+// process: permission or ownership on the target, a full disk, a path held open
+// by the Agent itself, an unavailable Windows account. The user fixes those and
+// the same write succeeds -- so this is exactly the case that needs a retry
+// button, and it had none, because Retryable defaults to false.
 func writeError(format string, values ...any) error {
-	return oneerrors.New(oneerrors.ConfigWriteFailed, fmt.Sprintf(format, values...))
+	return oneerrors.New(oneerrors.ConfigWriteFailed, fmt.Sprintf(format, values...), oneerrors.WithRetryable(true))
 }
 
 func secretWord(secret bool) string {

--- a/internal/securefs/securefs_test.go
+++ b/internal/securefs/securefs_test.go
@@ -163,6 +163,32 @@ func TestAtomicWriteMapsFilesystemFailuresAndDoesNotLeakContent(t *testing.T) {
 	}
 }
 
+// Every failure writeError reports is a condition outside the process --
+// permission, ownership, a full disk, a file held open by the Agent. The user
+// fixes it and the same write succeeds, so the activation page has to offer a
+// retry; it renders that button only when Retryable is set.
+func TestConfigWriteFailuresAreRetryable(t *testing.T) {
+	store := New(Options{OS: "linux"})
+	directory := t.TempDir()
+	blocker := filepath.Join(directory, "blocked")
+	if err := os.WriteFile(blocker, []byte("not a directory"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// A file where a directory has to be: the temporary-file create fails with
+	// ENOTDIR, which is the same shape as the permission failures this guards.
+	_, err := store.AtomicWrite(context.Background(), filepath.Join(blocker, "target"), []byte("secret-value"), false)
+	converted := oneerrors.As(err)
+	if err == nil || converted.Code != oneerrors.ConfigWriteFailed {
+		t.Fatalf("write into a non-directory = %v", err)
+	}
+	if !converted.Retryable {
+		t.Fatalf("a filesystem write failure is fixable outside the app, so it must be retryable: %+v", converted)
+	}
+	if strings.Contains(err.Error(), "secret-value") {
+		t.Fatalf("write failure leaked the payload: %q", err.Error())
+	}
+}
+
 func assertMode(t *testing.T, path string, want os.FileMode) {
 	t.Helper()
 	info, err := os.Stat(path)


### PR DESCRIPTION
Fixes #113.

The retry button is gated on the error's `Retryable` flag (`AgentProgressRow.tsx:39`, `ActivationPage.tsx:336`), and the flag was set on the failures a user cannot act on while the ones they can fix by hand defaulted to `false`.

So `npm is required to install Codex` was a dead end: no retry button, and no primary action either, because `primaryLabel` only appears once `allDone`. The only exit was the back link — and the control that installs Node sits two wizard steps behind it.

## PrerequisiteMissing is two different outcomes

Rather than setting the flag wholesale, this splits by whether retrying can change anything:

- `missingToolError` — a prerequisite the user can supply: npm, uv, a Windows dependency. Retryable.
- `prerequisiteError` — unchanged. A manifest with no install contract, an unsupported archive format, a platform the Agent does not serve. Retrying runs the same code over the same inputs.

## securefs

Every `writeError` case is a condition outside the process: permission or ownership on the target, a full disk, a path held open by the Agent itself, an unavailable Windows account. The user fixes it and the same write succeeds, so all of them are retryable now.

## The runtime install, in place

The activation row offers it next to the retry. Gated on `error_code === "PREREQUISITE_MISSING"` **plus** a runtime that `capabilities.missingRuntime` actually names and that is not yet installed — the code alone would put the button on manifest failures no download fixes.

## Duplicate message merged

Missing npm was reported from two `LookPath` calls with two different strings — `install.go:152` without the "install Node first" guidance, `:227` with it. Which one a user saw was not predictable from the UI. Both now come from one function, and both npm and uv messages end with "then retry" now that retrying is actually possible.

## Verification

- `go test ./...`, `go vet ./...`, `go test -race` on the three touched packages — all pass
- `pnpm run test` — 272 passed (37 files), 4 new in `AgentProgressRow.test.tsx`
- `pnpm run build`, `pnpm run test:e2e` (6 passed)
- Reverted each flag independently: dropping `missingToolError`'s flag fails 2 Go tests, dropping `writeError`'s fails 1, removing the runtime button fails 2 frontend tests. Nothing passes vacuously.

`installResultFor`'s hardcoded `Retryable: false` is left alone — it only builds success rows; failures go through `installRun.fail`, which carries the error's own flag. Added a comment saying so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)