### PR TITLE
Tell the public site when a release publishes

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -309,3 +309,29 @@ jobs:
           else
             gh release create "$RELEASE_VERSION" release-assets/* --verify-tag --title "$RELEASE_VERSION" --generate-notes
           fi
+
+      # The public site reads this release's assets — filenames, sizes and digests —
+      # from the API at build time, because its CSP forbids a browser-side call to
+      # api.github.com. That makes its download page only as current as its last
+      # deploy, so without this it keeps advertising the previous version until a
+      # scheduled build happens to run.
+      #
+      # Deliberately after the step above rather than a separate job: the site needs
+      # to know the assets are *uploaded*, not that a tag exists. A build that read
+      # the feed mid-upload would publish a partial asset list, which is worse than
+      # publishing a stale complete one.
+      #
+      # Failure here does not fail the release. The release is the product; telling
+      # a website about it is not, and the site's own twelve-hour schedule is the
+      # backstop. `|| true` keeps a token that expired from turning a good release
+      # red.
+      - name: Notify the public site
+        if: env.SITE_DISPATCH_TOKEN != ''
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.SITE_DISPATCH_TOKEN }}
+          SITE_DISPATCH_TOKEN: ${{ secrets.SITE_DISPATCH_TOKEN }}
+        run: |
+          gh api repos/MaimoryLab/OneAgent-site/dispatches \
+            -f event_type=upstream-release \
+            -F "client_payload[release]=$RELEASE_VERSION" || true


### PR DESCRIPTION
The site at oneagentpro.ai reads this release's assets — filenames, sizes and
digests — from the API **at build time**, because its CSP forbids a browser-side
call to `api.github.com`. Its download page is therefore only as current as its last
deploy.

Concretely: after v0.5.0 shipped, the site kept offering v0.4.0 until someone
deployed by hand.

This adds one step to the `release` job that dispatches an `upstream-release` event
to `MaimoryLab/OneAgent-site`, which already has a matching `repository_dispatch`
trigger.

## Three deliberate choices

**Placed after the publish step, not in a separate job.** The site needs to know the
assets are *uploaded*, not that a tag exists. A build reading the release feed
mid-upload would publish a partial asset list — worse than publishing a stale but
complete one.

**Guarded on the secret being present** (`if: env.SITE_DISPATCH_TOKEN != ''`).
Without the secret the step skips rather than fails, so a fork still cuts releases
normally.

**`continue-on-error` plus `|| true`.** The release is the product; telling a website
about it is not. An expired token must not turn a good release red, and the site
keeps a twelve-hour schedule as its backstop.

`github.token` cannot do this — it is scoped to the repository it runs in, so a
cross-repository dispatch needs its own credential.

## The receiving end is already live and tested

I sent a dispatch by hand and confirmed the site's `deploy` job ran to **completion
rather than skipping**. That is the failure mode that matters here: a trigger can be
accepted (HTTP 204) while the job's `if` condition excludes it, which looks green
while publishing nothing. That repository has been bitten by exactly that once
before, so it was worth proving rather than assuming.

## ⚠️ Needs a secret before it does anything

`SITE_DISPATCH_TOKEN` must be added to this repository's Actions secrets. Until then
the step skips — deliberately, so merging this cannot break a release.

The token needs write access to `OneAgent-site` only. Either works:

- a fine-grained PAT scoped to `MaimoryLab/OneAgent-site` with **Contents: write**
- a GitHub App installation token

I could not create it from here: `gh` cannot mint fine-grained PATs (they are
browser-only), and the OAuth token I have lacks `admin:org` for an org-level secret.
Once it exists I can verify the whole path end to end by cutting a test tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)