### PR TITLE
fix: refuse an update the app cannot install where it is

### DIFF
--- a/frontend/src/backend/failureCopy.test.ts
+++ b/frontend/src/backend/failureCopy.test.ts
@@ -67,6 +67,7 @@ describe("failureCopyFor", () => {
       "MODELS_UNSUPPORTED",
       "CONFIG_WRITE_FAILED",
       "UPDATE_NOT_INSTALLABLE",
+      "UPDATE_LOCATION_BLOCKED",
     ]) {
       const copy = failureCopyFor(code, 0, t);
       expect(copy, code).not.toBeNull();
@@ -94,6 +95,19 @@ describe("UPDATE_NOT_INSTALLABLE", () => {
     expect(copy?.message).toBe("下载到的更新包无法安装");
     expect(copy?.hint).toContain("手动下载");
     expect(copy?.hint).not.toMatch(/重试|再试/);
+  });
+});
+
+describe("UPDATE_LOCATION_BLOCKED", () => {
+  // Running from a mounted dmg puts the app on a read-only AppTranslocation
+  // volume, where the helper cannot write its backup. It gives up before either
+  // restore path, so the app exits on "restart and update" and never returns.
+  // The copy has to name the fix, because nothing later gets the chance.
+  it("names moving the app, not retrying", () => {
+    const copy = failureCopyFor("UPDATE_LOCATION_BLOCKED", 409, t);
+    expect(copy?.message).toBe("OneAgent 无法在当前位置自我更新");
+    expect(copy?.hint).toContain("应用程序");
+    expect(copy?.hint).not.toMatch(/稍后|再试一次/);
   });
 });
 

--- a/frontend/src/backend/failureCopy.ts
+++ b/frontend/src/backend/failureCopy.ts
@@ -91,6 +91,10 @@ export function failureCopyFor(code: string | null | undefined, status: number |
       return { message: t("无法获取模型列表"), hint: t("这个端点不提供模型列表，可以直接手动输入模型 ID") };
     case "CONFIG_WRITE_FAILED":
       return { message: t("无法写入配置文件"), hint: t("确认配置文件没有被其他程序占用，以及你对它有写入权限") };
+    case "UPDATE_LOCATION_BLOCKED":
+      // Withheld at check time on purpose: the swap runs after the app exits, so
+      // this is the last moment anything can tell the user.
+      return { message: t("OneAgent 无法在当前位置自我更新"), hint: t("请先把 OneAgent 拖到「应用程序」文件夹，再重新检查更新") };
     case "UPDATE_NOT_INSTALLABLE":
       // Retrying re-downloads the same asset, so the hint has to send the user
       // somewhere else rather than suggest another attempt.

--- a/frontend/src/i18n.tsx
+++ b/frontend/src/i18n.tsx
@@ -183,6 +183,8 @@ const english = {
   "确认配置文件没有被其他程序占用，以及你对它有写入权限": "Check that the file is not held open by another program and that you can write to it",
   "{message}。{hint}": "{message}. {hint}",
   "下载到的更新包无法安装": "The downloaded update cannot be installed",
+  "OneAgent 无法在当前位置自我更新": "OneAgent cannot update itself where it is installed",
+  "请先把 OneAgent 拖到「应用程序」文件夹，再重新检查更新": "Move OneAgent to the Applications folder, then check for updates again",
   "请到发布页面手动下载新版本安装": "Download and install the new version manually from the releases page",
   // Shown when the probe failed on a model OneAgent picked rather than one the
   // user typed. Without it, a video or image model rejecting a chat request reads

--- a/frontend/src/pages/SettingsPage.test.tsx
+++ b/frontend/src/pages/SettingsPage.test.tsx
@@ -40,4 +40,29 @@ describe("SettingsPage", () => {
     fireEvent.click(screen.getByRole("button", { name: /帮助文档/ }));
     await waitFor(() => expect(screen.getByText("Unable to open the help site")).toBeTruthy());
   });
+
+  // An app running from a mounted dmg sits on a read-only volume, so the update
+  // helper cannot write its backup and abandons the swap without restarting the
+  // app. The backend withholds the version and reports the location instead; this
+  // one line is the whole report, so it has to carry the instruction too.
+  it("says to move the app when it cannot update in place", async () => {
+    const check = vi.spyOn(api, "checkUpdate").mockRejectedValue(
+      new OneAgentApiError(
+        "OneAgent is running from a disk image. Move OneAgent to the Applications folder, then check again.",
+        "UPDATE_LOCATION_BLOCKED",
+        false,
+        409,
+      ),
+    );
+    show();
+
+    fireEvent.click(screen.getByRole("button", { name: "检查更新" }));
+
+    await waitFor(() => expect(check).toHaveBeenCalled());
+    const report = await screen.findByRole("status");
+    expect(report.textContent).toContain("无法在当前位置自我更新");
+    expect(report.textContent).toContain("应用程序");
+    // No install button: there is nothing to install until the app is moved.
+    expect(screen.queryByRole("button", { name: "立即更新" })).toBeNull();
+  });
 });

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -32,7 +32,9 @@ export function SettingsPage() {
       setLatestVersion(latest);
       setUpdateMessage(latest ? t("发现新版本 {version}", { version: latest }) : t("当前已是最新版本"));
     } catch (error) {
-      setUpdateMessage(describeFailure(error, t("检查更新失败"), t).message);
+      // failureLine, not .message: for UPDATE_LOCATION_BLOCKED the hint carries
+      // the instruction, and this single line is the whole report.
+      setUpdateMessage(failureLine(error, t("检查更新失败"), t));
     } finally {
       setChecking(false);
     }

--- a/internal/binding/update.go
+++ b/internal/binding/update.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"errors"
+	"os"
 
 	oneerrors "github.com/MaimoryLab/OneAgent/internal/errors"
 	"github.com/MaimoryLab/OneAgent/internal/process"
@@ -24,10 +25,13 @@ type UpdateBackend interface {
 
 type UpdateService struct {
 	backend UpdateBackend
+	// executable resolves the running binary, so the service can tell whether
+	// the installation can be replaced in place. Overridden in tests.
+	executable func() (string, error)
 }
 
 func NewUpdateService(backend UpdateBackend) *UpdateService {
-	return &UpdateService{backend: backend}
+	return &UpdateService{backend: backend, executable: os.Executable}
 }
 
 func (s *UpdateService) Version() string {
@@ -51,7 +55,45 @@ func (s *UpdateService) Check(ctx context.Context) (string, error) {
 	if release.Verification == nil || release.Verification.DigestAlgo != "sha256" || len(release.Verification.Digest) != sha256.Size {
 		return "", updateError(errors.New("invalid update verification"), "Unable to check for updates")
 	}
+	// Reported here rather than at download time: the helper replaces the
+	// application after this process exits, so a location it cannot write to
+	// fails with no interface left to say so -- the app simply never comes back.
+	// Refusing before the user spends a download is the only honest moment.
+	if err := s.locationError(); err != nil {
+		return "", err
+	}
 	return release.Version, nil
+}
+
+// locationError reports an installation the helper could not replace. A version
+// is withheld rather than returned with a warning, because every caller treats a
+// version as "an update is available" and offers to install it.
+func (s *UpdateService) locationError() error {
+	resolve := s.executable
+	if resolve == nil {
+		resolve = os.Executable
+	}
+	executable, err := resolve()
+	if err != nil {
+		// Nothing to conclude: leave the existing behaviour rather than
+		// withholding an update from an installation that may be fine.
+		return nil
+	}
+	switch checkUpdateLocation(executable) {
+	case locationTranslocated:
+		return oneerrors.New(
+			oneerrors.UpdateLocationBlocked,
+			"OneAgent is running from a disk image. Move OneAgent to the Applications folder, then check again.",
+			oneerrors.WithStatus(409),
+		)
+	case locationUnwritable:
+		return oneerrors.New(
+			oneerrors.UpdateLocationBlocked,
+			"OneAgent cannot update itself where it is installed. Move OneAgent to the Applications folder, then check again.",
+			oneerrors.WithStatus(409),
+		)
+	}
+	return nil
 }
 
 func (s *UpdateService) DownloadAndInstall(ctx context.Context) error {

--- a/internal/binding/update_location.go
+++ b/internal/binding/update_location.go
@@ -1,0 +1,80 @@
+package binding
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// translocationMarker appears in the path macOS mounts an app at when it runs
+// from a disk image or a quarantined location. The volume is read-only, so the
+// updater cannot write its backup beside the bundle.
+const translocationMarker = "/AppTranslocation/"
+
+// installTarget is the path the updater helper replaces: the .app bundle on
+// macOS, the executable itself elsewhere. It mirrors updater.bundleTarget,
+// which is unexported.
+func installTarget(executable string) string {
+	if runtime.GOOS != "darwin" {
+		return executable
+	}
+	clean := filepath.Clean(executable)
+	parts := strings.Split(clean, string(os.PathSeparator))
+	for i, part := range parts {
+		if strings.HasSuffix(part, ".app") {
+			return string(os.PathSeparator) + filepath.Join(parts[1:i+1]...)
+		}
+	}
+	return executable
+}
+
+// updateLocationProblem describes why the running application cannot be
+// replaced in place, or "" when it can.
+type updateLocationProblem string
+
+const (
+	locationOK           updateLocationProblem = ""
+	locationTranslocated updateLocationProblem = "translocated"
+	locationUnwritable   updateLocationProblem = "unwritable"
+)
+
+// checkUpdateLocation reports whether the helper could replace the installed
+// application. It probes the directory holding the target, because that is
+// where the helper writes its backup and its replacement -- the bundle's own
+// permissions say nothing about whether a sibling can be created.
+//
+// Deliberately ordered: translocation is reported even on the rare occasion the
+// probe would succeed, because the path itself is a temporary mount that the
+// user should be told to move out of.
+func checkUpdateLocation(executable string) updateLocationProblem {
+	if executable == "" {
+		return locationOK
+	}
+	target := installTarget(executable)
+	if strings.Contains(target, translocationMarker) {
+		return locationTranslocated
+	}
+	if !directoryIsWritable(filepath.Dir(target)) {
+		return locationUnwritable
+	}
+	return locationOK
+}
+
+// directoryIsWritable answers by writing, not by reading permission bits: a
+// read-only mount, an immutable flag, or a sandbox denial all present as
+// permissive modes on the directory itself. Attempting the write is the only
+// reliable signal, and it is what the helper does.
+//
+// Any failure to create counts as not writable. The probe runs in the directory
+// the helper will use, so whatever stops the probe would stop the helper.
+func directoryIsWritable(dir string) bool {
+	probe, err := os.CreateTemp(dir, ".oneagent-update-probe-*")
+	if err != nil {
+		return false
+	}
+	name := probe.Name()
+	_ = probe.Close()
+	_ = os.Remove(name)
+	return true
+}

--- a/internal/binding/update_location_test.go
+++ b/internal/binding/update_location_test.go
@@ -1,0 +1,176 @@
+package binding
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	oneerrors "github.com/MaimoryLab/OneAgent/internal/errors"
+	"github.com/wailsapp/wails/v3/pkg/updater"
+)
+
+func availableRelease() *updater.Release {
+	return &updater.Release{
+		Version:      "0.5.2",
+		Verification: &updater.Verification{DigestAlgo: "sha256", Digest: make([]byte, sha256.Size)},
+	}
+}
+
+func checkableService(executable func() (string, error)) *UpdateService {
+	service := NewUpdateService(&updateBackendFake{
+		check: func(context.Context) (*updater.Release, error) { return availableRelease(), nil },
+	})
+	service.executable = executable
+	return service
+}
+
+// The four logged failures on a real machine were all this: the app ran from a
+// mounted dmg, macOS put it on a read-only AppTranslocation mount, and the
+// helper could not write its backup. It returns before either restore path, so
+// the app exited on "restart and update" and never came back -- with the only
+// record in a temp-file log no user would find.
+func TestCheckWithholdsAnUpdateFromATranslocatedApp(t *testing.T) {
+	translocated := "/private/var/folders/m7/x/T/AppTranslocation/79C329CB-B290-4966-9582-D0DD9AD6FB33/d/OneAgent.app/Contents/MacOS/oneagent-desktop"
+	service := checkableService(func() (string, error) { return translocated, nil })
+
+	version, err := service.Check(context.Background())
+
+	if version != "" {
+		t.Fatalf("Check() = %q, want no version: every caller reads one as an offer to install", version)
+	}
+	got := oneerrors.As(err)
+	if got.Code != oneerrors.UpdateLocationBlocked || got.Status != 409 {
+		t.Fatalf("error = %#v", got)
+	}
+	if got.Retryable {
+		t.Fatal("error is retryable; checking again from the same location gives the same answer")
+	}
+}
+
+func TestCheckWithholdsAnUpdateFromAnUnwritableDirectory(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root can write to a 0o500 directory")
+	}
+	parent := t.TempDir()
+	installed := filepath.Join(parent, "readonly")
+	if err := os.Mkdir(installed, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(installed, 0o700) })
+
+	// The bundle sits inside the unwritable directory, which is where the helper
+	// would have to create its backup.
+	executable := filepath.Join(installed, "OneAgent.app", "Contents", "MacOS", "oneagent-desktop")
+	if runtime.GOOS != "darwin" {
+		executable = filepath.Join(installed, "oneagent-desktop")
+	}
+	service := checkableService(func() (string, error) { return executable, nil })
+
+	version, err := service.Check(context.Background())
+
+	if version != "" {
+		t.Fatalf("Check() = %q, want no version", version)
+	}
+	if got := oneerrors.As(err); got.Code != oneerrors.UpdateLocationBlocked {
+		t.Fatalf("error = %#v", got)
+	}
+}
+
+func TestCheckReportsAnUpdateFromAWritableInstall(t *testing.T) {
+	parent := t.TempDir()
+	executable := filepath.Join(parent, "OneAgent.app", "Contents", "MacOS", "oneagent-desktop")
+	if err := os.MkdirAll(filepath.Dir(executable), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	service := checkableService(func() (string, error) { return executable, nil })
+
+	version, err := service.Check(context.Background())
+	if err != nil || version != "0.5.2" {
+		t.Fatalf("Check() = %q, %v", version, err)
+	}
+}
+
+// Withholding an update because the path could not be resolved would be worse
+// than attempting one: the installation may be perfectly fine.
+func TestCheckIgnoresAnUnresolvableExecutable(t *testing.T) {
+	for name, resolve := range map[string]func() (string, error){
+		"error":        func() (string, error) { return "", errors.New("no executable") },
+		"empty path":   func() (string, error) { return "", nil },
+		"nil resolver": nil,
+	} {
+		t.Run(name, func(t *testing.T) {
+			service := checkableService(resolve)
+
+			version, err := service.Check(context.Background())
+			if err != nil || version != "0.5.2" {
+				t.Fatalf("Check() = %q, %v", version, err)
+			}
+		})
+	}
+}
+
+// The probe has to leave nothing behind: it runs beside the installed
+// application, every time the app checks for updates.
+func TestUpdateLocationProbeRemovesItsFile(t *testing.T) {
+	dir := t.TempDir()
+	before, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !directoryIsWritable(dir) {
+		t.Fatal("a temp dir should be writable")
+	}
+
+	after, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(after) != len(before) {
+		names := make([]string, 0, len(after))
+		for _, entry := range after {
+			names = append(names, entry.Name())
+		}
+		t.Fatalf("probe left %v behind", names)
+	}
+}
+
+func TestInstallTargetResolvesTheBundle(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("bundle paths are macOS-only")
+	}
+	for executable, want := range map[string]string{
+		"/Applications/OneAgent.app/Contents/MacOS/oneagent-desktop": "/Applications/OneAgent.app",
+		// The directory the helper writes into is the bundle's parent, so a
+		// nested .app must not resolve to the inner one.
+		"/Applications/OneAgent.app/Contents/Helpers/Inner.app/Contents/MacOS/x": "/Applications/OneAgent.app",
+		"/usr/local/bin/oneagent-desktop":                                        "/usr/local/bin/oneagent-desktop",
+	} {
+		if got := installTarget(executable); got != want {
+			t.Fatalf("installTarget(%q) = %q, want %q", executable, got, want)
+		}
+	}
+}
+
+// A .app under the translocation mount is still translocated: the check must not
+// depend on where inside the bundle the executable sits.
+func TestCheckUpdateLocationClassifies(t *testing.T) {
+	writable := filepath.Join(t.TempDir(), "OneAgent.app", "Contents", "MacOS", "oneagent-desktop")
+	if err := os.MkdirAll(filepath.Dir(writable), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if got := checkUpdateLocation(writable); got != locationOK {
+		t.Fatalf("writable install = %q, want ok", got)
+	}
+	if got := checkUpdateLocation(""); got != locationOK {
+		t.Fatalf("empty path = %q, want ok", got)
+	}
+	translocated := "/private/var/folders/x/T/AppTranslocation/ABC/d/OneAgent.app/Contents/MacOS/oneagent-desktop"
+	if got := checkUpdateLocation(translocated); got != locationTranslocated {
+		t.Fatalf("translocated install = %q", got)
+	}
+}

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -22,6 +22,10 @@ const (
 	// over the installed application. Distinct from InternalError because the
 	// only way forward is a manual download, and the interface has to say so.
 	UpdateNotInstallable = "UPDATE_NOT_INSTALLABLE"
+	// UpdateLocationBlocked marks an installation the updater cannot replace in
+	// place, most often one running from a mounted disk image. Reported at check
+	// time so the user is not asked to download something that cannot be applied.
+	UpdateLocationBlocked = "UPDATE_LOCATION_BLOCKED"
 )
 
 // ExitCodes preserves the numeric codes included in existing error payloads.
@@ -40,6 +44,9 @@ var ExitCodes = map[string]int{
 	// distinct CLI contract, and the numeric codes in existing payloads are
 	// pinned by tests.
 	UpdateNotInstallable: 10,
+	// Also 10: an environment problem with no distinct CLI contract, and the
+	// numeric codes in existing payloads are pinned by tests.
+	UpdateLocationBlocked: 10,
 }
 
 // OneAgentError is safe to serialize across the Wails bridge. Message must


### PR DESCRIPTION
Fixes #143.

## The failure

Click "restart and update", the app exits, and it never comes back. Reopening it manually shows the old version. No error, anywhere.

From one machine's helper logs, four times:

```
helper start: target=/private/var/folders/.../AppTranslocation/262A487A-.../d/OneAgent.app new=.../OneAgent-darwin-arm64.dmg
backing up /private/var/folders/.../d/OneAgent.app → ....app.bak
backup failed: mkdir ....app.bak: read-only file system
```

Running the app from a mounted dmg makes Gatekeeper apply App Translocation: the bundle is mounted at a random read-only path. The helper backs the bundle up before replacing it, and that write cannot succeed there.

`helper.go:122` returns 12 at that point — **before** both of the helper's restore paths, which are conditioned on the swap attempts being exhausted (`:162`) or the launch failing (`:180`). Nothing restores and nothing relaunches. And because the helper is detached and outlives the UI by design, its exit code reaches no one; the only record is `$TMPDIR/wails-update-<pid>.log`, which no user will find.

## The change

`Check` resolves the running executable and withholds the version when the installation cannot be replaced in place.

Reported at check time, not download time, because check time is the last moment anything can speak: the swap happens after the process exits. And the version is **withheld** rather than returned next to a warning — every caller treats a non-empty version as "an update is available" and offers to install it, so returning one would keep the trap open.

Two conditions:

- **Translocation** — the path contains `/AppTranslocation/`. Reported even in the rare case the probe would pass, because the path is a temporary mount the user should be told to leave.
- **Unwritable target directory** — decided by creating a probe file in the directory the helper would use, then removing it. Not by reading permission bits: a read-only mount, an immutable flag or a sandbox denial all present as permissive modes on the directory itself. The probe is exactly what the helper does, so whatever stops one stops the other. Verified by test to leave nothing behind, since it runs beside the installed app on every check.

An executable that cannot be resolved is treated as fine. Withholding updates from an installation that may be perfectly healthy is the worse failure.

`installTarget` mirrors the unexported `updater.bundleTarget`, resolving to the `.app` on macOS so the probed directory is the bundle's parent — where the helper actually writes.

## Frontend

`UPDATE_LOCATION_BLOCKED` gets copy naming the fix, and the settings page now uses `failureLine` so the hint travels with the message: here the hint *is* the instruction, and that one line is the entire report.

The startup check keeps swallowing errors, which is correct — launching should not be interrupted to announce that an update was not offered. Only the explicit "check for updates" click reports.

## Tests

- Translocated path and unwritable directory both withhold the version and return `UPDATE_LOCATION_BLOCKED` / 409, non-retryable (checking again from the same place gives the same answer)
- A writable install still reports the version
- Unresolvable executable — error, empty path, nil resolver — all still report
- The probe leaves no file behind
- `installTarget` resolves the outer bundle, including a nested `.app` case
- Settings page shows both halves and offers no install button
- Copy names moving the app rather than retrying

Each guard was verified load-bearing by removing it and confirming the tests fail.

Also checked against the two real paths from the logs: the translocated one classifies as `translocated`, `/Applications/OneAgent.app` as OK.

## Verification

`go test ./...`, `go test -race ./internal/binding ./internal/errors`, `go vet ./...`, `go build -tags wails` pass. Frontend 336 tests pass, `pnpm run build` succeeds, `check-docs.py` clean.

`internal/process/process.go` is flagged by `gofmt -l` but untouched by this branch — pre-existing.

## Scope

This tells the user what to do instead of failing silently. It does not make updating from a read-only location work — that is not possible in place.

Not verified on hardware: whether a quarantined app in `/Applications` (as opposed to one under the translocation mount) also trips the check. The writability probe should cover it, but I have not reproduced that state.

The remaining structural gap is #141: the helper only learns the outcome after the process is gone, so a failure after the swap begins still has no way back to the UI. This PR removes the most common way into that state rather than closing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)