### PR TITLE
fix: make the probe model selectable and say what it does not do

### DIFF
--- a/frontend/e2e/wails.spec.ts
+++ b/frontend/e2e/wails.spec.ts
@@ -97,7 +97,7 @@ test("onboarding installs one Agent end to end and writes its Profile", async ({
   await page.getByRole("button", { name: "继续" }).click();
 
   await expect(page.getByRole("heading", { name: "连接模型服务" })).toBeVisible();
-  await page.getByLabel("自定义模型名称（可选）").fill("oneagent-e2e-model");
+  await page.getByLabel("测试用模型（可选）").fill("oneagent-e2e-model");
   await page.getByRole("button", { name: "测试连接" }).click();
   // The model step is gated on a passing Provider probe.
   await page.getByRole("button", { name: "继续选择模型" }).click();

--- a/frontend/src/components/ProviderModelPicker.tsx
+++ b/frontend/src/components/ProviderModelPicker.tsx
@@ -11,9 +11,25 @@ interface ProviderModelPickerProps {
   value: string;
   onChange: (value: string) => void;
   inputId: string;
+  /** Overrides the field label; defaults to the Profile editors' "模型". */
+  inputLabel?: string;
+  /** The line under the field, for a caller whose model means something else. */
+  hint?: string;
+  /**
+   * Profile editors need a model to save. The wizard's connection step does not:
+   * the field there only picks what the probe requests, and leaving it empty lets
+   * the backend choose.
+   */
+  required?: boolean;
+  /**
+   * grid-column: 1 / -1, which only means anything inside the Profile editor
+   * grid. Off by default so a caller outside that grid is not handed a stray
+   * declaration.
+   */
+  wide?: boolean;
 }
 
-export function ProviderModelPicker({ provider, protocol, hasKey, value, onChange, inputId }: ProviderModelPickerProps) {
+export function ProviderModelPicker({ provider, protocol, hasKey, value, onChange, inputId, inputLabel, hint, required = true, wide = false }: ProviderModelPickerProps) {
   const { t } = useI18n();
   const [models, setModels] = useState<string[]>([]);
   const [loading, setLoading] = useState(false);
@@ -42,13 +58,14 @@ export function ProviderModelPicker({ provider, protocol, hasKey, value, onChang
   }, [hasKey, protocol, provider, t]);
 
   return (
-    <div className="field-stack profile-editor-wide">
+    <div className={`field-stack${wide ? " profile-editor-wide" : ""}`}>
       {loading ? <div className="loading-block"><span className="spinner" />{t("正在读取模型列表")}</div> : null}
       {message && !loading ? <div className={`notice ${success ? "notice-success" : "notice-warning"}`}>{message}</div> : null}
-      {/* collapsible: both callers are compact editors where an always-open list
+      {/* collapsible: every caller is a compact form where an always-open list
           pushed the footer off screen. The arrow is also the only affordance that
           said the discovered models were selectable at all. */}
-      <ModelPicker models={models} value={value} onChange={onChange} inputId={inputId} inputLabel={t("模型")} required collapsible />
+      <ModelPicker models={models} value={value} onChange={onChange} inputId={inputId} inputLabel={inputLabel || t("模型")} required={required} collapsible />
+      {hint ? <small>{hint}</small> : null}
     </div>
   );
 }

--- a/frontend/src/i18n.tsx
+++ b/frontend/src/i18n.tsx
@@ -248,6 +248,12 @@ const english = {
   // flow; this wording covers both arriving signed in and having to sign up.
   "获取 API Key": "Get an API key",
   "自定义模型名称（可选）": "Custom model name (optional)",
+  // The connection step's model field. It only decides what the probe requests --
+  // the configured model is chosen on the next step -- and saying so plainly is
+  // the difference between a user thinking they have configured something and
+  // knowing they have not.
+  "测试用模型（可选）": "Test model (optional)",
+  "仅用于测试这个模型服务是否连得通，不会写入任何配置。真正使用的模型在下一步选择": "Used only to test whether this provider is reachable; nothing is written to any configuration. The model you actually use is chosen in the next step",
   "填写后将用此模型测试连接；留空时自动选择": "When provided, this model is used for the connection test. Leave blank to select automatically",
   "可选，仅用于测试连接；实际配置模型在下一步选择": "Optional; used only for the connection test. Choose the configured model in the next step",
   "测试连接": "Test connection",

--- a/frontend/src/pages/AgentProfilePage.tsx
+++ b/frontend/src/pages/AgentProfilePage.tsx
@@ -219,6 +219,7 @@ export function AgentProfilePage() {
               value={draft.model}
               onChange={(model) => setDraft({ ...draft, model })}
               inputId="agent-profile-model"
+              wide
             />
           </div>
           <p className="profile-key-hint">

--- a/frontend/src/pages/ProfilesPage.tsx
+++ b/frontend/src/pages/ProfilesPage.tsx
@@ -323,6 +323,7 @@ export function ProfilesPage() {
               value={editor.model}
               onChange={(model) => setEditor({ ...editor, model })}
               inputId="profile-model"
+              wide
             />
             {/* The key is the Provider's, so this only reports whether that
                 Provider has one and links to where it is set. */}

--- a/frontend/src/pages/ProviderKeyPage.test.tsx
+++ b/frontend/src/pages/ProviderKeyPage.test.tsx
@@ -53,7 +53,7 @@ describe("ProviderKeyPage", () => {
     });
     const page = render(<MemoryRouter><ProviderKeyPage /></MemoryRouter>);
 
-    fireEvent.change(screen.getByLabelText("自定义模型名称（可选）"), { target: { value: "vendor/custom-model" } });
+    fireEvent.change(screen.getByLabelText("测试用模型（可选）"), { target: { value: "vendor/custom-model" } });
     page.rerender(<MemoryRouter><ProviderKeyPage /></MemoryRouter>);
     expect(screen.queryByLabelText("API Key")).toBeNull();
     fireEvent.click(screen.getByRole("button", { name: "测试连接" }));
@@ -85,6 +85,49 @@ describe("ProviderKeyPage", () => {
     await waitFor(() => expect(save).toHaveBeenCalledWith(expect.objectContaining({ id: "ppio", api_key: "new-key", create: false })));
     expect(refreshStatus).toHaveBeenCalled();
     expect(keyRef.current).toBe("");
+  });
+
+  // The field was a bare text input, so the models this Key can actually reach
+  // were invisible and had to be typed from memory.
+  it("offers the discovered models from the probe field", async () => {
+    // A selected Agent is what gives the step a protocol, and without one
+    // discovery does not run at all.
+    state = {
+      ...initialWizardState,
+      status: { ...status, catalog: [{ id: "codex", name: "Codex", protocol: "openai" }] } as unknown as StatusResponse,
+      statusState: "success",
+      selectedAgentIds: ["codex"],
+      hasApiKey: true,
+    };
+    keyRef.current = "";
+    vi.spyOn(api, "models").mockResolvedValue({
+      ok: true, reachable: true, status: 200, message: "Found 2 models.",
+      error_code: null, retryable: false, models: ["deepseek/deepseek-v4-pro", "qwen/qwen3-coder"],
+    });
+    render(<MemoryRouter><ProviderKeyPage /></MemoryRouter>);
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "展开模型列表" })).toBeTruthy());
+    fireEvent.click(screen.getByRole("button", { name: "展开模型列表" }));
+    fireEvent.click(screen.getByRole("radio", { name: /qwen\/qwen3-coder/ }));
+    expect(dispatch).toHaveBeenCalledWith({ type: "SET_PROBE_MODEL", value: "qwen/qwen3-coder" });
+  });
+
+  // A model entered here is not configured anywhere, and a user who assumes it is
+  // will not understand why the next step asks again.
+  it("says the probe model configures nothing", () => {
+    state = { ...initialWizardState, status, statusState: "success", hasApiKey: true };
+    render(<MemoryRouter><ProviderKeyPage /></MemoryRouter>);
+
+    expect(screen.getByText(/不会写入任何配置/)).toBeTruthy();
+    expect(screen.getByText(/真正使用的模型在下一步选择/)).toBeTruthy();
+  });
+
+  it("leaves the probe model optional", () => {
+    // Empty is the common path: the backend picks a model for the probe.
+    state = { ...initialWizardState, status, statusState: "success", hasApiKey: true };
+    render(<MemoryRouter><ProviderKeyPage /></MemoryRouter>);
+
+    expect(screen.getByLabelText("测试用模型（可选）").hasAttribute("required")).toBe(false);
   });
 
   it("keeps custom Providers on the management-page path", () => {

--- a/frontend/src/pages/ProviderKeyPage.tsx
+++ b/frontend/src/pages/ProviderKeyPage.tsx
@@ -5,6 +5,7 @@ import { useNavigate } from "react-router-dom";
 import { api, describeFailure } from "../backend/api";
 import { ConnectionStatus } from "../components/ConnectionStatus";
 import { PageScaffold } from "../components/PageScaffold";
+import { ProviderModelPicker } from "../components/ProviderModelPicker";
 import { ProviderSegment } from "../components/ProviderSegment";
 import { SecureKeyField } from "../components/SecureKeyField";
 import { useI18n } from "../i18n";
@@ -165,20 +166,22 @@ export function ProviderKeyPage() {
           ) : null}
         </div>
 
-        <div className="field-stack">
-          <label htmlFor="provider-probe-model">{t("自定义模型名称（可选）")}</label>
-          <input
-            id="provider-probe-model"
-            className="text-field"
-            value={state.probeModel}
-            onChange={(event) => dispatch({ type: "SET_PROBE_MODEL", value: event.target.value })}
-            placeholder={t("例如 deepseek/deepseek-v4-pro")}
-            spellCheck={false}
-            autoCorrect="off"
-            autoCapitalize="none"
-          />
-          <small>{t("可选，仅用于测试连接；实际配置模型在下一步选择")}</small>
-        </div>
+        {/* The same discovery the Profile editors use, so the models this Key can
+            reach are selectable here instead of having to be typed from memory.
+            Not required: leaving it empty lets the backend pick a model for the
+            probe, which is the common path. */}
+        <ProviderModelPicker
+          key={`${protocols.join(",")}:${state.provider}`}
+          provider={state.provider}
+          protocol={protocols[0] || ""}
+          hasKey={providerHasKey}
+          value={state.probeModel}
+          onChange={(value) => dispatch({ type: "SET_PROBE_MODEL", value })}
+          inputId="provider-probe-model"
+          inputLabel={t("测试用模型（可选）")}
+          hint={t("仅用于测试这个模型服务是否连得通，不会写入任何配置。真正使用的模型在下一步选择")}
+          required={false}
+        />
 
         <div className="connection-row">
           <button className="button button-secondary" type="button" onClick={() => void testConnection()} disabled={!canProbe || state.connectionState === "loading"}>


### PR DESCRIPTION
Two fixes on the connection step (setup step 3).

## The dropdown

The model field was a bare `<input>`, so the models this Key can actually reach were invisible and had to be typed from memory — on the one screen that has just finished discovering them.

It now uses `ProviderModelPicker`, the same discovery plus disclosure arrow the Profile editors already have, so nothing new had to be built. `required` is off here: leaving the field empty lets the backend pick a model for the probe, which is the common path.

## Saying what it does not do

The old hint (`仅用于测试连接；实际配置模型在下一步选择`) was accurate but easy to read as "this is the default" rather than "this is thrown away". Now:

> 仅用于测试这个模型服务是否连得通，不会写入任何配置。真正使用的模型在下一步选择

A user who assumes this configured something will not understand why the next step asks again.

## Prop changes

`ProviderModelPicker` gained `inputLabel`, `hint`, `required` and `wide`. `wide` carries `profile-editor-wide` — which is `grid-column: 1 / -1`, meaningful only inside the Profile editor grid — so it is opt-in now instead of being handed to a caller outside that grid. Both existing callers pass it and their layout is unchanged.

## Verification

- 326 frontend tests (43 files), 3 new
- Reverted to a plain input: 2 of the 3 fail
- `go test ./...`, `pnpm run build`, `check-docs.py`, no duplicate i18n keys (438)

One catch worth naming: **the e2e suite failed** on this change. `wails.spec.ts:100` fills that field by its label during onboarding, and it timed out. The label rename fixed it, and the test now also proves the field is still freely typeable rather than select-only — which the unit tests alone would not have shown. All 6 e2e pass.

Also note the new dropdown test needs a selected Agent in its fixture: without one the step derives no protocol and discovery never runs. That is real behaviour for a Provider reached with nothing selected, so the other tests keep the empty-catalog fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)