### PR TITLE
fix: give a partly successful activation a way forward

### DIFF
--- a/frontend/src/pages/ActivationPage.test.tsx
+++ b/frontend/src/pages/ActivationPage.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { initialWizardState, type WizardState } from "../state/wizardReducer";
+import type { AgentInstallResult, StatusResponse } from "../types/api";
+import { ActivationPage } from "./ActivationPage";
+
+// No I18nProvider, so translate() returns the Chinese keys unchanged.
+let state: WizardState;
+const refreshStatus = vi.fn(async () => {});
+
+vi.mock("../state/WizardContext", () => ({
+  useWizard: () => ({ state, dispatch: vi.fn(), refreshStatus }),
+}));
+
+vi.mock("../state/TaskCenterContext", async (importOriginal) => ({
+  ...await importOriginal<typeof import("../state/TaskCenterContext")>(),
+  useTaskCenter: () => ({
+    tasks: [], startTask: vi.fn(() => true), finishTask: vi.fn(),
+    setTaskCanceller: vi.fn(), taskFor: vi.fn(() => undefined),
+  }),
+  useTaskRoute: () => "/setup/activation",
+}));
+
+const status = {
+  providers: {}, catalog: [
+    { id: "codex", name: "Codex" },
+    { id: "aider", name: "Aider" },
+  ],
+  capabilities: { canInstall: {}, missingRuntime: {}, supportedAgentIds: [] },
+  runtimes: [], agents: {}, profiles: [],
+} as unknown as StatusResponse;
+
+const result = (agent: string, over: Partial<AgentInstallResult> = {}): AgentInstallResult =>
+  ({ agent, status: "configured", retryable: false, ...over });
+
+function show(results: AgentInstallResult[], next = "") {
+  state = {
+    ...initialWizardState,
+    status,
+    statusState: "success",
+    selectedAgentIds: ["codex", "aider"],
+    // Not "success": a run with a failed row lands on the error state, which is
+    // exactly the case that had no way forward.
+    activationState: "error",
+    activationRequested: true,
+    activationResults: results,
+    activationNext: next,
+  };
+  render(<MemoryRouter><ActivationPage /></MemoryRouter>);
+}
+
+describe("ActivationPage partial results", () => {
+  beforeEach(() => refreshStatus.mockClear());
+
+  // One Agent configured and another failed unretryably left no forward button
+  // and no retry button -- the only exit was back to the review step, even though
+  // the configured Agent is usable.
+  it("offers the overview when at least one Agent was configured", () => {
+    show([result("codex"), result("aider", { status: "failed", retryable: false })]);
+    expect(screen.getByRole("button", { name: "进入总览" })).toBeTruthy();
+  });
+
+  it("offers no way forward when every Agent failed", () => {
+    // Nothing was configured, so the overview would show no new state; the back
+    // link remains the honest exit.
+    show([
+      result("codex", { status: "failed", retryable: false }),
+      result("aider", { status: "failed", retryable: false }),
+    ]);
+    expect(screen.queryByRole("button", { name: "进入总览" })).toBeNull();
+  });
+
+  // The commands belong to the Agents that succeeded. Hiding them because a
+  // different Agent failed withheld the next step for work that was done -- and
+  // for OpenClaw that command is the one that makes it usable at all.
+  it("still shows the next-step command on a partial run", () => {
+    show([result("codex"), result("aider", { status: "failed", retryable: false })], "openclaw onboard");
+    expect(screen.getByText("openclaw onboard")).toBeTruthy();
+  });
+
+  it("hides the next-step command when nothing succeeded", () => {
+    show([result("codex", { status: "failed", retryable: false })], "openclaw onboard");
+    expect(screen.queryByText("openclaw onboard")).toBeNull();
+  });
+});

--- a/frontend/src/pages/ActivationPage.tsx
+++ b/frontend/src/pages/ActivationPage.tsx
@@ -196,7 +196,11 @@ export function ActivationPage() {
         replaceAgents: state.selectedAgentIds,
       });
       finishActivationTasks(startedTasks, response.results, response.ok, t("激活失败"));
-      if (response.ok) {
+      // Refreshed whenever any Agent got as far as being configured, not only on a
+      // wholly successful run. An Agent that really did install inside a run that
+      // was not `ok` stayed reported as missing until some later refresh, so the
+      // overview showed the wrong thing with no explanation.
+      if (response.ok || response.results.some((result) => result.status !== "failed" && result.status !== "skipped")) {
         await refreshStatus();
       }
     } catch (error) {
@@ -277,8 +281,10 @@ export function ActivationPage() {
         replaceAgents: [agentId],
       });
       finishActivationTasks(startedTasks, response.results, response.ok, t("重试失败"));
-      const otherFailures = state.activationResults.filter((item) => item.agent !== agentId && item.status === "failed");
-      if (response.ok && !otherFailures.length) {
+      // Unconditional, for the same reason as the first run: a successful retry
+      // changes what is on disk whether or not other rows are still failing, and
+      // suppressing the refresh left the overview describing the old state.
+      if (response.ok) {
         await refreshStatus();
       }
     } catch (error) {
@@ -320,6 +326,13 @@ export function ActivationPage() {
   const activationCancelled = state.selectedAgentIds.some((agentId) => taskFor(taskKey("install", taskTarget(agentId)))?.state === "cancelled");
   const activationLoading = state.activationState === "loading" && !activationCancelled;
   const allDone = state.activationState === "success" && !activationCancelled;
+  // A run where one Agent succeeded and another failed unretryably had no forward
+  // button and no retry button: the only exit was back to the review step, even
+  // though the Agent that succeeded is configured and usable. Any finished row is
+  // enough to offer the overview.
+  const anyConfigured = !activationLoading && state.activationResults.some(
+    (result) => result.status !== "failed" && result.status !== "skipped",
+  );
   const runtimeDownloadActive = runtimeDownloads.some(({ id }) => taskFor(taskKey("download", id))?.state === "running")
     && (state.activationState === "loading" || retrying !== null);
   return (
@@ -328,8 +341,8 @@ export function ActivationPage() {
       description={activationLoading ? t("安装请求同步执行，完成后将显示每个 Agent 的最终状态") : activationCancelled ? t("已取消") : t("每个 Agent 的结果彼此独立，失败项可以单独重试")}
       stepper
       onBack={activationLoading ? undefined : () => navigate("/setup/review")}
-      primaryLabel={allDone ? t("进入总览") : undefined}
-      onPrimary={allDone ? () => navigate("/overview") : undefined}
+      primaryLabel={allDone || anyConfigured ? t("进入总览") : undefined}
+      onPrimary={allDone || anyConfigured ? () => navigate("/overview") : undefined}
       footerNote={activationLoading ? t("请保持此窗口打开") : undefined}
     >
       {runtimeDownloadActive && runtimeDownloads.length ? (
@@ -375,8 +388,10 @@ export function ActivationPage() {
       </div>
       {state.activationProbe && !state.activationProbe.ok ? <div className="notice notice-warning">{state.activationProbe.message}</div> : null}
       {/* The launch commands belong to the moment installation finishes, not to
-          the overview a user opens every day. */}
-      {allDone && state.activationNext ? (
+          the overview a user opens every day. Shown for a partial run too: the
+          commands belong to the Agents that succeeded, and hiding them because a
+          different Agent failed withheld the next step for work that was done. */}
+      {(allDone || anyConfigured) && state.activationNext ? (
         <section className="next-command-section">
           <h2>{t("下一步命令")}</h2>
           <pre>{state.activationNext}</pre>


### PR DESCRIPTION
Fixes #118.

A run where one Agent was configured and another failed unretryably had **no forward button and no retry button**. The only exit was the back link to the review step — even though the configured Agent is on disk and usable. The page's own description promised `失败项可以单独重试`, which was the one thing not on offer.

Any finished row now offers the overview. A run where nothing succeeded still does not, because there is no new state to go look at.

## The stale overview

`refreshStatus` was skipped unless the whole run was `ok` (`:199`), and the retry path additionally required every *other* row to be clean (`:251`). So an Agent that really did install inside a partly failed run stayed reported as missing until some later refresh — the overview described the wrong state, with no explanation.

It now refreshes whenever any row reached a non-failed status, and a successful retry refreshes on its own merit.

## The next-step command

Gated on `allDone` too, so a failure elsewhere withheld the follow-up command for the Agent that succeeded. For OpenClaw that command (`openclaw onboard`) is what makes it usable at all — see #117, which this partly relieves but does not close: the command is still a bare `<pre>` with no explanation that pairing is mandatory.

## Verification

- 303 passed (40 files), 4 new in a new `ActivationPage.test.tsx`
- Reverted the gating: 2 of the 4 fail
- `pnpm run build`, `pnpm run test:e2e` (6 passed)

Note the test drives `activationState: "error"`, not `"success"` — a run with a failed row lands on the error state, which is precisely the case that had no way out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)