### PR TITLE
fix: show each protocol's probe result and repair three task dead ends

### DIFF
--- a/frontend/src/components/ConnectionStatus.test.tsx
+++ b/frontend/src/components/ConnectionStatus.test.tsx
@@ -86,6 +86,52 @@ describe("ConnectionStatus", () => {
     expect(document.querySelector(".status-warning")).toBeTruthy();
   });
 
+  // ProbeProvider probes every protocol the selected Agents need, then overwrites
+  // the single reported result with the first failure (internal/app/provider.go
+  // :75-83). A Provider serving Chat Completions but refusing Responses therefore
+  // reported one failure naming one protocol, with no way to see that the other
+  // had passed or which of the user's Agents would work.
+  it("shows each protocol's own verdict when several were tested", () => {
+    show(probe({
+      error_code: "PROTOCOL_UNSUPPORTED",
+      status: 404,
+      protocols: {
+        openai: { ok: true, reachable: true, status: 200, message: "passed", error_code: null, retryable: false },
+        responses: { ok: false, reachable: true, status: 404, message: "Model does not support OpenAI Responses.", error_code: "PROTOCOL_UNSUPPORTED", retryable: false },
+      },
+    }));
+    expect(screen.getByText("OpenAI Chat Completions")).toBeTruthy();
+    expect(screen.getByText("Available")).toBeTruthy();
+    expect(screen.getByText("OpenAI Responses")).toBeTruthy();
+    // The failing row carries localised copy too, not the English backend text.
+    expect(screen.queryByText(/does not support OpenAI Responses\./)).toBeNull();
+  });
+
+  it("still breaks the protocols down on a wholly successful probe", () => {
+    // Both passing is also worth showing: it is the only confirmation that the
+    // second protocol was tested at all.
+    show(probe({
+      ok: true, status: 200, message: "连接正常", error_code: null,
+      protocols: {
+        openai: { ok: true, reachable: true, status: 200, message: "passed", error_code: null, retryable: false },
+        anthropic: { ok: true, reachable: true, status: 200, message: "passed", error_code: null, retryable: false },
+      },
+    }));
+    expect(screen.getByText("Anthropic Messages")).toBeTruthy();
+    expect(screen.getAllByText("Available")).toHaveLength(2);
+  });
+
+  it("stays quiet about protocols when only one was tested", () => {
+    // A single protocol adds nothing: the message above already describes it.
+    show(probe({
+      error_code: "PROTOCOL_UNSUPPORTED",
+      protocols: {
+        openai: { ok: false, reachable: true, status: 404, message: "no", error_code: "PROTOCOL_UNSUPPORTED", retryable: false },
+      },
+    }));
+    expect(screen.queryByText("OpenAI Chat Completions")).toBeNull();
+  });
+
   it("keeps a message the code cannot improve on", () => {
     // INVALID_REQUEST carries field-level detail written for the field it came
     // from; a generic sentence would lose what the user needs.

--- a/frontend/src/components/ConnectionStatus.tsx
+++ b/frontend/src/components/ConnectionStatus.tsx
@@ -3,7 +3,7 @@ import { AlertCircle, CheckCircle2, LoaderCircle, Radio, ShieldAlert } from "luc
 import { failureCopyFor, isHTTPStatus } from "../backend/failureCopy";
 import { useI18n } from "../i18n";
 import type { AsyncState } from "../state/wizardReducer";
-import type { ProbeResponse } from "../types/api";
+import { PROTOCOL_LABELS, type ProbeResponse, type ProtocolId } from "../types/api";
 
 export function ConnectionStatus({ state, result }: { state: AsyncState; result: ProbeResponse | null }) {
   const { t } = useI18n();
@@ -23,11 +23,34 @@ export function ConnectionStatus({ state, result }: { state: AsyncState; result:
       </div>
     );
   }
+  // Every protocol the selected Agents need is probed concurrently, and one
+  // failure used to overwrite the single reported result (internal/app/provider.go
+  // :75-83). So a Provider that serves Chat Completions but refuses Responses
+  // reported one failure naming one protocol, with no way to tell that the other
+  // had passed or which of the user's Agents would actually work. Shown per
+  // protocol whenever more than one was tested.
+  const perProtocol = Object.entries(result?.protocols ?? {})
+    .filter((entry): entry is [ProtocolId, ProbeResponse] => Boolean(entry[1]));
+  const breakdown = perProtocol.length > 1 ? (
+    <ul className="protocol-results">
+      {perProtocol.map(([protocol, outcome]) => (
+        <li key={protocol} className={outcome.ok ? "is-ok" : "is-failed"}>
+          {outcome.ok ? <CheckCircle2 size={13} aria-hidden="true" /> : <AlertCircle size={13} aria-hidden="true" />}
+          <strong>{PROTOCOL_LABELS[protocol] ?? protocol}</strong>
+          <span>{outcome.ok ? t("可用") : failureCopyFor(outcome.error_code, outcome.status, t)?.message || t("不可用")}</span>
+        </li>
+      ))}
+    </ul>
+  ) : null;
+
   if (result?.ok) {
     return (
       <div className="inline-status status-success" role="status">
         <CheckCircle2 size={17} />
-        {result.message}
+        <span>
+          {result.message}
+          {breakdown}
+        </span>
       </div>
     );
   }
@@ -55,6 +78,7 @@ export function ConnectionStatus({ state, result }: { state: AsyncState; result:
         {blamedModel ? (
           <small>{t("测试使用的模型 {model} 由 OneAgent 自动选择，可能不支持对话。可在上方自定义模型名称后重试", { model: blamedModel })}</small>
         ) : copy?.hint ? <small>{copy.hint}</small> : null}
+        {breakdown}
       </span>
     </div>
   );

--- a/frontend/src/i18n.tsx
+++ b/frontend/src/i18n.tsx
@@ -133,6 +133,14 @@ const english = {
   "尚未测试连接": "Connection not tested",
   "正在验证端点和 Key": "Validating endpoint and key",
   "连接失败": "Connection failed",
+  // Per-protocol verdicts. One failing protocol used to overwrite the single
+  // reported result, hiding that another had passed.
+  "可用": "Available",
+  "{name} 有任务正在运行，本次未开始": "{name} already has a task running, so this run did not start",
+  "已有安装任务正在运行，请在任务中心查看后重试": "An install task is already running. Check the task centre, then retry",
+  "已取消。已完成的部分保留在本机，重新运行是安全的": "Cancelled. Whatever finished is kept on this machine, and re-running is safe",
+  "这个任务已经结束或被关闭。安装结果请在环境总览中查看": "This task has finished or been dismissed. Check the environment overview for the result",
+  "不可用": "Unavailable",
   // Localised copy for backend error codes (src/backend/failureCopy.ts). Every Go
   // message reaching the UI is English; these replace it, keyed on error_code and
   // the HTTP status rather than on the message text.

--- a/frontend/src/pages/ActivationPage.test.tsx
+++ b/frontend/src/pages/ActivationPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -9,6 +9,10 @@ import { ActivationPage } from "./ActivationPage";
 // No I18nProvider, so translate() returns the Chinese keys unchanged.
 let state: WizardState;
 const refreshStatus = vi.fn(async () => {});
+/** Task ids the mocked task centre should report as cancelled. */
+const cancelledTargets = new Set<string>();
+/** Makes startTask refuse, as it does when a task with the same key is running. */
+let refuseStart = false;
 
 vi.mock("../state/WizardContext", () => ({
   useWizard: () => ({ state, dispatch: vi.fn(), refreshStatus }),
@@ -17,8 +21,9 @@ vi.mock("../state/WizardContext", () => ({
 vi.mock("../state/TaskCenterContext", async (importOriginal) => ({
   ...await importOriginal<typeof import("../state/TaskCenterContext")>(),
   useTaskCenter: () => ({
-    tasks: [], startTask: vi.fn(() => true), finishTask: vi.fn(),
-    setTaskCanceller: vi.fn(), taskFor: vi.fn(() => undefined),
+    tasks: [], startTask: () => !refuseStart, finishTask: vi.fn(),
+    setTaskCanceller: vi.fn(),
+    taskFor: (id: string) => (cancelledTargets.has(id) ? { state: "cancelled" } : undefined),
   }),
   useTaskRoute: () => "/setup/activation",
 }));
@@ -52,7 +57,7 @@ function show(results: AgentInstallResult[], next = "") {
 }
 
 describe("ActivationPage partial results", () => {
-  beforeEach(() => refreshStatus.mockClear());
+  beforeEach(() => { refreshStatus.mockClear(); cancelledTargets.clear(); refuseStart = false; });
 
   // One Agent configured and another failed unretryably left no forward button
   // and no retry button -- the only exit was back to the review step, even though
@@ -78,6 +83,49 @@ describe("ActivationPage partial results", () => {
   it("still shows the next-step command on a partial run", () => {
     show([result("codex"), result("aider", { status: "failed", retryable: false })], "openclaw onboard");
     expect(screen.getByText("openclaw onboard")).toBeTruthy();
+  });
+
+  // A cancel can land between steps -- after a runtime tree is published but
+  // before the Agent package installs, or after config is written. The row is
+  // synthesised as skipped with retryable: false, so there is no retry button
+  // either; saying only "已取消" left the user unable to tell whether re-running
+  // was safe.
+  // A mid-loop collision rolls back the tasks it already started. Reusing the
+  // collision message for those made an unrelated Agent report "this task is
+  // already running", pointing the user at the wrong row and at a task that was
+  // never theirs.
+  it("names where to look when another install is already running", async () => {
+    // startTask refuses the first target, so activate() reports the collision
+    // instead of starting a run. The old copy said only that a task existed.
+    refuseStart = true;
+    state = {
+      ...initialWizardState,
+      status,
+      statusState: "success",
+      selectedAgentIds: ["codex", "aider"],
+      activationState: "idle",
+      activationRequested: true,
+      activationResults: [],
+    };
+    render(<MemoryRouter><ActivationPage /></MemoryRouter>);
+    // activate() runs from an effect, so the notice appears after a tick.
+    await waitFor(() => expect(screen.getByText(/任务中心/)).toBeTruthy());
+  });
+
+  it("says what a cancelled run left behind", () => {
+    // activationCancelled is derived from the task centre, not wizard state.
+    cancelledTargets.add("install:codex");
+    state = {
+      ...initialWizardState,
+      status,
+      statusState: "success",
+      selectedAgentIds: ["codex"],
+      activationState: "error",
+      activationRequested: true,
+      activationResults: [],
+    };
+    render(<MemoryRouter><ActivationPage /></MemoryRouter>);
+    expect(screen.getByText(/重新运行是安全的/)).toBeTruthy();
   });
 
   it("hides the next-step command when nothing succeeded", () => {

--- a/frontend/src/pages/ActivationPage.tsx
+++ b/frontend/src/pages/ActivationPage.tsx
@@ -21,6 +21,9 @@ export function ActivationPage() {
   const route = useTaskRoute();
   const started = useRef(false);
   const [retrying, setRetrying] = useState<string | null>(null);
+  // Shown when a run could not start at all. Local state rather than the wizard:
+  // it describes this visit to the page, not the outcome of an install.
+  const [blockedMessage, setBlockedMessage] = useState("");
   const isDesktop = state.setupKind === "desktop";
   const desktop = isDesktop && state.status ? selectedDesktopApp(state.status, state.selectedAgentIds) : undefined;
   const selectedNames = useMemo(
@@ -81,7 +84,14 @@ export function ActivationPage() {
         route: installTaskRoute(target),
         group,
       })) {
-        for (const started of startedAgents) finishTask(started, { kind: "failure", message: t("任务正在运行") });
+        // The rollback names the Agent that is actually blocked. Reusing the
+        // collision message here reported "this task is already running" against
+        // Agents that were merely rolled back, which pointed the user at the wrong
+        // row -- and at a task that was never theirs.
+        const blockedBy = selectedNames[target] || target;
+        for (const started of startedAgents) {
+          finishTask(started, { kind: "failure", message: t("{name} 有任务正在运行，本次未开始", { name: blockedBy }) });
+        }
         return null;
       }
       startedAgents.push(id);
@@ -170,7 +180,10 @@ export function ActivationPage() {
   const activate = useCallback(async () => {
     const startedTasks = startActivationTasks(state.selectedAgentIds);
     if (!startedTasks) {
-      dispatch({ type: "ACTIVATION_FAILED", message: t("任务正在运行") });
+      setBlockedMessage(t("已有安装任务正在运行，请在任务中心查看后重试"));
+      // Names where to look. "任务正在运行" alone said a task existed without
+      // saying which, and the task centre is the only place to find it.
+      dispatch({ type: "ACTIVATION_FAILED", message: t("已有安装任务正在运行，请在任务中心查看后重试") });
       return;
     }
     dispatch({ type: "ACTIVATION_LOADING", agentIds: state.selectedAgentIds });
@@ -258,8 +271,14 @@ export function ActivationPage() {
   };
 
   const retry = async (agentId: string) => {
+    setBlockedMessage("");
     const startedTasks = startActivationTasks([agentId]);
-    if (!startedTasks) return;
+    // Same silent dead end as the first run: without this a blocked retry did
+    // nothing and said nothing.
+    if (!startedTasks) {
+      setBlockedMessage(t("已有安装任务正在运行，请在任务中心查看后重试"));
+      return;
+    }
     setRetrying(agentId);
     try {
       let response;
@@ -338,7 +357,14 @@ export function ActivationPage() {
   return (
     <PageScaffold
       title={activationLoading ? t("正在安装") : allDone ? t("安装完成") : activationCancelled ? t("已取消") : t("需要处理部分问题")}
-      description={activationLoading ? t("安装请求同步执行，完成后将显示每个 Agent 的最终状态") : activationCancelled ? t("已取消") : t("每个 Agent 的结果彼此独立，失败项可以单独重试")}
+      // A cancel can land between steps, so it says what is guaranteed rather than
+      // just "cancelled": runtime extraction is atomic (staging plus rename), and
+      // re-running is safe because every write is idempotent.
+      description={activationLoading
+        ? t("安装请求同步执行，完成后将显示每个 Agent 的最终状态")
+        : activationCancelled
+          ? t("已取消。已完成的部分保留在本机，重新运行是安全的")
+          : t("每个 Agent 的结果彼此独立，失败项可以单独重试")}
       stepper
       onBack={activationLoading ? undefined : () => navigate("/setup/review")}
       primaryLabel={allDone || anyConfigured ? t("进入总览") : undefined}
@@ -387,6 +413,10 @@ export function ActivationPage() {
         })}
       </div>
       {state.activationProbe && !state.activationProbe.ok ? <div className="notice notice-warning">{state.activationProbe.message}</div> : null}
+      {/* A run that never started produces no rows, and ACTIVATION_FAILED only
+          appends to the log -- which sits behind a collapsed disclosure. So a
+          collision with another install left the page showing nothing at all. */}
+      {blockedMessage ? <div className="notice notice-error">{blockedMessage}</div> : null}
       {/* The launch commands belong to the moment installation finishes, not to
           the overview a user opens every day. Shown for a partial run too: the
           commands belong to the Agents that succeeded, and hiding them because a

--- a/frontend/src/pages/InstallTaskPage.test.tsx
+++ b/frontend/src/pages/InstallTaskPage.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+
+// No I18nProvider, so translate() returns the Chinese keys unchanged.
+import { InstallTaskPage } from "./InstallTaskPage";
+
+vi.mock("../state/TaskCenterContext", async (importOriginal) => ({
+  ...await importOriginal<typeof import("../state/TaskCenterContext")>(),
+  useTaskCenter: () => ({ tasks: [], cancelTask: vi.fn(), dismissTask: vi.fn(), progress: {}, running: false }),
+}));
+
+describe("InstallTaskPage without a matching task", () => {
+  // Reached by reloading the route after tasks were cleared, or by following a
+  // link to a dismissed one. A bare "暂无任务" left the user unsure whether the
+  // install had been lost. ActivationPage already has a recovery path for the
+  // analogous case, so the two pages disagreed about the same situation.
+  it("says where the result actually is", () => {
+    render(
+      <MemoryRouter initialEntries={["/tasks/install/codex"]}>
+        <Routes>
+          <Route path="/tasks/install/:agentId" element={<InstallTaskPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+    expect(screen.getByText("暂无任务")).toBeTruthy();
+    expect(screen.getByText(/安装结果请在环境总览中查看/)).toBeTruthy();
+    expect(screen.getByRole("button", { name: "进入总览" })).toBeTruthy();
+  });
+});

--- a/frontend/src/pages/InstallTaskPage.tsx
+++ b/frontend/src/pages/InstallTaskPage.tsx
@@ -14,7 +14,18 @@ export function InstallTaskPage() {
   const target = decodeURIComponent(agentId);
   const task = tasks.find((item) => item.kind === kind && item.target === target);
   if (!task) {
-    return <PageScaffold title={t("暂无任务")} primaryLabel={t("进入总览")} onPrimary={() => navigate("/overview")} />;
+    // Reached by reloading this route after tasks were cleared, or by following a
+    // link to one that has been dismissed. A bare "no tasks" left the user unsure
+    // whether their install had been lost; the overview is where the real state
+    // is, so say that rather than only offering a button.
+    return (
+      <PageScaffold
+        title={t("暂无任务")}
+        description={t("这个任务已经结束或被关闭。安装结果请在环境总览中查看")}
+        primaryLabel={t("进入总览")}
+        onPrimary={() => navigate("/overview")}
+      />
+    );
   }
   const running = task.state === "running";
   const title = running

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -859,6 +859,31 @@
   line-height: 1.45;
 }
 
+/* Per-protocol verdicts under a probe result. Each row carries its own colour
+   because the point is that they can disagree -- inheriting the parent's status
+   colour would paint a passing protocol red inside a failed probe. */
+.protocol-results {
+  margin: 6px 0 0;
+  padding: 0;
+  display: grid;
+  gap: 4px;
+  list-style: none;
+}
+
+.protocol-results li {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.protocol-results li.is-ok { color: var(--green); }
+.protocol-results li.is-failed { color: var(--red); }
+.protocol-results strong { font-weight: 600; }
+.protocol-results span { color: var(--text-secondary); }
+.protocol-results svg { flex: 0 0 auto; }
+
 .model-picker {
   width: 100%;
   display: grid;


### PR DESCRIPTION
Addresses the parts of #120 and #121 that the issue comments identified as real, and leaves the rest alone deliberately.

## #120 — per-protocol verdicts

`ProbeProvider` probes every protocol the selected Agents need, then overwrites the single reported result with the **first failure** (`internal/app/provider.go:75-83`). A Provider serving Chat Completions but refusing Responses therefore reported one failure naming one protocol, with no way to see the other had passed or which of the user's Agents would actually work.

The map was already computed, serialized and typed with no consumer. `ProviderKeyPage.tsx:36-37` warns about this exact outcome in a comment — the UI was doing what the comment cautioned against.

Each protocol now carries its own verdict **and its own colour**, because the point is that they can disagree. Verified in a browser: inside a red failed probe, the passing protocol renders green (`rgb(36,138,61)`) rather than inheriting the parent's `rgb(215,0,21)`. Shown only when more than one protocol was tested — a single one adds nothing to the message above it.

**Not done, per the issue comment:** making `providers.lock.json`'s `protocols` field affect runtime behaviour. `catalog_test.go` pins it as deliberately unparsed site-only data, so wiring it in is a product-boundary decision needing an ADR, not a bug fix.

## #121 — three task dead ends

**Empty task page** said only `暂无任务`. Reached by reloading the route after tasks are cleared; now says the result is on the overview instead of leaving the user unsure whether the install was lost.

**Cancelled run** said only `已取消`. A cancel can land between steps, so it now states what is guaranteed: finished work is kept, re-running is safe (writes are idempotent, runtime extraction is staging-plus-rename atomic).

**Collision with a running install was invisible.** `ACTIVATION_FAILED` only appends to `activationLog`, which sits behind a collapsed disclosure — so a blocked run produced no rows and no message at all. That was worse than the wording problem the issue reported. It now reports itself as a notice, and the rollback names the Agent actually holding the lock instead of labelling unrelated Agents `任务正在运行`.

## #111 — no code change needed, and my earlier claim was wrong

I claimed the import path takes no backup, contradicting `02-api-key.md:31`. I probed it instead of trusting the read: both `provider.Store.write` and `profile.Store.Save` go through `securefs.AtomicWrite`, which calls `Backup` on every write. A second save leaves `providers.json.backup-20260808101425` behind; the profile side likewise.

So the doc claim is accurate and the import path is covered. Correcting the issue rather than changing code.

## Verification

- 316 passed (42 files), 6 new
- Each fix reverted independently: the breakdown drops 2, the cancelled copy drops 1, the blocked notice drops 1
- Browser-verified the protocol row colours and list layout (grid, 4px gap, bullets removed)
- `pnpm run build`, `pnpm run test:e2e` (6 passed), `go test ./...`, `check-docs.py`

One process note: my first attempt at the collision test passed while asserting nothing real — the mock returned `true` unconditionally, so `startTask` was never consulted. I traced it with temporary logging rather than accepting the green result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)