### PR TITLE
fix: stop the API key field showing a secret it has discarded

### DIFF
--- a/frontend/src/components/SecureKeyField.test.tsx
+++ b/frontend/src/components/SecureKeyField.test.tsx
@@ -31,4 +31,36 @@ describe("SecureKeyField", () => {
     page.rerender(<SecureKeyField value="sk-persisted" onChange={() => {}} />);
     expect(screen.getByLabelText("API Key")).toHaveValue("sk-persisted");
   });
+
+  // The wizard passes a constant value="", so the effect on `value` cannot see a
+  // reset. Without resetKey a key typed for one Provider stayed on screen after
+  // switching to another, while the ref behind it had been cleared -- the field
+  // displayed a secret that was no longer going to be saved.
+  it("clears a typed key when the reset token changes", async () => {
+    const page = render(<SecureKeyField value="" onChange={() => {}} resetKey="ppio" />);
+    const input = screen.getByLabelText("API Key");
+    await userEvent.type(input, "sk-for-ppio");
+    expect(input).toHaveValue("sk-for-ppio");
+
+    page.rerender(<SecureKeyField value="" onChange={() => {}} resetKey="novita" />);
+    expect(screen.getByLabelText("API Key")).toHaveValue("");
+  });
+
+  it("hides a revealed key on reset", async () => {
+    // Leaving it revealed would show the next Provider's field unmasked.
+    const page = render(<SecureKeyField value="" onChange={() => {}} resetKey="ppio" />);
+    await userEvent.type(screen.getByLabelText("API Key"), "sk-for-ppio");
+    await userEvent.click(screen.getByRole("button", { name: "显示密钥" }));
+    expect(screen.getByLabelText("API Key")).toHaveAttribute("type", "text");
+
+    page.rerender(<SecureKeyField value="" onChange={() => {}} resetKey="novita" />);
+    expect(screen.getByLabelText("API Key")).toHaveAttribute("type", "password");
+  });
+
+  it("keeps a key that was loaded on mount", () => {
+    // The reset effect must skip its own first run: the Provider editor mounts
+    // this with the saved key already in `value`, and clearing would discard it.
+    render(<SecureKeyField value="sk-saved" onChange={() => {}} resetKey="ppio" />);
+    expect(screen.getByLabelText("API Key")).toHaveValue("sk-saved");
+  });
 });

--- a/frontend/src/components/SecureKeyField.tsx
+++ b/frontend/src/components/SecureKeyField.tsx
@@ -1,15 +1,35 @@
 import { Eye, EyeOff, KeyRound } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { useI18n } from "../i18n";
 
-export function SecureKeyField({ value, onChange }: { value: string; onChange: (value: string) => void }) {
+export function SecureKeyField({ value, onChange, resetKey }: {
+  value: string;
+  onChange: (value: string) => void;
+  /**
+   * Clears the field when it changes. The wizard passes a constant `value=""`,
+   * so the effect below cannot see a reset: the prop it depends on never
+   * changes. That left a key the user typed for one Provider still displayed
+   * after switching to another, while the ref behind it had been cleared -- the
+   * field showed a secret that was no longer going to be saved.
+   */
+  resetKey?: string;
+}) {
   const { t } = useI18n();
   const [visible, setVisible] = useState(false);
   // The wizard keeps the key in a ref, not in state, so the parent gives no
   // re-render guarantee per keystroke; echo must come from local state.
   const [draft, setDraft] = useState(value);
   useEffect(() => setDraft(value), [value]);
+  // Skips its own first run: on mount `draft` is already the incoming value, and
+  // clearing here would discard the saved key the Provider editor loads.
+  const seenReset = useRef(resetKey);
+  useEffect(() => {
+    if (seenReset.current === resetKey) return;
+    seenReset.current = resetKey;
+    setDraft("");
+    setVisible(false);
+  }, [resetKey]);
   return (
     <div className="field-stack">
       <label htmlFor="api-key">API Key</label>

--- a/frontend/src/pages/ProviderKeyPage.test.tsx
+++ b/frontend/src/pages/ProviderKeyPage.test.tsx
@@ -107,6 +107,37 @@ describe("ProviderKeyPage", () => {
     expect(screen.getByRole("button", { name: "继续选择模型" })).not.toBeDisabled();
   });
 
+  // Continuing used to return early on providerHasKey alone, before ever reading
+  // the ref -- so a key typed in this session was dropped with no save call and no
+  // message, while the page advanced as though it had worked.
+  it("saves a key typed in this session even when one is already stored", async () => {
+    state = { ...initialWizardState, status, statusState: "success", hasApiKey: true };
+    keyRef.current = "sk-rotated";
+    const save = vi.spyOn(api, "saveProvider").mockResolvedValue({
+      entry: {
+        id: "ppio", name: "PPIO", home: "", base_url: "https://api.ppio.com/openai",
+        anthropic_base_url: "", api_key: "sk-rotated", built_in: true,
+      },
+      reapplied: null,
+      failures: null,
+    });
+    render(<MemoryRouter><ProviderKeyPage /></MemoryRouter>);
+
+    fireEvent.click(screen.getByRole("button", { name: "继续选择模型" }));
+    await waitFor(() => expect(save).toHaveBeenCalledWith(expect.objectContaining({ api_key: "sk-rotated" })));
+  });
+
+  it("continues without a save when nothing was typed", async () => {
+    state = { ...initialWizardState, status, statusState: "success", hasApiKey: true };
+    keyRef.current = "";
+    const save = vi.spyOn(api, "saveProvider");
+    render(<MemoryRouter><ProviderKeyPage /></MemoryRouter>);
+
+    fireEvent.click(screen.getByRole("button", { name: "继续选择模型" }));
+    await waitFor(() => expect(screen.getByRole("button", { name: "继续选择模型" })).not.toBeDisabled());
+    expect(save).not.toHaveBeenCalled();
+  });
+
   it("offers the key button for a Provider with only a key page", () => {
     // No home URL, so the pre-change guard would have hidden the button. The
     // backend picks the URL; the page only decides whether to offer the action.

--- a/frontend/src/pages/ProviderKeyPage.tsx
+++ b/frontend/src/pages/ProviderKeyPage.tsx
@@ -58,7 +58,11 @@ export function ProviderKeyPage() {
   };
 
   const continueSetup = async () => {
-    if (providerHasKey) {
+    // Only when there is nothing to save. Returning early on providerHasKey alone
+    // discarded a key typed in this session -- the field is rendered when no key
+    // is saved yet, so a save that lands mid-visit (a probe, another tab) turned
+    // the user's input into a silent no-op.
+    if (providerHasKey && !secret.keyRef.current) {
       navigate("/setup/model");
       return;
     }
@@ -137,7 +141,7 @@ export function ProviderKeyPage() {
 
       <div className="provider-form">
         {!providerHasKey && builtInProvider ? (
-          <SecureKeyField value="" onChange={secret.setApiKey} />
+          <SecureKeyField value="" onChange={secret.setApiKey} resetKey={state.provider} />
         ) : !providerHasKey ? (
           <div className="notice notice-warning">
             <span>{t("这个模型服务还没有 Key，先到模型服务页面填写")}</span>


### PR DESCRIPTION
Fixes #119. The issue described two paths where a typed key is dropped; the first turned out to be worse than reported.

## The field displayed a key it had already thrown away

`ProviderKeyPage` renders `SecureKeyField` with a hardcoded `value=""` (`:140`), and the effect that syncs the draft depends on that prop — which never changes. So `changeProvider` → `clearApiKey()` emptied `keyRef` and flipped `hasApiKey` to false, but the input went on displaying what the user typed for the *previous* Provider.

I verified this with a throwaway probe rather than trusting the read: after a re-render with `value=""`, the input still held `sk-typed`.

The user-visible state is worse than "the key is silently discarded" (what #119 says). The field shows a plausible-looking key, `canContinue` is false because `hasApiKey` was cleared, and the Continue button is disabled with nothing on screen explaining why. The screen contradicts itself.

`resetKey` drives the clear instead. It skips its own first run — the Provider editor mounts this component with a saved key already in `value`, and clearing there would discard it. Revealed state resets too, so the next Provider's field does not open unmasked.

## The second path

`continueSetup` returned early on `providerHasKey` alone, before reading the ref, so a key typed in this session was dropped with no save call and no message while the page advanced as though it had worked. Now it checks both.

## Verification

- 304 passed (39 files), 5 new
- Reverted each fix independently: dropping the reset effect fails 2, restoring the early return fails 1
- `pnpm run build`, `pnpm run test:e2e` (6 passed)

The `SaveKey` no-op noted in #119 is left alone — `Store.SaveKey` returning nil for an empty key is correct for its callers; the issue there was only that this page could reach it with nothing to save, which is now fixed upstream of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)