### PR TITLE
fix: carry a Profile edit through to the Agents bound to it

### DIFF
--- a/frontend/bindings/github.com/MaimoryLab/OneAgent/internal/app/index.ts
+++ b/frontend/bindings/github.com/MaimoryLab/OneAgent/internal/app/index.ts
@@ -12,6 +12,7 @@ export type {
     InstallRuntimeResult,
     ProfileSummary,
     RuntimeStatus,
+    SaveProfileResult,
     SaveProviderResult,
     Settings,
     StatusResponse

--- a/frontend/bindings/github.com/MaimoryLab/OneAgent/internal/app/models.ts
+++ b/frontend/bindings/github.com/MaimoryLab/OneAgent/internal/app/models.ts
@@ -143,6 +143,18 @@ export interface ProfileSummary {
 export type RuntimeStatus = install$0.RuntimeState;
 
 /**
+ * SaveProfileResult reports which Agents followed the Profile to its new
+ * Provider or model, mirroring SaveProviderResult. Reapply failures are returned
+ * per Agent rather than failing the save: the Profile record on disk is already
+ * correct, and reverting it would lose the edit.
+ */
+export interface SaveProfileResult {
+    "profile": ProfileSummary;
+    "reapplied": string[] | null;
+    "failures": { [_ in string]?: string } | null;
+}
+
+/**
  * SaveProviderResult reports which Agents were rewritten after the edit so the
  * UI can say so, and which ones could not be, keyed by Agent ID.
  */

--- a/frontend/bindings/github.com/MaimoryLab/OneAgent/internal/binding/profileservice.ts
+++ b/frontend/bindings/github.com/MaimoryLab/OneAgent/internal/binding/profileservice.ts
@@ -21,6 +21,6 @@ export function ListProfiles(): $CancellablePromise<app$0.ProfileSummary[] | nul
     return $Call.ByID(192725737);
 }
 
-export function SaveProfile(request: $models.SaveProfileRequest): $CancellablePromise<app$0.ProfileSummary> {
+export function SaveProfile(request: $models.SaveProfileRequest): $CancellablePromise<app$0.SaveProfileResult> {
     return $Call.ByID(972252911, request);
 }

--- a/frontend/src/backend/wails.ts
+++ b/frontend/src/backend/wails.ts
@@ -26,6 +26,7 @@ import type {
   ProfileSummary,
   ProviderId,
   RuntimeStatus,
+  SaveProfileResult,
   SaveProviderInput,
   SaveProviderResult,
   Settings,
@@ -199,7 +200,7 @@ export const wailsApi = {
     model: string;
     configMode: string;
     protocol?: string;
-  }): CancellableRequest<ProfileSummary> =>
+  }): CancellableRequest<SaveProfileResult> =>
     call(() => ProfileService.SaveProfile({
       id: input.id,
       label: input.label,
@@ -209,5 +210,5 @@ export const wailsApi = {
       model: input.model,
       config_mode: input.configMode,
       protocol: input.protocol ?? "",
-    })) as CancellableRequest<ProfileSummary>,
+    })) as CancellableRequest<SaveProfileResult>,
 };

--- a/frontend/src/pages/ActivationPage.tsx
+++ b/frontend/src/pages/ActivationPage.tsx
@@ -156,7 +156,7 @@ export function ActivationPage() {
       protocol: desktopProtocol(desktop),
     });
     register(taskCanceller(profileRequest));
-    const profile = await profileRequest;
+    const { profile } = await profileRequest;
     const installRequest = desktop.installed ? undefined : api.installDesktopAgent(desktop.id);
     if (installRequest) register(taskCanceller(installRequest));
     const installed = installRequest ? await installRequest : undefined;

--- a/frontend/src/pages/AgentProfilePage.tsx
+++ b/frontend/src/pages/AgentProfilePage.tsx
@@ -127,7 +127,7 @@ export function AgentProfilePage() {
         configMode: "provider",
         protocol: app ? desktopProtocol(app) : catalog?.protocol || "",
       });
-      setSelectedId(saved.id);
+      setSelectedId(saved.profile.id);
       setDraft(null);
       await refreshStatus();
     } catch (error) {

--- a/frontend/src/pages/AgentProfilePage.tsx
+++ b/frontend/src/pages/AgentProfilePage.tsx
@@ -174,6 +174,8 @@ export function AgentProfilePage() {
       onPrimary={() => void apply()}
       primaryDisabled={!canApply || busy}
       footerNote={selected?.label || t("选择一个配置模版")}
+      // Stays secondary: this footer already has a primary ("应用"), and two
+      // blue buttons side by side would compete for the same attention.
       secondaryAction={(
         <button className="button button-secondary" type="button" onClick={openCreate} disabled={Boolean(draft)}>
           <Plus size={15} />{t("创建配置模版")}

--- a/frontend/src/pages/ProfileSelectionPage.tsx
+++ b/frontend/src/pages/ProfileSelectionPage.tsx
@@ -60,6 +60,8 @@ export function ProfileSelectionPage() {
       primaryLabel={t("继续")}
       onPrimary={choose}
       primaryDisabled={!selected}
+      // Stays secondary: the footer's primary is "继续", the step's actual
+      // forward action.
       secondaryAction={<button className="button button-secondary" type="button" onClick={() => { dispatch({ type: "START_NEW_PROFILE" }); navigate("/setup/provider"); }}><Plus size={15} />{t("新建配置模版")}</button>}
     >
       <div className="profile-list">

--- a/frontend/src/pages/ProfilesPage.test.tsx
+++ b/frontend/src/pages/ProfilesPage.test.tsx
@@ -3,7 +3,7 @@ import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { api } from "../backend/api";
-import type { ProfileSummary, StatusResponse } from "../types/api";
+import type { SaveProfileResult, ProfileSummary, StatusResponse } from "../types/api";
 import { ProfilesPage } from "./ProfilesPage";
 
 const refreshStatus = vi.fn<() => Promise<void>>();
@@ -83,6 +83,12 @@ function profile(over: Partial<ProfileSummary> = {}): ProfileSummary {
     activatedAt: null,
     ...over,
   };
+}
+
+// saveProfile reports the Agents it rewrote alongside the saved record, so a
+// mock has to carry the whole result rather than the Profile alone.
+function saved(over: Partial<ProfileSummary> = {}): SaveProfileResult {
+  return { profile: profile(over), reapplied: null, failures: null };
 }
 
 function renderPage(profiles: ProfileSummary[]) {
@@ -186,7 +192,7 @@ describe("ProfilesPage", () => {
   });
 
   it("creates a Profile inline without entering onboarding", async () => {
-    const save = vi.spyOn(api, "saveProfile").mockResolvedValue(profile({
+    const save = vi.spyOn(api, "saveProfile").mockResolvedValue(saved({
       id: "profile-ppio",
       label: "Codex Profile",
     }));
@@ -220,7 +226,7 @@ describe("ProfilesPage", () => {
   });
 
   it("requires a manually selected API type", async () => {
-    const save = vi.spyOn(api, "saveProfile").mockResolvedValue(profile({ id: "profile-ppio" }));
+    const save = vi.spyOn(api, "saveProfile").mockResolvedValue(saved({ id: "profile-ppio" }));
     renderPage([]);
     fireEvent.click(screen.getByRole("button", { name: "新增配置模版" }));
     expect(screen.getByRole("button", { name: "保存配置模版" })).toBeDisabled();
@@ -232,7 +238,7 @@ describe("ProfilesPage", () => {
   });
 
   it("points at the Provider page when its key is missing", async () => {
-    const save = vi.spyOn(api, "saveProfile").mockResolvedValue(profile({ label: "团队默认" }));
+    const save = vi.spyOn(api, "saveProfile").mockResolvedValue(saved({ label: "团队默认" }));
     renderPage([profile()]);
     fireEvent.click(screen.getByRole("button", { name: "编辑 团队 PPIO" }));
     expect(screen.getByLabelText("配置模版 ID").hasAttribute("disabled")).toBe(true);
@@ -247,11 +253,36 @@ describe("ProfilesPage", () => {
     })));
   });
 
+  // Switching a Profile's Provider rewrites the Agents bound to it, so the page
+  // has to say which ones moved. Silently reapplying left the user unable to tell
+  // whether their Agent had followed the edit.
+  it("reports the Agents a Profile edit reapplied", async () => {
+    vi.spyOn(api, "saveProfile").mockResolvedValue({
+      profile: profile({ provider: "novita" }), reapplied: ["codex"], failures: null,
+    });
+    renderPage([profile()]);
+    fireEvent.click(screen.getByRole("button", { name: "编辑 团队 PPIO" }));
+    fireEvent.click(screen.getByRole("button", { name: "保存配置模版" }));
+
+    await waitFor(() => expect(screen.getByText(/已重新应用到.*Codex/)).toBeTruthy());
+  });
+
+  it("reports a Profile edit whose reapply failed", async () => {
+    vi.spyOn(api, "saveProfile").mockResolvedValue({
+      profile: profile({ provider: "novita" }), reapplied: null, failures: { codex: "写入失败" },
+    });
+    renderPage([profile()]);
+    fireEvent.click(screen.getByRole("button", { name: "编辑 团队 PPIO" }));
+    fireEvent.click(screen.getByRole("button", { name: "保存配置模版" }));
+
+    await waitFor(() => expect(screen.getByText(/Codex.*重新应用失败.*写入失败/)).toBeTruthy());
+  });
+
   it("saves a Profile whose name was left blank", async () => {
     // The backend fills an empty label in from the existing value or the ID
     // (internal/profile/write.go:71-74), so requiring one here was stricter than
     // the write path and blocked a rename-to-nothing edit.
-    const save = vi.spyOn(api, "saveProfile").mockResolvedValue(profile());
+    const save = vi.spyOn(api, "saveProfile").mockResolvedValue(saved());
     renderPage([profile()]);
     fireEvent.click(screen.getByRole("button", { name: "编辑 团队 PPIO" }));
     const label = screen.getByLabelText("名称");
@@ -340,7 +371,7 @@ describe("ProfilesPage", () => {
     // recomputed on a switch. So a Profile created after switching to Novita was
     // still called "PPIO 配置模版" and stored under profile-ppio -- a name and a
     // storage key both naming the Provider the user had just moved away from.
-    const save = vi.spyOn(api, "saveProfile").mockResolvedValue(profile());
+    const save = vi.spyOn(api, "saveProfile").mockResolvedValue(saved());
     renderWithTwoProviders();
     fireEvent.click(screen.getByRole("button", { name: "新增配置模版" }));
     // Novita, not PPIO: byProviderCreatedAt breaks a tie between two built-ins on

--- a/frontend/src/pages/ProfilesPage.tsx
+++ b/frontend/src/pages/ProfilesPage.tsx
@@ -46,6 +46,7 @@ export function ProfilesPage() {
   const [busy, setBusy] = useState(false);
   const [applying, setApplying] = useState("");
   const [failure, setFailure] = useState("");
+  const [applied, setApplied] = useState("");
 
   if (!status) {
     return (
@@ -57,6 +58,8 @@ export function ProfilesPage() {
 
   const profiles = status.profiles;
   const configurableAgents = status.catalog.filter((agent) => agent.configMode === "auto");
+  const nameOf = (agentId: string) =>
+    status.catalog.find((item) => item.id === agentId)?.name || agentId;
   const protocolOf = (profile: ProfileSummary) =>
     profile.protocol || status.catalog.find((agent) => status.agents[agent.id]?.profileId === profile.id)?.protocol || "";
   const providerHasKey = Boolean(editor && status.providers[editor.provider]?.has_key);
@@ -133,8 +136,12 @@ export function ProfilesPage() {
     if (!editor || !canSave) return;
     setBusy(true);
     setFailure("");
+    setApplied("");
     try {
-      await api.saveProfile({
+      // Switching the Provider or model rewrites every Agent already following
+      // this Profile, so the outcome has to be reported rather than applied
+      // silently -- the Agent's own config file moves with it.
+      const result = await api.saveProfile({
         id: editor.id.trim().toLowerCase(),
         label: editor.label.trim(),
         provider: editor.provider,
@@ -144,6 +151,18 @@ export function ProfilesPage() {
         configMode: "provider",
         protocol: editor.protocol,
       });
+      const reapplied = result.reapplied ?? [];
+      const failures = Object.entries(result.failures ?? {});
+      if (failures.length) {
+        setFailure(t("{agents} 重新应用失败：{message}", {
+          agents: failures.map(([agentId]) => nameOf(agentId)).join(locale === "en" ? ", " : "、"),
+          message: failures[0][1] ?? "",
+        }));
+      } else if (reapplied.length) {
+        setApplied(t("已重新应用到 {agents}", {
+          agents: reapplied.map(nameOf).join(locale === "en" ? ", " : "、"),
+        }));
+      }
       await refreshStatus();
       setEditor(null);
     } catch (error) {
@@ -349,6 +368,7 @@ export function ProfilesPage() {
       ) : null}
 
       {failure ? <p className="agent-manage-error">{failure}</p> : null}
+      {applied ? <div className="agent-manage-applied"><strong>{t("应用完成")}</strong><span>{applied}</span></div> : null}
 
       {!profiles.length && !editor ? (
         <div className="empty-overview">

--- a/frontend/src/pages/ProfilesPage.tsx
+++ b/frontend/src/pages/ProfilesPage.tsx
@@ -238,7 +238,7 @@ export function ProfilesPage() {
       description={t("在这里创建配置模版，再将它应用到所选 Agent")}
       bodyClassName="management-page"
       secondaryAction={(
-        <button className="button button-secondary" type="button" onClick={openCreate} disabled={Boolean(editor)}>
+        <button className="button button-primary" type="button" onClick={openCreate} disabled={Boolean(editor)}>
           <Plus size={15} />
           {t("新增配置模版")}
         </button>
@@ -400,10 +400,10 @@ export function ProfilesPage() {
                 </p>
                 <footer>
                   {users.length ? (
-                    <span className="provider-users">
-                      {users.map((agent) => <span className="provider-user-chip" key={agent.id}>{agent.name}</span>)}
+                    <span className="card-users">
+                      {users.map((agent) => <span className="card-user-chip" key={agent.id}>{agent.name}</span>)}
                     </span>
-                  ) : <span className="provider-users is-empty">{t("暂无 Agent 使用")}</span>}
+                  ) : <span className="card-users is-empty">{t("暂无 Agent 使用")}</span>}
                   <button
                     className="button button-secondary"
                     type="button"

--- a/frontend/src/pages/ProvidersPage.tsx
+++ b/frontend/src/pages/ProvidersPage.tsx
@@ -177,7 +177,7 @@ export function ProvidersPage({ create = false }: { create?: boolean }) {
       description={t("管理模型服务、端点与本机保存的 API Key")}
       bodyClassName="management-page"
       secondaryAction={!create ? (
-        <button className="button button-secondary" type="button" onClick={() => { setEditor({ ...emptyProvider, id: suggestProviderID(Object.keys(status.providers)) }); setCreating(true); setFailure(""); setApplied(""); }}>
+        <button className="button button-primary" type="button" onClick={() => { setEditor({ ...emptyProvider, id: suggestProviderID(Object.keys(status.providers)) }); setCreating(true); setFailure(""); setApplied(""); }}>
           <Plus size={15} />
           {t("新增模型服务")}
         </button>
@@ -286,10 +286,10 @@ export function ProvidersPage({ create = false }: { create?: boolean }) {
               </dl>
               <footer>
                 {users.length ? (
-                  <span className="provider-users">
-                    {users.map((agentId) => <span className="provider-user-chip" key={agentId}>{nameOf(agentId)}</span>)}
+                  <span className="card-users">
+                    {users.map((agentId) => <span className="card-user-chip" key={agentId}>{nameOf(agentId)}</span>)}
                   </span>
-                ) : <span className="provider-users is-empty">{t("暂无 Agent 使用")}</span>}
+                ) : <span className="card-users is-empty">{t("暂无 Agent 使用")}</span>}
                 <span className={`provider-key-state${meta.has_key ? " has-key" : ""}`}>
                   <KeyRound size={12} />{meta.has_key ? t("已保存 Key") : t("未保存 Key")}
                 </span>

--- a/frontend/src/pages/TransferPage.test.tsx
+++ b/frontend/src/pages/TransferPage.test.tsx
@@ -149,7 +149,7 @@ describe("TransferPage", () => {
     // `encrypted: []` is truthy, so this used to prompt for a password that
     // decrypted nothing -- and cancelling it aborted the import silently.
     const saveProvider = vi.spyOn(api, "saveProvider").mockResolvedValue({ entry: { id: "ppio", name: "PPIO", home: "", base_url: "https://api.example.test", anthropic_base_url: "", api_key: "incoming", built_in: true }, reapplied: null, failures: null });
-    vi.spyOn(api, "saveProfile").mockResolvedValue(status.profiles[0]);
+    vi.spyOn(api, "saveProfile").mockResolvedValue({ profile: status.profiles[0], reapplied: null, failures: null });
     refreshStatus.mockResolvedValue();
     startImport(collidingFile);
     await waitFor(() => expect(screen.getByText("确认导入")).toBeTruthy());
@@ -178,7 +178,7 @@ describe("TransferPage", () => {
       entry: { id: "ppio", name: "PPIO", home: "", base_url: "https://api.example.test", anthropic_base_url: "", api_key: "kept", built_in: true },
       reapplied: null, failures: null,
     });
-    vi.spyOn(api, "saveProfile").mockResolvedValue(status.profiles[0]);
+    vi.spyOn(api, "saveProfile").mockResolvedValue({ profile: status.profiles[0], reapplied: null, failures: null });
     refreshStatus.mockResolvedValue();
     startImport(keylessFile);
     await waitFor(() => expect(screen.getByText("确认导入")).toBeTruthy());
@@ -196,7 +196,7 @@ describe("TransferPage", () => {
       entry: { id: "ppio", name: "PPIO", home: "", base_url: "https://api.example.test", anthropic_base_url: "", api_key: "incoming", built_in: true },
       reapplied: null, failures: null,
     });
-    vi.spyOn(api, "saveProfile").mockResolvedValue(status.profiles[0]);
+    vi.spyOn(api, "saveProfile").mockResolvedValue({ profile: status.profiles[0], reapplied: null, failures: null });
     refreshStatus.mockResolvedValue();
     startImport(collidingFile);
     await waitFor(() => expect(screen.getByText("确认导入")).toBeTruthy());

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -1238,7 +1238,7 @@
 .agent-manage-row {
   --agent-accent: var(--blue);
   --agent-soft: var(--blue-soft);
-  width: min(100%, 1040px);
+  width: min(100%, var(--card-measure));
   min-height: 84px;
   padding: 12px 14px;
   display: grid;
@@ -1249,7 +1249,7 @@
   align-items: center;
   gap: 10px 18px;
   border: 1px solid var(--border);
-  border-radius: 12px;
+  border-radius: var(--radius-card);
   background: var(--surface-subtle);
   font: inherit;
   text-align: left;
@@ -1292,7 +1292,7 @@
   gap: 3px;
 }
 
-.agent-manage-row .agent-manage-identity-copy strong { font-size: 16px; line-height: 1.3; }
+.agent-manage-row .agent-manage-identity-copy strong { font-size: var(--card-title-size); line-height: 1.3; }
 .agent-manage-identity-copy small {
   color: var(--text-tertiary);
   font-size: 10px;
@@ -1515,7 +1515,7 @@
   align-items: center;
   gap: 10px 18px;
   border: 1px solid var(--border);
-  border-radius: 12px;
+  border-radius: var(--radius-card);
   background: var(--surface-subtle);
 }
 
@@ -1809,21 +1809,27 @@
    set. */
 .provider-list,
 .profile-list {
-  width: 100%;
+  width: min(100%, var(--card-measure));
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
   align-items: start;
-  gap: 10px;
+  gap: 8px;
 }
 
+/* Shares the entity-card surface with .agent-manage-row and .desktop-app-row:
+   same border, radius, padding and background. These cards previously carried
+   no border at all, leaving --surface-subtle against --window-bg (1.19:1 dark,
+   1.07:1 light) as the only thing marking the edge -- not enough to read as a
+   card, least of all in light mode. */
 .provider-card,
 .profile-card {
   width: 100%;
   min-width: 0;
-  padding: 13px;
+  padding: 12px 14px;
   display: grid;
   gap: 9px;
-  border-radius: var(--radius-panel);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-card);
   background: var(--surface-subtle);
 }
 
@@ -1836,9 +1842,10 @@
 }
 
 .provider-card strong,
-.profile-card strong { font-size: 13px; }
+.profile-card strong { font-size: var(--card-title-size); }
 
-.provider-card > * { min-width: 0; }
+.provider-card > *,
+.profile-card > * { min-width: 0; }
 
 .provider-title {
   min-width: 0;
@@ -1850,6 +1857,20 @@
 .provider-title small {
   color: var(--text-tertiary);
   font-size: 10px;
+}
+
+/* An unbroken Provider name or Profile ID -- both are user-supplied and neither
+   is required to contain a space -- otherwise pushed the header past the card
+   edge and over the action buttons. The card cannot widen to fit it (the grid
+   column is fixed), so the name has to give. */
+.provider-title strong,
+.profile-title strong,
+.provider-title small,
+.profile-title small {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .provider-card-actions {
@@ -1900,23 +1921,38 @@
   white-space: nowrap;
 }
 
-.provider-users {
+/* .card-users / .card-user-chip are shared by the Provider and Profile cards.
+   Named for the role, not the page: the Profile card used to borrow
+   .provider-user-chip, so narrowing the Provider chip would have reshaped a
+   card on a different page. */
+.card-users {
+  min-width: 0;
   display: flex;
   flex-wrap: wrap;
   gap: 5px;
 }
 
-.provider-users.is-empty {
+.card-users.is-empty {
   color: var(--text-tertiary);
   font-size: 11px;
 }
 
-.provider-user-chip {
-  padding: 2px 8px;
+/* Matched to .agent-manage-pill -- same border, padding and radius. Without the
+   border the chip had no outline of its own either: --window-bg on
+   --surface-subtle is the same 1.19:1 the card itself was relying on. */
+.card-user-chip {
+  min-width: 0;
+  max-width: 100%;
+  padding: 4px 8px;
+  border: 1px solid var(--border);
   border-radius: 999px;
   background: var(--window-bg);
   color: var(--text-secondary);
   font-size: 11px;
+  line-height: 1.2;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .provider-card footer {
@@ -2356,7 +2392,8 @@
   .profile-editor-grid { grid-template-columns: minmax(0, 1fr); }
   .provider-editor-wide,
   .profile-editor-wide { grid-column: auto; }
-  .provider-card footer { align-items: flex-start; flex-direction: column; }
+  .provider-card footer,
+  .profile-card footer { align-items: flex-start; flex-direction: column; }
 
   .agent-manage-row {
     width: 100%;

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -38,6 +38,17 @@
   --radius-control: 6px;
   --radius-panel: 8px;
   --radius-window: 12px;
+  /* Entity cards (Agent rows, Provider cards, Profile cards). These three used
+     to disagree -- 12px hardcoded against --radius-panel -- which put two
+     corner radii on one screen. Separate from --radius-panel so a change to
+     inline panels does not silently reshape the card grid. */
+  --radius-card: 12px;
+  --card-title-size: 15px;
+  /* Shared measure for entity-card content. The Agent rows carried this as a
+     bare `min(100%, 1040px)` while the Provider and Profile grids ran the full
+     pane, so on a wide window the two card families ended at different x and
+     the columns no longer lined up. */
+  --card-measure: 1040px;
   --sidebar-width: 232px;
   --footer-height: 68px;
   /* The task centre is position: fixed, so it contributes no height to the

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -44,6 +44,9 @@ export type SaveProviderInput = Omit<BindingModels.SaveProviderRequest, "keep_ex
 };
 export type SaveProviderResult = AppModels.SaveProviderResult;
 export type ProfileSummary = Omit<AppModels.ProfileSummary, "protocol" | "createdAt"> & { protocol: ProtocolId | ""; createdAt?: string };
+// Mirrors SaveProviderResult: saving a Profile can rewrite the Agents bound to
+// it, so the outcome per Agent travels with the saved record.
+export type SaveProfileResult = Omit<AppModels.SaveProfileResult, "profile"> & { profile: ProfileSummary };
 
 export type StatusResponse = Omit<
   AppModels.StatusResponse,

--- a/internal/app/desktopapp_test.go
+++ b/internal/app/desktopapp_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 
 	"github.com/MaimoryLab/OneAgent/internal/desktopapp"
@@ -105,6 +106,28 @@ func TestConfigureWorkBuddyWritesModelsJSONFromProvider(t *testing.T) {
 	binding, err := core.profiles.ReadAgentBinding(desktopapp.WorkBuddyID)
 	if err != nil || binding == nil || binding.BaseURL != "https://relay.example/openai" {
 		t.Fatalf("reapplied WorkBuddy binding = %#v, err=%v", binding, err)
+	}
+	// A desktop Agent has to follow a Profile edit too, and it takes a different
+	// branch than a managed CLI Agent -- WorkBuddy writes models.json through the
+	// config adapter rather than through activation.
+	profileEdit, err := core.SaveProfile(context.Background(), SaveProfileOptions{
+		ID: "workbuddy-profile", Label: "WorkBuddy", Provider: "ppio",
+		Model: "model-b", ConfigMode: "provider", Protocol: "openai",
+	})
+	if err != nil || len(profileEdit.Failures) != 0 || len(profileEdit.Reapplied) != 1 {
+		t.Fatalf("WorkBuddy Profile reapply = %#v, err=%v", profileEdit, err)
+	}
+	data, err = os.ReadFile(wantPath)
+	if err != nil || json.Unmarshal(data, &models) != nil {
+		t.Fatalf("WorkBuddy models unreadable after Profile edit: %s, err=%v", data, err)
+	}
+	// The adapter registers models rather than replacing the list, so assert the
+	// new one arrived instead of asserting it is the only one.
+	if !slices.ContainsFunc(models, func(model map[string]any) bool { return model["id"] == "model-b" }) {
+		t.Fatalf("Profile edit did not reach WorkBuddy models: %s", data)
+	}
+	if binding, err := core.profiles.ReadAgentBinding(desktopapp.WorkBuddyID); err != nil || binding == nil || binding.Model != "model-b" {
+		t.Fatalf("WorkBuddy binding did not follow the Profile: %#v, err=%v", binding, err)
 	}
 }
 

--- a/internal/app/provider.go
+++ b/internal/app/provider.go
@@ -195,6 +195,25 @@ func (u *UseCases) SaveProvider(ctx context.Context, entry provider.Entry, creat
 // Provider, keeping its own model and Profile reference. Callers must hold
 // writeMu.
 func (u *UseCases) reapplyProviderLocked(ctx context.Context, target provider.Entry) ([]string, map[string]string, error) {
+	// The Agent's own model stays authoritative; only the Provider changed.
+	return u.reapplyBindingsLocked(ctx, func(binding profileStore.AgentBinding) bool {
+		return binding.Provider == target.ID
+	}, func(binding profileStore.AgentBinding) (provider.Entry, string) {
+		return target, binding.Model
+	})
+}
+
+// reapplyBindingsLocked rewrites every Agent whose binding `selects`, using the
+// Provider and model that `rewrite` returns for it. Both a Provider edit and a
+// Profile edit need this same per-Agent dispatch -- managed CLI Agents go
+// through activation, desktop Agents split three ways by definition -- and they
+// differ only in which bindings to touch and what to write. Callers must hold
+// writeMu.
+func (u *UseCases) reapplyBindingsLocked(
+	ctx context.Context,
+	selects func(profileStore.AgentBinding) bool,
+	rewrite func(profileStore.AgentBinding) (provider.Entry, string),
+) ([]string, map[string]string, error) {
 	var reapplied []string
 	var failures map[string]string
 	bindings, err := u.profiles.ListAgentBindings()
@@ -208,10 +227,10 @@ func (u *UseCases) reapplyProviderLocked(ctx context.Context, target provider.En
 	sort.Strings(agentIDs)
 	for _, agentID := range agentIDs {
 		binding := bindings[agentID]
-		if binding.Provider != target.ID {
+		if !selects(binding) {
 			continue
 		}
-		// The Agent's own model stays authoritative; only the Provider changed.
+		target, model := rewrite(binding)
 		var err error
 		if definition, isDesktop := desktopapp.DefinitionFor(agentID); isDesktop {
 			if definition.SharedConfigAgentID != "" {
@@ -219,23 +238,23 @@ func (u *UseCases) reapplyProviderLocked(ctx context.Context, target provider.En
 					AgentID:   definition.ProfileAgentID,
 					Provider:  target.ID,
 					APIKey:    target.APIKey,
-					Model:     binding.Model,
+					Model:     model,
 					ProfileID: binding.ProfileRef,
 				})
 			} else if definition.ConfigAdapter != "" {
-				_, managed, configErr := u.writeDesktopAgentConfig(ctx, definition, target, binding.Model)
+				_, managed, configErr := u.writeDesktopAgentConfig(ctx, definition, target, model)
 				err = configErr
 				if err == nil && !managed {
 					continue
 				}
 				if err == nil && managed {
 					_, err = u.profiles.WriteAgentBinding(ctx, agentID, profileStore.BindingWriteRequest{
-						Provider: target.ID, BaseURL: target.BaseURL, Model: binding.Model, ProfileRef: binding.ProfileRef,
+						Provider: target.ID, BaseURL: target.BaseURL, Model: model, ProfileRef: binding.ProfileRef,
 					})
 				}
 			} else {
 				_, err = u.profiles.WriteAgentBinding(ctx, agentID, profileStore.BindingWriteRequest{
-					Provider: target.ID, BaseURL: target.BaseURL, Model: binding.Model, ProfileRef: binding.ProfileRef,
+					Provider: target.ID, BaseURL: target.BaseURL, Model: model, ProfileRef: binding.ProfileRef,
 				})
 			}
 		} else {
@@ -243,7 +262,7 @@ func (u *UseCases) reapplyProviderLocked(ctx context.Context, target provider.En
 				AgentID:   agentID,
 				Provider:  target.ID,
 				APIKey:    target.APIKey,
-				Model:     binding.Model,
+				Model:     model,
 				ProfileID: binding.ProfileRef,
 			})
 		}

--- a/internal/app/provider_test.go
+++ b/internal/app/provider_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -226,6 +227,85 @@ func TestDeleteProviderRejectsBoundAgents(t *testing.T) {
 	}
 	if _, err := core.GetProvider(context.Background(), "acme"); err != nil {
 		t.Fatalf("guard deleted Provider: %v", err)
+	}
+}
+
+// Switching a Profile's Provider used to leave every Agent following it bound to
+// the old one: the Profile page showed the new Provider while the Agent kept
+// sending traffic to the old endpoint, and neither Provider card listed the Agent
+// correctly. Asserting the binding, not just that SaveProfile returns no error --
+// the pre-fix code passed that.
+func TestSaveProfileMigratesBoundAgentsToTheNewProvider(t *testing.T) {
+	home := t.TempDir()
+	core := activationCore(t, home, provider.NewClient(nil), "linux")
+	// novita is a built-in Provider, so it only needs a key to be usable as a
+	// switch target.
+	if err := core.providers.SaveKey(context.Background(), "novita", "novita-key"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := core.SaveProfile(context.Background(), SaveProfileOptions{
+		ID: "team", Provider: "ppio", Model: "model-a", ConfigMode: "provider",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := core.ActivateAgent(context.Background(), ActivateAgentOptions{
+		AgentID: "codex", Provider: "ppio", APIKey: "key", Model: "model-a", ProfileID: "team",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	result, err := core.SaveProfile(context.Background(), SaveProfileOptions{
+		ID: "team", Provider: "novita", Model: "model-b", ConfigMode: "provider",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Failures) != 0 || !slices.Contains(result.Reapplied, "codex") {
+		t.Fatalf("reapply result = %#v", result)
+	}
+	binding, err := core.profiles.ReadAgentBinding("codex")
+	if err != nil || binding == nil {
+		t.Fatalf("binding read failed: %v", err)
+	}
+	if binding.Provider != "novita" || binding.Model != "model-b" {
+		t.Fatalf("binding did not follow the Profile: %#v", binding)
+	}
+	if binding.ProfileRef != "team" {
+		t.Fatalf("binding lost its Profile reference: %#v", binding)
+	}
+	// The Agent's own config has to move too, or the UI reports the new Provider
+	// while the Agent still talks to the old endpoint.
+	written, err := os.ReadFile(filepath.Join(home, ".codex", "config.toml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(written), "https://api.novita.ai/openai") {
+		t.Fatalf("Agent config kept the old endpoint: %s", written)
+	}
+}
+
+// A label-only edit must not churn Agent configs: rewriting them would restart
+// the Agent's file for no reason and report a reapply the user did not ask for.
+func TestSaveProfileLeavesBindingsAloneWhenRoutingIsUnchanged(t *testing.T) {
+	home := t.TempDir()
+	core := activationCore(t, home, provider.NewClient(nil), "linux")
+	if _, err := core.SaveProfile(context.Background(), SaveProfileOptions{
+		ID: "team", Provider: "ppio", Model: "model-a", ConfigMode: "provider",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := core.ActivateAgent(context.Background(), ActivateAgentOptions{
+		AgentID: "codex", Provider: "ppio", APIKey: "key", Model: "model-a", ProfileID: "team",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	result, err := core.SaveProfile(context.Background(), SaveProfileOptions{
+		ID: "team", Label: "Renamed", Provider: "ppio", Model: "model-a", ConfigMode: "provider",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Reapplied) != 0 || len(result.Failures) != 0 {
+		t.Fatalf("a label edit reapplied Agents: %#v", result)
 	}
 }
 

--- a/internal/app/status.go
+++ b/internal/app/status.go
@@ -508,18 +508,28 @@ type SaveProfileOptions struct {
 	Protocol   string
 }
 
-func (u *UseCases) SaveProfile(ctx context.Context, options SaveProfileOptions) (ProfileSummary, error) {
+// SaveProfileResult reports which Agents followed the Profile to its new
+// Provider or model, mirroring SaveProviderResult. Reapply failures are returned
+// per Agent rather than failing the save: the Profile record on disk is already
+// correct, and reverting it would lose the edit.
+type SaveProfileResult struct {
+	Profile   ProfileSummary    `json:"profile"`
+	Reapplied []string          `json:"reapplied"`
+	Failures  map[string]string `json:"failures"`
+}
+
+func (u *UseCases) SaveProfile(ctx context.Context, options SaveProfileOptions) (SaveProfileResult, error) {
 	if u == nil {
-		return ProfileSummary{}, oneerrors.New(oneerrors.InternalError, "Profile service is not configured", oneerrors.WithStatus(501))
+		return SaveProfileResult{}, oneerrors.New(oneerrors.InternalError, "Profile service is not configured", oneerrors.WithStatus(501))
 	}
 	if err := ctx.Err(); err != nil {
-		return ProfileSummary{}, oneerrors.New(oneerrors.Timeout, "Profile request was cancelled", oneerrors.WithRetryable(true), oneerrors.WithCause(err))
+		return SaveProfileResult{}, oneerrors.New(oneerrors.Timeout, "Profile request was cancelled", oneerrors.WithRetryable(true), oneerrors.WithCause(err))
 	}
 	u.writeMu.Lock()
 	defer u.writeMu.Unlock()
 	target, err := u.providers.Resolve(options.Provider, options.APIBaseURL)
 	if err != nil {
-		return ProfileSummary{}, err
+		return SaveProfileResult{}, err
 	}
 	providedKey := options.APIKey
 	providerKey := providedKey
@@ -528,9 +538,10 @@ func (u *UseCases) SaveProfile(ctx context.Context, options SaveProfileOptions) 
 	}
 	if strings.TrimSpace(providerKey) != "" {
 		if err := u.providers.SaveKey(ctx, options.Provider, providerKey); err != nil {
-			return ProfileSummary{}, err
+			return SaveProfileResult{}, err
 		}
 	}
+	before := u.profileByID(options.ID)
 	stored, err := u.profiles.Save(ctx, profileStore.SaveRequest{
 		ID:       options.ID,
 		Label:    options.Label,
@@ -545,9 +556,64 @@ func (u *UseCases) SaveProfile(ctx context.Context, options SaveProfileOptions) 
 		Protocol:             options.Protocol,
 	})
 	if err != nil {
-		return ProfileSummary{}, err
+		return SaveProfileResult{}, err
 	}
-	return profileSummary(stored), nil
+	result := SaveProfileResult{Profile: profileSummary(stored)}
+	result.Reapplied, result.Failures, err = u.reapplyProfileLocked(ctx, before, stored)
+	if err != nil {
+		return result, err
+	}
+	return result, nil
+}
+
+// reapplyProfileLocked carries a Profile edit through to the Agents bound to it.
+// Without this a Profile could be switched to another Provider while every Agent
+// following it stayed pointed at the old endpoint -- the Profile page showed the
+// new Provider, the Agent kept sending traffic to the old one, and neither
+// Provider card listed the Agent correctly. Callers must hold writeMu.
+func (u *UseCases) reapplyProfileLocked(ctx context.Context, before, after profileStore.Profile) ([]string, map[string]string, error) {
+	model := ""
+	if after.Model != nil {
+		model = strings.TrimSpace(*after.Model)
+	}
+	previousModel := ""
+	if before.Model != nil {
+		previousModel = strings.TrimSpace(*before.Model)
+	}
+	// Nothing an Agent config carries has changed. A label or config-mode edit
+	// leaves every binding correct, so there is nothing to rewrite.
+	if before.ID == after.ID && before.Provider == after.Provider && previousModel == model {
+		return nil, nil, nil
+	}
+	// A Profile with no model cannot produce a valid binding: WriteAgentBinding
+	// requires one, and activation refuses an empty model. Leave the bindings as
+	// they are rather than failing every one of them.
+	if model == "" {
+		return nil, nil, nil
+	}
+	target, err := u.providers.Get(after.Provider)
+	if err != nil {
+		return nil, nil, err
+	}
+	return u.reapplyBindingsLocked(ctx, func(binding profileStore.AgentBinding) bool {
+		return binding.ProfileRef == after.ID
+	}, func(profileStore.AgentBinding) (provider.Entry, string) {
+		return target, model
+	})
+}
+
+func (u *UseCases) profileByID(id string) profileStore.Profile {
+	id = strings.TrimSpace(id)
+	profiles, err := u.profiles.List()
+	if err != nil {
+		return profileStore.Profile{}
+	}
+	for _, saved := range profiles {
+		if saved.ID == id {
+			return saved
+		}
+	}
+	return profileStore.Profile{}
 }
 
 func (u *UseCases) DeleteProfile(ctx context.Context, id string) error {

--- a/internal/app/status_test.go
+++ b/internal/app/status_test.go
@@ -148,7 +148,7 @@ func TestSaveProfileUseCaseWritesOnlyPublicSummary(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if summary.ID != "team" || summary.Protocol != "openai" {
+	if summary.Profile.ID != "team" || summary.Profile.Protocol != "openai" {
 		t.Fatalf("saved summary = %#v", summary)
 	}
 	if err := core.providers.SaveKey(context.Background(), "ppio", "new-provider-key"); err != nil {

--- a/internal/binding/services.go
+++ b/internal/binding/services.go
@@ -451,12 +451,12 @@ func (s *ProfileService) ListProfiles(ctx context.Context) ([]app.ProfileSummary
 	return s.core.ListProfiles(ctx)
 }
 
-func (s *ProfileService) SaveProfile(ctx context.Context, request SaveProfileRequest) (app.ProfileSummary, error) {
+func (s *ProfileService) SaveProfile(ctx context.Context, request SaveProfileRequest) (app.SaveProfileResult, error) {
 	if err := contextError(ctx); err != nil {
-		return app.ProfileSummary{}, err
+		return app.SaveProfileResult{}, err
 	}
 	if s == nil || s.core == nil {
-		return app.ProfileSummary{}, notReady("Profile service is not configured")
+		return app.SaveProfileResult{}, notReady("Profile service is not configured")
 	}
 	return s.core.SaveProfile(ctx, app.SaveProfileOptions{
 		ID:         request.ID,

--- a/internal/binding/services_test.go
+++ b/internal/binding/services_test.go
@@ -272,7 +272,7 @@ func TestProfileServiceSavesWithoutReturningSecret(t *testing.T) {
 		APIKey:     "sk-secret",
 		ConfigMode: "provider",
 	})
-	if err != nil || summary.ID != "team" {
+	if err != nil || summary.Profile.ID != "team" {
 		t.Fatalf("saved profile = %#v, err=%v", summary, err)
 	}
 	wire, err := json.Marshal(summary)


### PR DESCRIPTION
Two commits, reviewable independently.

## fix: carry a Profile edit through to the Agents bound to it

Closes #148.

Switching a Profile's Provider left every Agent following it bound to the old one. `SaveProfile` wrote the Profile record and stopped — no binding rewrite, no reactivation. `SaveProvider` has had the matching path all along ([provider.go:197](internal/app/provider.go#L197) walks the bindings and rewrites every Agent pointed at the edited Provider), so this was a missing counterpart rather than a design choice. `DeleteProfile` already refuses to delete an in-use Profile by matching `profile_ref`, which shows the backend knew the relationship; the save path just never used it.

The consequence was worse than a display bug: the Profile page showed the new Provider while the Agent's `~/.codex/config.toml` still carried the old `base_url`, so the Agent kept sending traffic to the old endpoint.

The per-Agent dispatch is identical for a Provider edit and a Profile edit — managed CLI Agents go through activation, desktop Agents split three ways by definition — so it moves into `reapplyBindingsLocked`, parameterized by which bindings to select and what to write. `SaveProfile` returns `SaveProfileResult` mirroring `SaveProviderResult`, and the Profiles page reports which Agents moved.

Two cases deliberately skip reapply: an edit leaving provider, model and ID untouched (a rename would otherwise churn Agent configs and report a reapply nobody asked for), and a Profile with no model, which cannot produce a valid binding since `WriteAgentBinding` requires one.

## style: give Provider and Profile cards the Agent card surface

The three entity cards disagreed on border, radius, title size, padding and chip shape. The missing border mattered most — `--surface-subtle` on `--window-bg` is 1.19:1 in dark and 1.07:1 in light, not enough on its own to mark a card edge.

Two problems found by measuring in the browser rather than reading CSS:

- The card lists ran the full pane while the Agent row is capped at 1040px, so on a 1440px window their right edges sat **124px** apart, and the gap grew with window width. Both now share `--card-measure`.
- Long unbroken content escaped the card instead of widening it, since the grid column is fixed. A Provider name with no spaces overflowed its header by 184px and printed over the edit and delete buttons. Titles and chips now truncate.

Also renames `.provider-user-chip` to `.card-user-chip`: the Profile card was borrowing the Provider chip, so narrowing one would have reshaped a card on another page.

The footer add button goes blue on the two management pages whose footer has no primary button. `AgentProfilePage` and `ProfileSelectionPage` keep theirs secondary — "应用" and "继续" are the real forward actions there, and two blue buttons side by side would compete.

## Testing

- `go test ./...` — all packages pass
- `go vet ./...`, `gofmt -l` — clean
- `pnpm test` — 338 passed (43 files), up from 336
- `pnpm run typecheck` — clean
- `task package` — builds; ran the resulting `OneAgent.app` on macOS 15 arm64
- The #148 regression test asserts the binding **and** the written config file, not just that `SaveProfile` returns no error. Confirmed it fails with the fix removed — the pre-existing `TestSaveProfileCanSwitchAKeylessProfileProvider` walked the same path but only asserted no error, which is why the bug survived a green suite.
- Card geometry verified at 900 / 1440 / 1920 px and in both themes; alignment offset is now 0.

## Note

Wails TS bindings under `frontend/bindings/` are regenerated output (`task generate:bindings`), included because the `SaveProfile` return type changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
