### PR TITLE
fix: stop a failed download pointing at a setting that cannot help

### DIFF
--- a/frontend/src/backend/failureCopy.test.ts
+++ b/frontend/src/backend/failureCopy.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { sourceTranslate } from "../i18n";
-import { failureCopyFor, isHTTPStatus } from "./failureCopy";
+import { failureCopyFor, isHTTPStatus, runtimeDownloadHint } from "./failureCopy";
 
 // sourceTranslate returns the Chinese keys, which is what the source language is.
 const t = sourceTranslate;
@@ -80,5 +80,16 @@ describe("failureCopyFor", () => {
       const copy = failureCopyFor("PROVIDER_UNREACHABLE", status, t);
       expect(copy?.message ?? "").not.toMatch(/dial tcp|Post "|no such host|context deadline/);
     }
+  });
+});
+
+describe("runtimeDownloadHint", () => {
+  // Counter-intuitive on purpose: downloadSources always tries both hosts and the
+  // preference only reorders them, so by the time a download fails the mirror has
+  // been attempted and the setting a user would reach for cannot change anything.
+  it("says switching the download source will not help", () => {
+    const hint = runtimeDownloadHint(t);
+    expect(hint).toContain("都已尝试过");
+    expect(hint).toContain("不会改变结果");
   });
 });

--- a/frontend/src/backend/failureCopy.ts
+++ b/frontend/src/backend/failureCopy.ts
@@ -95,3 +95,20 @@ export function failureCopyFor(code: string | null | undefined, status: number |
       return null;
   }
 }
+
+/**
+ * Hint for a failed runtime download.
+ *
+ * Separate from failureCopyFor because AGENT_INSTALL_FAILED covers npm exits and
+ * installer launches too, and this advice only holds for the download path -- the
+ * caller knows which it is, the code does not.
+ *
+ * What it has to say is counter-intuitive: `downloadSources`
+ * (internal/install/bootstrap.go:364-372) always tries both the official source
+ * and the mirror, and the preference only reorders them. So by the time this
+ * message appears both hosts have already failed, and toggling the mirror setting
+ * -- the one control a user would go looking for -- cannot change the outcome.
+ * Saying nothing left them to find that out by trying.
+ */
+export const runtimeDownloadHint = (t: Translate): string =>
+  t("官方源和镜像都已尝试过，切换下载源不会改变结果。请检查网络连接后重试");

--- a/frontend/src/components/RuntimePrompt.test.tsx
+++ b/frontend/src/components/RuntimePrompt.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+// No I18nProvider, so translate() returns the Chinese keys unchanged.
+import { RuntimePrompt } from "./RuntimePrompt";
+import type { RuntimeStatus } from "../types/api";
+
+vi.mock("../state/TaskCenterContext", async (importOriginal) => ({
+  ...await importOriginal<typeof import("../state/TaskCenterContext")>(),
+  useTaskCenter: () => ({
+    startTask: vi.fn(() => true), finishTask: vi.fn(), setTaskCanceller: vi.fn(),
+    // DownloadProgress renders inside this component and reads both.
+    progress: {}, running: false,
+    // A failed download for the runtime below.
+    taskFor: (id: string) => id === "download:node"
+      ? { state: "failure", message: "无法连接到模型服务" } : undefined,
+  }),
+  useTaskRoute: () => "/setup/agents",
+}));
+
+const node = { id: "node", name: "Node.js", installed: false, supported: true, lockedVersion: "24.16.0" } as unknown as RuntimeStatus;
+
+describe("RuntimePrompt download failure", () => {
+  it("says the mirror was already tried", () => {
+    render(<RuntimePrompt runtimes={[node]} missingRuntime={{ codex: "node" }} selectedAgentIds={["codex"]} agents={{}} onInstalled={vi.fn()} />);
+    expect(screen.getByText(/都已尝试过/)).toBeTruthy();
+    // notice notice-error, matching RuntimeSection rather than the bare span it was.
+    expect(document.querySelector(".notice-error")).toBeTruthy();
+  });
+});

--- a/frontend/src/components/RuntimePrompt.tsx
+++ b/frontend/src/components/RuntimePrompt.tsx
@@ -2,6 +2,7 @@ import { Download, RefreshCw, TriangleAlert } from "lucide-react";
 import { useMemo, useState } from "react";
 
 import { api, describeFailure } from "../backend/api";
+import { runtimeDownloadHint } from "../backend/failureCopy";
 import { useI18n } from "../i18n";
 import { taskCanceller, taskKey, useTaskCenter, useTaskRoute } from "../state/TaskCenterContext";
 import type { AgentStatus, RuntimeStatus } from "../types/api";
@@ -102,7 +103,14 @@ export function RuntimePrompt({ runtimes, missingRuntime, selectedAgentIds, agen
           ))}
         </div>
         {required.map((runtime) => <DownloadProgress key={runtime.id} target={runtime.id} />)}
-        {failure ? <span className="runtime-prompt-error">{failure}</span> : null}
+        {/* notice notice-error, matching RuntimeSection: the same class of failure
+            was a bare <span> here and a notice block there. */}
+        {failure ? (
+          <div className="notice notice-error">
+            <span>{failure}</span>
+            <small>{runtimeDownloadHint(t)}</small>
+          </div>
+        ) : null}
       </div>
     </div>
   );

--- a/frontend/src/components/RuntimeSection.tsx
+++ b/frontend/src/components/RuntimeSection.tsx
@@ -2,6 +2,7 @@ import { Download, RefreshCw } from "lucide-react";
 import { useState } from "react";
 
 import { api, describeFailure } from "../backend/api";
+import { runtimeDownloadHint } from "../backend/failureCopy";
 import { useI18n } from "../i18n";
 import { taskCanceller, taskKey, useTaskCenter, useTaskRoute } from "../state/TaskCenterContext";
 import type { RuntimeStatus } from "../types/api";
@@ -89,7 +90,12 @@ export function RuntimeSection({ runtimes, onInstalled }: RuntimeSectionProps) {
     : t("Agent 安装所需的运行时都已就绪");
   const body = (
     <>
-      {failure ? <div className="notice notice-error">{failure}</div> : null}
+      {failure ? (
+        <div className="notice notice-error">
+          <span>{failure}</span>
+          <small>{runtimeDownloadHint(t)}</small>
+        </div>
+      ) : null}
       <div className="runtime-list">
         {supported.map((runtime) => (
           <div className="runtime-row" key={runtime.id}>

--- a/frontend/src/i18n.tsx
+++ b/frontend/src/i18n.tsx
@@ -334,6 +334,9 @@ const english = {
   "运行时会安装到 {dir}，并写入登录 PATH，不需要管理员权限": "Runtimes install into {dir} and are added to your login PATH. No administrator rights needed",
   "运行时会安装到 OneAgent 的托管目录，并写入登录 PATH，不需要管理员权限": "Runtimes install into OneAgent's managed directory and are added to your login PATH. No administrator rights needed",
   "运行时下载": "Runtime downloads",
+  // Both hosts are always tried (downloadSources, bootstrap.go:364-372), so by the
+  // time a download fails the mirror has been attempted and the setting cannot help.
+  "官方源和镜像都已尝试过，切换下载源不会改变结果。请检查网络连接后重试": "Both the official source and the mirror were tried, so changing the download source will not help. Check the network connection and retry",
   "下载源": "Download source",
   "Agent 安装源": "Agent install source",
   "默认使用官方源。国内网络较慢时可以改用镜像": "Uses the official source by default. Switch to a mirror if it is slow from your network",

--- a/frontend/src/styles/base.css
+++ b/frontend/src/styles/base.css
@@ -329,6 +329,23 @@ button:active:not(:disabled) {
   border-color: rgba(215, 0, 21, 0.2);
 }
 
+/* A notice carrying a hint below its message stacks instead of laying the two out
+   side by side, which the default row direction would do. Scoped to :has(small) so
+   every single-line notice keeps the centred row it was built for. */
+.notice:has(> small) {
+  align-items: flex-start;
+  flex-direction: column;
+  gap: 4px;
+}
+
+/* Inherits neither the colour nor the weight of the message above it: the hint is
+   the next step, not a second alarm. */
+.notice > small {
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,


### PR DESCRIPTION
Fixes the actionable half of #116.

The mirror toggle is what a user reaches for when a runtime download fails — and it is the one thing that cannot change the outcome. `downloadSources` (`internal/install/bootstrap.go:364-372`) always returns **both** the official source and the mirror; the preference only reorders them. So by the time `Cannot download Node.js 24.16.0` appears, both hosts have already been tried and failed.

Nothing said so. The user's path was: hunt for the collapsed advanced setting, toggle it, retry, fail again.

Download failures now carry that line explicitly. It is a separate export rather than another `failureCopyFor` branch because `AGENT_INSTALL_FAILED` also covers npm exit codes and installer launches, where the advice would be wrong — the caller knows which path it is on, the error code does not.

## Also fixes the inconsistent treatment

`RuntimePrompt` rendered this class of failure as a bare `<span class="runtime-prompt-error">` while `RuntimeSection` used `notice notice-error` for the identical thing (the second half of #116, and #121's item 9). Both are notices now.

`.notice` is a horizontal flex, so a notice carrying a hint needed a stacking rule. Scoped to `:has(> small)` so the other 12 notices keep the centred row they were built for.

I verified this in the browser rather than trusting the selector:

- two-line notice → `column`, `flex-start`, `gap: 4px`
- single-line notice → unchanged `row`, `center`
- hint → `12px`, `rgb(110,110,115)` — secondary grey, not inheriting the red alarm colour
- `MirrorSetting`'s `<small>` (nested inside a `<span>`) → correctly **not** matched, stays `row`

## What #116 keeps open

The collapsed-by-default placement of the setting, and the fact that Aider's uv path is unaffected by the mirror with no in-app lever for a blocked network. Those are placement and coverage decisions rather than a wrong message.

## Verification

- 310 passed (41 files), 2 new
- Reverting the notice change fails the new `RuntimePrompt` test
- `pnpm run build`, `pnpm run test:e2e` (6 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)