### PR TITLE
fix: localise backend failures through the error contract

### DIFF
--- a/frontend/src/backend/api.ts
+++ b/frontend/src/backend/api.ts
@@ -12,4 +12,4 @@ export type BackendApi = typeof wailsApi;
 
 export const api: BackendApi = wailsApi;
 
-export { describeError, isCancellationError } from "./errors";
+export { describeError, describeFailure, isCancellationError } from "./errors";

--- a/frontend/src/backend/errors.test.ts
+++ b/frontend/src/backend/errors.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import { sourceTranslate } from "../i18n";
+import { describeError, describeFailure, OneAgentApiError } from "./errors";
+
+const t = sourceTranslate;
+
+/** What normalizeWailsError produces for a backend failure. */
+const apiError = (message: string, code: string, status = 400) =>
+  new OneAgentApiError(message, code, false, status);
+
+describe("describeFailure", () => {
+  // The defect this exists for: describeError returns error.message verbatim, and
+  // because normalizeWailsError wraps every backend failure in OneAgentApiError,
+  // the Chinese t() fallbacks callers passed almost never fired. Users read
+  // English inside a Chinese UI.
+  it("replaces the English backend message with localised copy", () => {
+    const raw = 'Cannot reach endpoint: Post "https://api.example.test/v1/chat/completions": dial tcp: lookup api.example.test: no such host';
+    const error = apiError(raw, "PROVIDER_UNREACHABLE", 0);
+
+    expect(describeError(error, "fallback").message).toBe(raw);
+    expect(describeFailure(error, "fallback", t).message).toBe("无法连接到模型服务");
+  });
+
+  it("carries the hint through so the caller can render a next step", () => {
+    const detail = describeFailure(apiError("Endpoint returned HTTP 429.", "PROVIDER_UNREACHABLE", 429), "fallback", t);
+    expect(detail.message).toBe("请求过于频繁，或已达到额度上限");
+    expect(detail.hint).toBeTruthy();
+  });
+
+  it("preserves the code and the retryable flag", () => {
+    // The retry button and the status styling read these, so localising the
+    // message must not disturb them.
+    const error = new OneAgentApiError("Cannot write temporary file for /c: permission denied", "CONFIG_WRITE_FAILED", true, 400);
+    const detail = describeFailure(error, "fallback", t);
+    expect(detail.code).toBe("CONFIG_WRITE_FAILED");
+    expect(detail.retryable).toBe(true);
+    expect(detail.message).toBe("无法写入配置文件");
+  });
+
+  it("keeps a message no code can improve on", () => {
+    // INVALID_REQUEST is validation text written for the field it came from.
+    const detail = describeFailure(apiError("Provider name is required", "INVALID_REQUEST"), "fallback", t);
+    expect(detail.message).toBe("Provider name is required");
+    expect(detail.hint).toBeUndefined();
+  });
+
+  it("falls back for a thrown value that is not a backend error", () => {
+    expect(describeFailure("just a string", "回退文案", t).message).toBe("回退文案");
+    // A real Error keeps its own message: this is where a frontend bug surfaces,
+    // and replacing it with a generic sentence would hide it.
+    expect(describeFailure(new Error("boom"), "回退文案", t).message).toBe("boom");
+  });
+
+  it("exposes the status describeError previously dropped", () => {
+    // Without it the copy layer could not tell 429 from 402 behind one code.
+    expect(describeError(apiError("x", "PROVIDER_UNREACHABLE", 402), "f").status).toBe(402);
+  });
+});

--- a/frontend/src/backend/errors.ts
+++ b/frontend/src/backend/errors.ts
@@ -1,3 +1,6 @@
+import type { Translate } from "../i18n";
+import { failureCopyFor } from "./failureCopy";
+
 export class OneAgentApiError extends Error {
 	readonly code: string;
 	readonly retryable: boolean;
@@ -16,6 +19,10 @@ export interface FailureDetail {
 	message: string;
 	code: string;
 	retryable: boolean;
+	/** The HTTP status behind the failure, when one reached the transport. */
+	status?: number;
+	/** One line of what to do about it, set only by describeFailure. */
+	hint?: string;
 }
 
 export function isCancellationError(error: unknown): boolean {
@@ -26,11 +33,32 @@ export function isCancellationError(error: unknown): boolean {
 /** Normalize any thrown value into the stable frontend error contract. */
 export function describeError(error: unknown, fallback: string): FailureDetail {
 	if (error instanceof OneAgentApiError) {
-		return { message: error.message, code: error.code, retryable: error.retryable };
+		return { message: error.message, code: error.code, retryable: error.retryable, status: error.status };
 	}
 	return {
 		message: error instanceof Error ? error.message : fallback,
 		code: "INTERNAL_ERROR",
 		retryable: true,
 	};
+}
+
+/**
+ * describeError, with the message replaced by localised copy where a code maps to
+ * any.
+ *
+ * Separate from describeError rather than folded into it: this needs a Translate,
+ * which only components have, and describeError is also called from places that
+ * just want the code or the retryable flag. Callers that show a message to a user
+ * should prefer this one.
+ *
+ * The English backend message is dropped, not appended. It is written for a
+ * maintainer reading a log -- "Cannot reach endpoint: dial tcp: lookup
+ * api.example.com: no such host" -- and showing both would leave the user to
+ * decide which half to trust.
+ */
+export function describeFailure(error: unknown, fallback: string, t: Translate): FailureDetail {
+	const detail = describeError(error, fallback);
+	const copy = failureCopyFor(detail.code, detail.status, t);
+	if (!copy) return detail;
+	return { ...detail, message: copy.message, hint: copy.hint };
 }

--- a/frontend/src/backend/failureCopy.test.ts
+++ b/frontend/src/backend/failureCopy.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+
+import { sourceTranslate } from "../i18n";
+import { failureCopyFor, isHTTPStatus } from "./failureCopy";
+
+// sourceTranslate returns the Chinese keys, which is what the source language is.
+const t = sourceTranslate;
+
+describe("failureCopyFor", () => {
+  it("separates the two statuses a new user hits most", () => {
+    // Both used to arrive as a bare "Endpoint returned HTTP 429." with no
+    // indication of which, or that the account rather than the config was at fault.
+    expect(failureCopyFor("PROVIDER_UNREACHABLE", 429, t)?.message).toBe("请求过于频繁，或已达到额度上限");
+    expect(failureCopyFor("PROVIDER_UNREACHABLE", 402, t)?.message).toBe("账户额度不足");
+  });
+
+  it("distinguishes a timeout from an unreachable endpoint", () => {
+    // The backend tracks these as separate codes while producing the identical
+    // "Cannot reach endpoint" sentence for both.
+    const timeout = failureCopyFor("TIMEOUT", 0, t);
+    const unreachable = failureCopyFor("PROVIDER_UNREACHABLE", 0, t);
+    expect(timeout?.message).toBe("连接模型服务超时");
+    expect(unreachable?.message).toBe("无法连接到模型服务");
+    expect(timeout?.message).not.toBe(unreachable?.message);
+  });
+
+  it("reads a 401 behind PROVIDER_UNREACHABLE as a rejected key", () => {
+    // classifyHTTPModels only tags API_KEY_REJECTED when the models call failed,
+    // so the same rejection arrives under either code depending on the path.
+    expect(failureCopyFor("PROVIDER_UNREACHABLE", 401, t)?.message)
+      .toBe(failureCopyFor("API_KEY_REJECTED", 401, t)?.message);
+  });
+
+  it("treats status 0 as a request that never landed", () => {
+    // internal/provider/client.go:21 uses 0 as the sentinel, so it must not be
+    // read as an HTTP response.
+    expect(isHTTPStatus(0)).toBe(false);
+    expect(isHTTPStatus(undefined)).toBe(false);
+    expect(isHTTPStatus(429)).toBe(true);
+    // Falls back to the code's own copy rather than inventing an HTTP sentence.
+    expect(failureCopyFor("PROVIDER_UNREACHABLE", 0, t)?.message).toBe("无法连接到模型服务");
+  });
+
+  it("returns null where the code cannot improve on the backend message", () => {
+    // INVALID_REQUEST is field-level validation text; replacing it with a generic
+    // sentence would lose what the user needs to fix.
+    expect(failureCopyFor("INVALID_REQUEST", 400, t)).toBeNull();
+    expect(failureCopyFor("INTERNAL_ERROR", 500, t)).toBeNull();
+    expect(failureCopyFor(null, undefined, t)).toBeNull();
+    expect(failureCopyFor(undefined, undefined, t)).toBeNull();
+  });
+
+  it("names a server-side failure as the provider's problem", () => {
+    const copy = failureCopyFor("PROVIDER_UNREACHABLE", 503, t);
+    expect(copy?.message).toContain("503");
+    expect(copy?.hint).toBe("这是对方服务的问题，稍后重试");
+  });
+
+  it("gives every mapped code something to do about it", () => {
+    // A message that only restates the problem leaves the user where they started;
+    // these are the codes where there is a next step to name.
+    for (const code of [
+      "API_KEY_REJECTED",
+      "PROVIDER_UNREACHABLE",
+      "TIMEOUT",
+      "PROTOCOL_UNSUPPORTED",
+      "MODELS_UNSUPPORTED",
+      "CONFIG_WRITE_FAILED",
+    ]) {
+      const copy = failureCopyFor(code, 0, t);
+      expect(copy, code).not.toBeNull();
+      expect(copy?.hint, code).toBeTruthy();
+    }
+  });
+
+  it("never leaks a raw transport detail into the copy", () => {
+    // The whole point: "dial tcp: lookup api.example.com: no such host" is written
+    // for a maintainer reading a log.
+    for (const status of [0, 401, 402, 404, 429, 500, 503, 418]) {
+      const copy = failureCopyFor("PROVIDER_UNREACHABLE", status, t);
+      expect(copy?.message ?? "").not.toMatch(/dial tcp|Post "|no such host|context deadline/);
+    }
+  });
+});

--- a/frontend/src/backend/failureCopy.ts
+++ b/frontend/src/backend/failureCopy.ts
@@ -1,0 +1,97 @@
+import type { Translate } from "../i18n";
+
+/**
+ * Localised copy for backend failures.
+ *
+ * Every Go message reaching the UI is English, and describeError passed it
+ * through verbatim: normalizeWailsError wraps each backend failure in
+ * OneAgentApiError, so the Chinese `t()` fallbacks callers supplied almost never
+ * fired. This maps the stable error contract -- `error_code` from
+ * internal/errors, plus the HTTP `status` a probe carries -- onto copy the i18n
+ * table owns.
+ *
+ * Deliberately not string matching on the English message: that would break the
+ * moment Go rewords anything, and the codes exist precisely so the UI does not
+ * have to read prose. Where a code is too coarse to be useful on its own (an
+ * HTTP status behind PROVIDER_UNREACHABLE covers 402, 429 and 500 alike) the
+ * status refines it.
+ */
+
+export interface FailureCopy {
+  /** The sentence to show in place of the backend message. */
+  message: string;
+  /** One line of what to do about it, when there is something to do. */
+  hint?: string;
+}
+
+/**
+ * True when `status` came from an actual HTTP response.
+ *
+ * A transport failure reports status 0 (`unsupportedStatus`,
+ * internal/provider/client.go:21), so zero means the request never landed rather
+ * than naming a response.
+ */
+export const isHTTPStatus = (status: number | undefined): boolean =>
+  typeof status === "number" && status > 0;
+
+/**
+ * Copy for an HTTP status a Provider returned.
+ *
+ * 429 and 402 are the two a new user hits most -- rate limit and exhausted
+ * credit -- and both arrived as a bare "Endpoint returned HTTP 429." with no
+ * indication of which, or that the account rather than the config is the issue.
+ */
+function httpStatusCopy(status: number, t: Translate): FailureCopy | null {
+  if (status === 401 || status === 403) {
+    return { message: t("API Key 被拒绝"), hint: t("确认 Key 已完整粘贴，或到模型服务页面重新填写") };
+  }
+  if (status === 402) {
+    return { message: t("账户额度不足"), hint: t("到模型服务官网充值或查看账户额度") };
+  }
+  if (status === 429) {
+    return { message: t("请求过于频繁，或已达到额度上限"), hint: t("稍等一会儿再试，或到模型服务官网查看额度") };
+  }
+  if (status === 404 || status === 405) {
+    return { message: t("端点不提供这个接口"), hint: t("确认 Base URL 是否正确，以及这个模型服务是否支持所选 API 类型") };
+  }
+  if (status >= 500) {
+    return { message: t("模型服务暂时不可用（HTTP {status}）", { status }), hint: t("这是对方服务的问题，稍后重试") };
+  }
+  if (status > 0) return { message: t("模型服务返回了 HTTP {status}", { status }) };
+  return null;
+}
+
+/**
+ * Copy for an error code, with an optional HTTP status to refine it.
+ *
+ * Returns null when the code carries no more information than the backend
+ * message already did -- INVALID_REQUEST is a validation message written for the
+ * field it came from, and replacing it with a generic sentence would lose detail
+ * the user needs.
+ */
+export function failureCopyFor(code: string | null | undefined, status: number | undefined, t: Translate): FailureCopy | null {
+  switch (code) {
+    case "API_KEY_REJECTED":
+      return { message: t("API Key 被拒绝"), hint: t("确认 Key 已完整粘贴，或到模型服务页面重新填写") };
+    case "PROVIDER_UNREACHABLE": {
+      // A real status means the endpoint answered, so it is reachable and the
+      // status is the story. Status 0 means the request never landed.
+      const byStatus = isHTTPStatus(status) ? httpStatusCopy(status as number, t) : null;
+      if (byStatus) return byStatus;
+      return { message: t("无法连接到模型服务"), hint: t("检查网络连接和 Base URL 是否正确") };
+    }
+    case "TIMEOUT":
+      // Distinguished from unreachable, which the backend has always tracked as a
+      // separate code while producing the identical "Cannot reach endpoint"
+      // sentence for both.
+      return { message: t("连接模型服务超时"), hint: t("检查网络连接，或稍后重试") };
+    case "PROTOCOL_UNSUPPORTED":
+      return { message: t("这个模型不支持所选的 API 类型"), hint: t("换一个支持该 API 类型的模型，或改用其他 API 类型") };
+    case "MODELS_UNSUPPORTED":
+      return { message: t("无法获取模型列表"), hint: t("这个端点不提供模型列表，可以直接手动输入模型 ID") };
+    case "CONFIG_WRITE_FAILED":
+      return { message: t("无法写入配置文件"), hint: t("确认配置文件没有被其他程序占用，以及你对它有写入权限") };
+    default:
+      return null;
+  }
+}

--- a/frontend/src/components/AgentManageRow.test.tsx
+++ b/frontend/src/components/AgentManageRow.test.tsx
@@ -14,6 +14,7 @@ vi.mock("../backend/api", async () => {
   return {
     api: { launchAgent: (agentId: string, directory: string) => launchAgent(agentId, directory) },
     describeError: errors.describeError,
+    describeFailure: errors.describeFailure,
   };
 });
 

--- a/frontend/src/components/AgentManageRow.tsx
+++ b/frontend/src/components/AgentManageRow.tsx
@@ -3,7 +3,7 @@ import { FolderOpen, Play, RefreshCw, SlidersHorizontal } from "lucide-react";
 import { useState } from "react";
 import { Link } from "react-router-dom";
 
-import { api, describeError } from "../backend/api";
+import { api, describeFailure } from "../backend/api";
 import { sourceTranslate, type Translate, useI18n } from "../i18n";
 import { taskCanceller, taskKey, updateTaskRoute, useTaskCenter, useTaskRoute } from "../state/TaskCenterContext";
 import type { AgentCatalogItem, AgentStatus, ProfileSummary, StatusResponse } from "../types/api";
@@ -181,7 +181,7 @@ export function AgentManageRow({
     try {
       await api.launchAgent(agentId, launchDirectory.trim());
     } catch (error) {
-      setFailure(describeError(error, t("无法启动 Agent")).message);
+      setFailure(describeFailure(error, t("无法启动 Agent"), t).message);
     } finally {
       setLaunching(false);
     }
@@ -203,7 +203,7 @@ export function AgentManageRow({
       finishTask(updateTaskID, { kind: "success", message: t("更新完成") });
       await onChanged?.();
     } catch (error) {
-      finishTask(updateTaskID, { kind: "failure", message: describeError(error, t("无法更新 Agent")).message });
+      finishTask(updateTaskID, { kind: "failure", message: describeFailure(error, t("无法更新 Agent"), t).message });
     } finally {
       setLocalUpdating(false);
     }

--- a/frontend/src/components/AppUpdater.test.tsx
+++ b/frontend/src/components/AppUpdater.test.tsx
@@ -27,6 +27,7 @@ vi.mock("../backend/api", async () => {
       restartUpdate: mocks.restartUpdate,
     },
     describeError: errors.describeError,
+    describeFailure: errors.describeFailure,
     isCancellationError: errors.isCancellationError,
   };
 });

--- a/frontend/src/components/AppUpdater.tsx
+++ b/frontend/src/components/AppUpdater.tsx
@@ -1,7 +1,7 @@
 import { Dialogs } from "@wailsio/runtime";
 import { useEffect, useRef } from "react";
 
-import { api, describeError, isCancellationError } from "../backend/api";
+import { api, describeFailure, isCancellationError } from "../backend/api";
 import { OTA_PROGRESS_TARGET } from "../backend/wails";
 import { useI18n } from "../i18n";
 import { taskCanceller, taskKey, updateTaskRoute, useTaskCenter } from "../state/TaskCenterContext";
@@ -68,7 +68,7 @@ export function AppUpdater() {
             try {
               await api.restartUpdate();
             } catch (error) {
-              latest.current.setTaskMessage(OTA_TASK_ID, describeError(error, t("无法重启并更新")).message);
+              latest.current.setTaskMessage(OTA_TASK_ID, describeFailure(error, t("无法重启并更新"), t).message);
             } finally {
               restarting.current = false;
             }
@@ -77,7 +77,7 @@ export function AppUpdater() {
       } catch (error) {
         latest.current.finishTask(OTA_TASK_ID, isCancellationError(error)
           ? { kind: "cancelled", message: t("已取消") }
-          : { kind: "failure", message: describeError(error, t("更新失败")).message });
+          : { kind: "failure", message: describeFailure(error, t("更新失败"), t).message });
       }
     })();
 

--- a/frontend/src/components/ConnectionStatus.test.tsx
+++ b/frontend/src/components/ConnectionStatus.test.tsx
@@ -32,19 +32,64 @@ describe("ConnectionStatus", () => {
     // Their override, so the failure is the answer they asked for; explaining our
     // choice would be both wrong and confusing.
     show(probe({ model: "kwai/kling-v1-video", auto_selected_model: false }));
-    expect(screen.getByText("模型请求被拒绝")).toBeTruthy();
+    expect(screen.getByText(/does not serve the selected API type/)).toBeTruthy();
     expect(screen.queryByText(/OneAgent chose the model/)).toBeNull();
   });
 
   it("does not blame the model when the key itself was rejected", () => {
     // A rejected key is about the key whatever model carried the request.
-    show(probe({ error_code: "API_KEY_REJECTED", message: "API Key 无效", model: "wan-ai/wan2.1-t2v-14b", auto_selected_model: true }));
-    expect(screen.getByText("API Key 无效")).toBeTruthy();
+    show(probe({ error_code: "API_KEY_REJECTED", status: 401, model: "wan-ai/wan2.1-t2v-14b", auto_selected_model: true }));
+    expect(screen.getByText("The API key was rejected")).toBeTruthy();
     expect(screen.queryByText(/OneAgent chose the model/)).toBeNull();
   });
 
   it("reports a successful probe with the provider's own message", () => {
     show(probe({ ok: true, status: 200, message: "连接正常", error_code: null }));
     expect(screen.getByText("连接正常")).toBeTruthy();
+  });
+
+  // The backend's own sentences are English and written for a maintainer reading a
+  // log. These replace them rather than appending, so the user is not left
+  // deciding which half to trust.
+  it("replaces the English backend message with localised copy", () => {
+    show(probe({ error_code: "PROVIDER_UNREACHABLE", status: 0, message: 'Cannot reach endpoint: Post "https://api.example.test/v1/chat/completions": dial tcp: lookup api.example.test: no such host' }));
+    expect(screen.getByText("Could not reach the provider")).toBeTruthy();
+    expect(screen.queryByText(/dial tcp/)).toBeNull();
+    expect(screen.getByText(/Check the network connection and the base URL/)).toBeTruthy();
+  });
+
+  // 429 and 402 were the two a new user hits most, and both arrived as a bare
+  // "Endpoint returned HTTP 429." with no indication of which, or that the
+  // account rather than the configuration was the problem.
+  it("explains a rate limit and an exhausted balance separately", () => {
+    show(probe({ error_code: "PROVIDER_UNREACHABLE", status: 429, message: "Endpoint returned HTTP 429." }));
+    expect(screen.getByText(/Too many requests, or a quota limit/)).toBeTruthy();
+
+    show(probe({ error_code: "PROVIDER_UNREACHABLE", status: 402, message: "Endpoint returned HTTP 402." }));
+    expect(screen.getByText("The account is out of credit")).toBeTruthy();
+  });
+
+  // The backend has always tracked TIMEOUT separately from PROVIDER_UNREACHABLE
+  // while producing the identical "Cannot reach endpoint" sentence for both, so a
+  // 10-second hang and a mistyped hostname looked the same.
+  it("distinguishes a timeout from an unreachable endpoint", () => {
+    show(probe({ error_code: "TIMEOUT", status: 0, message: "Cannot reach endpoint: context deadline exceeded" }));
+    expect(screen.getByText("The connection to the provider timed out")).toBeTruthy();
+  });
+
+  it("treats a 401 behind PROVIDER_UNREACHABLE as a rejected key", () => {
+    // classifyHTTPModels only tags API_KEY_REJECTED when the models call is what
+    // failed, so the status has to be read too or the same rejection renders as a
+    // hard error on one path and a warning on the other.
+    show(probe({ error_code: "PROVIDER_UNREACHABLE", status: 401, message: "Endpoint returned HTTP 401." }));
+    expect(screen.getByText("The API key was rejected")).toBeTruthy();
+    expect(document.querySelector(".status-warning")).toBeTruthy();
+  });
+
+  it("keeps a message the code cannot improve on", () => {
+    // INVALID_REQUEST carries field-level detail written for the field it came
+    // from; a generic sentence would lose what the user needs.
+    show(probe({ error_code: "INVALID_REQUEST", status: 400, message: "Provider name is required" }));
+    expect(screen.getByText("Provider name is required")).toBeTruthy();
   });
 });

--- a/frontend/src/components/ConnectionStatus.tsx
+++ b/frontend/src/components/ConnectionStatus.tsx
@@ -1,5 +1,6 @@
 import { AlertCircle, CheckCircle2, LoaderCircle, Radio, ShieldAlert } from "lucide-react";
 
+import { failureCopyFor, isHTTPStatus } from "../backend/failureCopy";
 import { useI18n } from "../i18n";
 import type { AsyncState } from "../state/wizardReducer";
 import type { ProbeResponse } from "../types/api";
@@ -30,7 +31,14 @@ export function ConnectionStatus({ state, result }: { state: AsyncState; result:
       </div>
     );
   }
-  const rejected = result?.error_code === "API_KEY_REJECTED";
+  const rejected = result?.error_code === "API_KEY_REJECTED"
+    // 401/403 behind PROVIDER_UNREACHABLE is the same rejection: classifyHTTPModels
+    // only tags the code when the models call is what failed.
+    || (isHTTPStatus(result?.status) && (result?.status === 401 || result?.status === 403));
+  // Localised copy replaces the backend's English sentence where a code maps to
+  // any. Falls through to the raw message otherwise -- INVALID_REQUEST carries
+  // field-level detail a generic sentence would lose.
+  const copy = failureCopyFor(result?.error_code, result?.status, t);
   // A model OneAgent chose is named in the failure. A Provider's catalogue is
   // mostly image, video and audio generators, and one of those rejecting a chat
   // payload otherwise reads as a broken key -- a wrong verdict about the user's
@@ -41,10 +49,12 @@ export function ConnectionStatus({ state, result }: { state: AsyncState; result:
     <div className={`inline-status ${rejected ? "status-warning" : "status-error"}`} role="alert">
       {rejected ? <ShieldAlert size={17} /> : <AlertCircle size={17} />}
       <span>
-        {result?.message || t("连接失败")}
+        {copy?.message || result?.message || t("连接失败")}
+        {/* The auto-selected model explains the failure, so it wins over the
+            generic hint: a hint about the key is wrong when the model is at fault. */}
         {blamedModel ? (
           <small>{t("测试使用的模型 {model} 由 OneAgent 自动选择，可能不支持对话。可在上方自定义模型名称后重试", { model: blamedModel })}</small>
-        ) : null}
+        ) : copy?.hint ? <small>{copy.hint}</small> : null}
       </span>
     </div>
   );

--- a/frontend/src/components/DesktopAppSection.test.tsx
+++ b/frontend/src/components/DesktopAppSection.test.tsx
@@ -16,6 +16,7 @@ vi.mock("../backend/api", async () => {
   return {
     api: bridge,
     describeError: errors.describeError,
+    describeFailure: errors.describeFailure,
   };
 });
 

--- a/frontend/src/components/DesktopAppSection.tsx
+++ b/frontend/src/components/DesktopAppSection.tsx
@@ -1,7 +1,7 @@
 import { AppWindow, Download, Play, Plus, RefreshCw, SlidersHorizontal, TriangleAlert } from "lucide-react";
 import { useState } from "react";
 
-import { api, describeError } from "../backend/api";
+import { api, describeFailure } from "../backend/api";
 import { useI18n } from "../i18n";
 import { taskCanceller, taskKey, useTaskCenter, useTaskRoute } from "../state/TaskCenterContext";
 import type { DesktopAgentStatus, ProfileSummary } from "../types/api";
@@ -80,7 +80,7 @@ export function DesktopAppSection({ app: desktopApp, onChanged, onSetup, onConfi
       else setLocalNotice(message);
       await onChanged();
     } catch (error) {
-      const message = describeError(error, t("{name} 操作失败", { name: desktopApp.name })).message;
+      const message = describeFailure(error, t("{name} 操作失败", { name: desktopApp.name }), t).message;
       if (downloads) finishTask(installTaskID, { kind: "failure", message });
       else setLocalFailure(message);
     } finally {

--- a/frontend/src/components/MirrorSetting.test.tsx
+++ b/frontend/src/components/MirrorSetting.test.tsx
@@ -16,6 +16,7 @@ vi.mock("../backend/api", async () => {
       saveSettings: (settings: unknown) => saveSettings(settings),
     },
     describeError: errors.describeError,
+    describeFailure: errors.describeFailure,
   };
 });
 

--- a/frontend/src/components/MirrorSetting.tsx
+++ b/frontend/src/components/MirrorSetting.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 
-import { api, describeError } from "../backend/api";
+import { api, describeFailure } from "../backend/api";
 import { useI18n } from "../i18n";
 import { AdvancedSection } from "./AdvancedSection";
 
@@ -56,7 +56,7 @@ export function MirrorSetting({ label }: { label?: string }) {
       // Put the switch back so it never shows a preference that was not stored.
       setPreferMirror(previous);
       setFromRegion(wasFromRegion);
-      setFailure(describeError(error, t("无法保存下载设置")).message);
+      setFailure(describeFailure(error, t("无法保存下载设置"), t).message);
     }
   };
 

--- a/frontend/src/components/ProviderModelPicker.tsx
+++ b/frontend/src/components/ProviderModelPicker.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 
-import { api, describeError } from "../backend/api";
+import { api, describeFailure } from "../backend/api";
 import { useI18n } from "../i18n";
 import { ModelPicker } from "./ModelPicker";
 
@@ -34,7 +34,7 @@ export function ProviderModelPicker({ provider, protocol, hasKey, value, onChang
       if (cancelled) return;
       setModels([]);
       setSuccess(false);
-      setMessage(describeError(error, t("无法获取模型列表")).message);
+      setMessage(describeFailure(error, t("无法获取模型列表"), t).message);
     }).finally(() => {
       if (!cancelled) setLoading(false);
     });

--- a/frontend/src/components/RuntimePrompt.tsx
+++ b/frontend/src/components/RuntimePrompt.tsx
@@ -1,7 +1,7 @@
 import { Download, RefreshCw, TriangleAlert } from "lucide-react";
 import { useMemo, useState } from "react";
 
-import { api, describeError } from "../backend/api";
+import { api, describeFailure } from "../backend/api";
 import { useI18n } from "../i18n";
 import { taskCanceller, taskKey, useTaskCenter, useTaskRoute } from "../state/TaskCenterContext";
 import type { AgentStatus, RuntimeStatus } from "../types/api";
@@ -71,7 +71,7 @@ export function RuntimePrompt({ runtimes, missingRuntime, selectedAgentIds, agen
       finishTask(id, { kind: "success", message: t("安装完成") });
       await onInstalled();
     } catch (error) {
-      finishTask(id, { kind: "failure", message: describeError(error, t("运行时安装失败")).message });
+      finishTask(id, { kind: "failure", message: describeFailure(error, t("运行时安装失败"), t).message });
     } finally {
       setPending("");
     }

--- a/frontend/src/components/RuntimeSection.test.tsx
+++ b/frontend/src/components/RuntimeSection.test.tsx
@@ -22,6 +22,7 @@ vi.mock("../backend/api", async () => {
       saveSettings: (settings: unknown) => saveSettings(settings),
     },
     describeError: errors.describeError,
+    describeFailure: errors.describeFailure,
   };
 });
 

--- a/frontend/src/components/RuntimeSection.tsx
+++ b/frontend/src/components/RuntimeSection.tsx
@@ -1,7 +1,7 @@
 import { Download, RefreshCw } from "lucide-react";
 import { useState } from "react";
 
-import { api, describeError } from "../backend/api";
+import { api, describeFailure } from "../backend/api";
 import { useI18n } from "../i18n";
 import { taskCanceller, taskKey, useTaskCenter, useTaskRoute } from "../state/TaskCenterContext";
 import type { RuntimeStatus } from "../types/api";
@@ -78,7 +78,7 @@ export function RuntimeSection({ runtimes, onInstalled }: RuntimeSectionProps) {
       finishTask(id, { kind: "success", message: t("安装完成") });
       await onInstalled();
     } catch (error) {
-      finishTask(id, { kind: "failure", message: describeError(error, t("运行时安装失败")).message });
+      finishTask(id, { kind: "failure", message: describeFailure(error, t("运行时安装失败"), t).message });
     } finally {
       setPending("");
     }

--- a/frontend/src/components/TaskCenter.test.tsx
+++ b/frontend/src/components/TaskCenter.test.tsx
@@ -24,6 +24,7 @@ vi.mock("../backend/api", async () => {
       },
     },
     describeError: errors.describeError,
+    describeFailure: errors.describeFailure,
   };
 });
 

--- a/frontend/src/i18n.tsx
+++ b/frontend/src/i18n.tsx
@@ -133,6 +133,30 @@ const english = {
   "尚未测试连接": "Connection not tested",
   "正在验证端点和 Key": "Validating endpoint and key",
   "连接失败": "Connection failed",
+  // Localised copy for backend error codes (src/backend/failureCopy.ts). Every Go
+  // message reaching the UI is English; these replace it, keyed on error_code and
+  // the HTTP status rather than on the message text.
+  "API Key 被拒绝": "The API key was rejected",
+  "确认 Key 已完整粘贴，或到模型服务页面重新填写": "Check that the whole key was pasted, or re-enter it on the provider page",
+  "账户额度不足": "The account is out of credit",
+  "到模型服务官网充值或查看账户额度": "Top up or check the balance on the provider's website",
+  "请求过于频繁，或已达到额度上限": "Too many requests, or a quota limit was reached",
+  "稍等一会儿再试，或到模型服务官网查看额度": "Wait a moment and try again, or check the quota on the provider's website",
+  "端点不提供这个接口": "The endpoint does not serve this API",
+  "确认 Base URL 是否正确，以及这个模型服务是否支持所选 API 类型": "Check the base URL, and whether this provider supports the selected API type",
+  "模型服务暂时不可用（HTTP {status}）": "The provider is temporarily unavailable (HTTP {status})",
+  "这是对方服务的问题，稍后重试": "This is a problem on the provider's side; try again later",
+  "模型服务返回了 HTTP {status}": "The provider returned HTTP {status}",
+  "无法连接到模型服务": "Could not reach the provider",
+  "检查网络连接和 Base URL 是否正确": "Check the network connection and the base URL",
+  "连接模型服务超时": "The connection to the provider timed out",
+  "检查网络连接，或稍后重试": "Check the network connection, or try again later",
+  "这个模型不支持所选的 API 类型": "This model does not serve the selected API type",
+  "换一个支持该 API 类型的模型，或改用其他 API 类型": "Choose a model that serves this API type, or select a different API type",
+  // "无法获取模型列表" is already defined further down, as the fetch failure.
+  "这个端点不提供模型列表，可以直接手动输入模型 ID": "This endpoint does not publish a model list; enter a model ID manually",
+  "无法写入配置文件": "Could not write the configuration file",
+  "确认配置文件没有被其他程序占用，以及你对它有写入权限": "Check that the file is not held open by another program and that you can write to it",
   // Shown when the probe failed on a model OneAgent picked rather than one the
   // user typed. Without it, a video or image model rejecting a chat request reads
   // as a rejected API key.

--- a/frontend/src/pages/ActivationPage.tsx
+++ b/frontend/src/pages/ActivationPage.tsx
@@ -2,7 +2,7 @@ import { Download } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
-import { api, describeError, isCancellationError } from "../backend/api";
+import { api, describeFailure, isCancellationError } from "../backend/api";
 import { AgentProgressRow } from "../components/AgentProgressRow";
 import { DownloadProgress } from "../components/DownloadProgress";
 import { LogDisclosure } from "../components/LogDisclosure";
@@ -200,7 +200,7 @@ export function ActivationPage() {
         await refreshStatus();
       }
     } catch (error) {
-      const message = isCancellationError(error) ? t("已取消") : describeError(error, t("激活失败")).message;
+      const message = isCancellationError(error) ? t("已取消") : describeFailure(error, t("激活失败"), t).message;
       finishActivationTasks(startedTasks, [], false, message);
       dispatch({ type: "ACTIVATION_FAILED", message });
     }
@@ -249,7 +249,7 @@ export function ActivationPage() {
       finishTask(id, { kind: "success", message: t("安装完成") });
       await refreshStatus();
     } catch (error) {
-      finishTask(id, { kind: "failure", message: describeError(error, t("运行时安装失败")).message });
+      finishTask(id, { kind: "failure", message: describeFailure(error, t("运行时安装失败"), t).message });
     }
   };
 
@@ -282,7 +282,7 @@ export function ActivationPage() {
         await refreshStatus();
       }
     } catch (error) {
-      const message = isCancellationError(error) ? t("已取消") : describeError(error, t("重试失败")).message;
+      const message = isCancellationError(error) ? t("已取消") : describeFailure(error, t("重试失败"), t).message;
       finishActivationTasks(startedTasks, [], false, message);
       dispatch({ type: "ACTIVATION_FAILED", message });
     } finally {

--- a/frontend/src/pages/AgentProfilePage.tsx
+++ b/frontend/src/pages/AgentProfilePage.tsx
@@ -2,7 +2,7 @@ import { Check, Pencil, Plus, Save, X } from "lucide-react";
 import { useEffect, useMemo, useState, type FormEvent } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 
-import { api, describeError } from "../backend/api";
+import { api, describeFailure } from "../backend/api";
 import { PageScaffold } from "../components/PageScaffold";
 import { ProviderModelPicker } from "../components/ProviderModelPicker";
 import { ProviderSegment } from "../components/ProviderSegment";
@@ -131,7 +131,7 @@ export function AgentProfilePage() {
       setDraft(null);
       await refreshStatus();
     } catch (error) {
-      setFailure(describeError(error, t("无法保存配置模版")).message);
+      setFailure(describeFailure(error, t("无法保存配置模版"), t).message);
     } finally {
       setBusy(false);
     }
@@ -158,7 +158,7 @@ export function AgentProfilePage() {
       setApplied(t("{name} 已应用", { name: selected.label || selected.id }));
       await refreshStatus();
     } catch (error) {
-      setFailure(describeError(error, t("应用配置模版失败")).message);
+      setFailure(describeFailure(error, t("应用配置模版失败"), t).message);
     } finally {
       setBusy(false);
     }

--- a/frontend/src/pages/ModelSelectionPage.tsx
+++ b/frontend/src/pages/ModelSelectionPage.tsx
@@ -2,7 +2,7 @@ import { RefreshCw } from "lucide-react";
 import { useCallback, useEffect, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 
-import { api, describeError } from "../backend/api";
+import { api, describeFailure } from "../backend/api";
 import { ModelPicker } from "../components/ModelPicker";
 import { PageScaffold } from "../components/PageScaffold";
 import { useI18n } from "../i18n";
@@ -27,7 +27,7 @@ export function ModelSelectionPage() {
       });
       dispatch({ type: "MODELS_RESULT", result });
     } catch (error) {
-      dispatch({ type: "MODELS_FAILED", message: describeError(error, t("无法获取模型列表")).message });
+      dispatch({ type: "MODELS_FAILED", message: describeFailure(error, t("无法获取模型列表"), t).message });
     }
   }, [dispatch, state.provider, t]);
 

--- a/frontend/src/pages/ProfilesPage.tsx
+++ b/frontend/src/pages/ProfilesPage.tsx
@@ -2,7 +2,7 @@ import { KeyRound, Layers, Pencil, Play, Plus, Save, Trash2, X } from "lucide-re
 import { useState, type FormEvent } from "react";
 import { useNavigate } from "react-router-dom";
 
-import { api, describeError, isCancellationError } from "../backend/api";
+import { api, describeFailure, isCancellationError } from "../backend/api";
 import { PageScaffold } from "../components/PageScaffold";
 import { ProviderModelPicker } from "../components/ProviderModelPicker";
 import { ProviderSegment } from "../components/ProviderSegment";
@@ -147,7 +147,7 @@ export function ProfilesPage() {
       await refreshStatus();
       setEditor(null);
     } catch (error) {
-      setFailure(describeError(error, t("无法保存配置模版")).message);
+      setFailure(describeFailure(error, t("无法保存配置模版"), t).message);
     } finally {
       setBusy(false);
     }
@@ -185,7 +185,7 @@ export function ProfilesPage() {
           });
           finishTask(taskKey("install", agentId), { kind: "success", message: t("{name} 已应用", { name: profile.label || profile.id }) });
         } catch (error) {
-          finishTask(taskKey("install", agentId), { kind: "failure", message: describeError(error, t("应用配置模版失败")).message });
+          finishTask(taskKey("install", agentId), { kind: "failure", message: describeFailure(error, t("应用配置模版失败"), t).message });
           throw error;
         }
       }));
@@ -197,7 +197,7 @@ export function ProfilesPage() {
       navigate("/overview", { replace: true });
     } catch (error) {
       const cancelled = isCancellationError(error);
-      const message = cancelled ? "" : describeError(error, t("无法应用配置模版")).message;
+      const message = cancelled ? "" : describeFailure(error, t("无法应用配置模版"), t).message;
       if (!cancelled) setFailure(message);
     } finally {
       setApplying("");
@@ -226,7 +226,7 @@ export function ProfilesPage() {
       if (editor?.originalId === profile.id) setEditor(null);
       await refreshStatus();
     } catch (error) {
-      setFailure(describeError(error, t("无法删除配置模版")).message);
+      setFailure(describeFailure(error, t("无法删除配置模版"), t).message);
     } finally {
       setBusy(false);
     }

--- a/frontend/src/pages/ProviderKeyPage.tsx
+++ b/frontend/src/pages/ProviderKeyPage.tsx
@@ -2,7 +2,7 @@ import { ExternalLink, FlaskConical, Link2 } from "lucide-react";
 import { useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
-import { api, describeError } from "../backend/api";
+import { api, describeFailure } from "../backend/api";
 import { ConnectionStatus } from "../components/ConnectionStatus";
 import { PageScaffold } from "../components/PageScaffold";
 import { ProviderSegment } from "../components/ProviderSegment";
@@ -79,7 +79,7 @@ export function ProviderKeyPage() {
       await refreshStatus();
       navigate("/setup/model");
     } catch (error) {
-      setSaveFailure(describeError(error, t("无法保存模型服务")).message);
+      setSaveFailure(describeFailure(error, t("无法保存模型服务"), t).message);
     } finally {
       setSavingKey(false);
     }
@@ -100,7 +100,7 @@ export function ProviderKeyPage() {
       });
       dispatch({ type: "CONNECTION_RESULT", result });
     } catch (error) {
-      dispatch({ type: "CONNECTION_FAILED", failure: describeError(error, t("连接测试失败")) });
+      dispatch({ type: "CONNECTION_FAILED", failure: describeFailure(error, t("连接测试失败"), t) });
     }
   };
 
@@ -111,7 +111,7 @@ export function ProviderKeyPage() {
     try {
       await api.openRegister(state.provider, probeAgentIds);
     } catch (error) {
-      dispatch({ type: "CONNECTION_FAILED", failure: describeError(error, t("无法打开注册页面")) });
+      dispatch({ type: "CONNECTION_FAILED", failure: describeFailure(error, t("无法打开注册页面"), t) });
     }
   };
 

--- a/frontend/src/pages/ProvidersPage.tsx
+++ b/frontend/src/pages/ProvidersPage.tsx
@@ -2,7 +2,7 @@ import { ExternalLink, KeyRound, Pencil, Plus, Save, Trash2, X } from "lucide-re
 import { useEffect, useRef, useState, type FormEvent } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 
-import { api, describeError } from "../backend/api";
+import { api, describeFailure } from "../backend/api";
 import { PageScaffold } from "../components/PageScaffold";
 import { SecureKeyField } from "../components/SecureKeyField";
 import { useI18n } from "../i18n";
@@ -77,7 +77,7 @@ export function ProvidersPage({ create = false }: { create?: boolean }) {
       setEditor(await api.getProvider(providerId));
       setCreating(false);
     } catch (error) {
-      setFailure(describeError(error, t("无法读取模型服务")).message);
+      setFailure(describeFailure(error, t("无法读取模型服务"), t).message);
     } finally {
       setBusy(false);
     }
@@ -129,7 +129,7 @@ export function ProvidersPage({ create = false }: { create?: boolean }) {
       if (create) navigate(returnTo);
       else setEditor(null);
     } catch (error) {
-      setFailure(describeError(error, t("无法保存模型服务")).message);
+      setFailure(describeFailure(error, t("无法保存模型服务"), t).message);
     } finally {
       setBusy(false);
     }
@@ -157,7 +157,7 @@ export function ProvidersPage({ create = false }: { create?: boolean }) {
       if (editor?.id === providerId) setEditor(null);
       await refreshStatus();
     } catch (error) {
-      setFailure(describeError(error, t("无法删除模型服务")).message);
+      setFailure(describeFailure(error, t("无法删除模型服务"), t).message);
     } finally {
       setBusy(false);
     }

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -2,7 +2,7 @@ import { ChevronRight, Import, Languages, RefreshCw } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
-import { api, describeError } from "../backend/api";
+import { api, describeFailure } from "../backend/api";
 import { OTA_PROGRESS_TARGET } from "../backend/wails";
 import { PageScaffold } from "../components/PageScaffold";
 import { SelectField } from "../components/SelectField";
@@ -29,7 +29,7 @@ export function SettingsPage() {
       setLatestVersion(latest);
       setUpdateMessage(latest ? t("发现新版本 {version}", { version: latest }) : t("当前已是最新版本"));
     } catch (error) {
-      setUpdateMessage(describeError(error, t("检查更新失败")).message);
+      setUpdateMessage(describeFailure(error, t("检查更新失败"), t).message);
     } finally {
       setChecking(false);
     }
@@ -47,7 +47,7 @@ export function SettingsPage() {
       taskCenter.setTaskAction(taskID, { label: t("重启并更新"), run: () => api.restartUpdate() });
       setUpdateMessage(t("更新已下载"));
     } catch (error) {
-      taskCenter.finishTask(taskID, { kind: "failure", message: describeError(error, t("更新失败")).message });
+      taskCenter.finishTask(taskID, { kind: "failure", message: describeFailure(error, t("更新失败"), t).message });
     }
   };
 

--- a/frontend/src/pages/TransferPage.tsx
+++ b/frontend/src/pages/TransferPage.tsx
@@ -3,7 +3,7 @@ import { CheckCheck, Eye, EyeOff, KeyRound, Upload } from "lucide-react";
 import { useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
-import { api, describeError } from "../backend/api";
+import { api, describeFailure } from "../backend/api";
 import { PageScaffold } from "../components/PageScaffold";
 import { useI18n } from "../i18n";
 import { byProviderCreatedAt } from "../state/ranking";
@@ -69,7 +69,7 @@ export function TransferPage() {
     if (error instanceof TransferFormatError || error instanceof SyntaxError) {
       return t("文件格式无效，请确认这是 OneAgent 导出的文件");
     }
-    return describeError(error, fallback).message;
+    return describeFailure(error, fallback, t).message;
   };
 
   const profiles = status?.profiles ?? [];

--- a/frontend/src/state/WizardContext.tsx
+++ b/frontend/src/state/WizardContext.tsx
@@ -11,7 +11,7 @@ import {
   useRef,
 } from "react";
 
-import { api, describeError } from "../backend/api";
+import { api, describeFailure } from "../backend/api";
 import { useI18n } from "../i18n";
 import { initialWizardState, wizardReducer, type WizardAction, type WizardState } from "./wizardReducer";
 
@@ -50,7 +50,7 @@ export function WizardProvider({ children }: PropsWithChildren) {
     try {
       dispatch({ type: "STATUS_LOADED", status: await api.status() });
     } catch (error) {
-      dispatch({ type: "STATUS_FAILED", message: describeError(error, t("无法读取本机状态")).message });
+      dispatch({ type: "STATUS_FAILED", message: describeFailure(error, t("无法读取本机状态"), t).message });
     }
   }, [t]);
 


### PR DESCRIPTION
Fixes #114.

`describeError` (`frontend/src/backend/errors.ts:27`) returned `error.message` verbatim, and `normalizeWailsError` wraps every backend failure in `OneAgentApiError` — so the Chinese `t()` fallbacks the 19 call sites carefully passed almost never fired. They looked like localisation and were dead code. Users read English inside a Chinese UI, including on success: a passing probe reported `OpenAI Chat Completions connection test passed.`

The ten codes in `internal/errors/errors.go` already exist for exactly this. They were driving styling and the retry flag but were never used to choose copy, and there was no error-code-to-message table anywhere in the frontend.

## The mapping

`failureCopy.ts` keys on `error_code` **plus** the HTTP status a probe carries.

Not on message text — that breaks the moment Go rewords anything, and the codes exist precisely so the UI doesn't have to read prose.

The status is load-bearing because one code is too coarse. 402, 429 and 503 all arrive as `PROVIDER_UNREACHABLE`, and `Endpoint returned HTTP 429.` never told the user whether their account or their configuration was at fault — these are the two failures a new user with a fresh key hits most. Separately, `TIMEOUT` and `PROVIDER_UNREACHABLE` were already distinct codes producing one identical `Cannot reach endpoint` sentence, so a hung request and a mistyped hostname were indistinguishable.

Every mapped code also carries a `hint`. A message that only restates the problem leaves the user where they started.

## What is dropped and what is kept

The English message is replaced, not appended. It is written for a maintainer reading a log — `Cannot reach endpoint: Post "https://...": dial tcp: lookup api.example.com: no such host` — and showing both halves would leave the user deciding which to trust.

Where a code adds nothing, the raw message stays. `INVALID_REQUEST` is field-level validation text (`Provider name is required`); replacing it with a generic sentence would lose what the user needs.

## Shape

`describeFailure` is additive rather than a replacement for `describeError`: it needs a `Translate`, which only components have, and some callers want only the code or the retryable flag. All 19 user-facing call sites moved over; `describeError` keeps its two non-display uses.

`ConnectionStatus` also now reads a 401/403 behind `PROVIDER_UNREACHABLE` as a rejected key. `classifyHTTPModels` only tags `API_KEY_REJECTED` when the models call is what failed, so the same rejection rendered as a hard error on one path and a warning on the other.

## Verification

- `pnpm run test` — 299 passed (39 files), 14 new across `failureCopy.test.ts` and `errors.test.ts`
- Reverted both paths independently: neutering `describeFailure` **plus** `ConnectionStatus`'s direct `failureCopyFor` call fails 9 tests. Worth noting — reverting only `describeFailure` failed nothing, which is how I found that the probe path needed its own coverage rather than assuming one test covered both.
- `pnpm run build`, `pnpm run test:e2e` (6 passed), `go test ./...`, `scripts/check-docs.py`
- No duplicate i18n keys (420 total)

Remaining on #114: the three untranslated Chinese literals in `settingsTransfer.ts` were already fixed in #123, and `Cannot reach endpoint` still embeds the raw Go error in the *backend* message — this change stops it reaching the user, but trimming it at the source is a separate Go-side edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)