### PR TITLE
fix: update with mirror

### DIFF
--- a/frontend/src/components/DownloadProgress.tsx
+++ b/frontend/src/components/DownloadProgress.tsx
@@ -13,7 +13,7 @@ function megabytes(bytes: number): string {
  * A download whose server sent no Content-Length gets an indeterminate bar
  * rather than a percentage computed from a zero total.
  */
-export function DownloadProgress({ target, pending = false }: { target: string; pending?: boolean }) {
+export function DownloadProgress({ target, pending = false, showSize = true }: { target: string; pending?: boolean; showSize?: boolean }) {
   const { t } = useI18n();
   const { progress, running } = useTaskCenter();
   const current = progress[target];
@@ -40,7 +40,7 @@ export function DownloadProgress({ target, pending = false }: { target: string; 
       >
         <span className="download-progress-fill" style={known ? { width: `${percent}%` } : undefined} />
       </div>
-      <small>
+      {showSize ? <small>
         {known
           ? t("已下载 {done} MB / {total} MB（{percent}%）", {
               done: megabytes(received),
@@ -48,7 +48,7 @@ export function DownloadProgress({ target, pending = false }: { target: string; 
               percent,
             })
           : t("已下载 {done} MB", { done: megabytes(received) })}
-      </small>
+      </small> : null}
     </div>
   );
 }

--- a/frontend/src/components/LogDisclosure.tsx
+++ b/frontend/src/components/LogDisclosure.tsx
@@ -3,13 +3,13 @@ import { useEffect, useState } from "react";
 
 import { useI18n } from "../i18n";
 
-export function LogDisclosure({ log, open: openByParent = false }: { log: string; open?: boolean }) {
+export function LogDisclosure({ log, open: openByParent = false, showEmpty = false }: { log: string; open?: boolean; showEmpty?: boolean }) {
   const { t } = useI18n();
   const [open, setOpen] = useState(openByParent);
   useEffect(() => {
     if (openByParent) setOpen(true);
   }, [openByParent]);
-  if (!log) return null;
+  if (!log && !showEmpty) return null;
   return (
     <section className={`log-disclosure${open ? " is-open" : ""}`}>
       <button type="button" onClick={() => setOpen((value) => !value)} aria-expanded={open}>

--- a/frontend/src/pages/InstallTaskPage.test.tsx
+++ b/frontend/src/pages/InstallTaskPage.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { describe, expect, it, vi } from "vitest";
 
@@ -57,7 +57,6 @@ describe("InstallTaskPage update route", () => {
       </MemoryRouter>,
     );
     expect(screen.getByText("更新完成 · 更新 OpenClaw")).toBeTruthy();
-    fireEvent.click(screen.getByRole("button", { name: "查看安装日志" }));
     expect(screen.getByText(/npm update -g openclaw/)).toBeTruthy();
   });
 });

--- a/frontend/src/pages/InstallTaskPage.test.tsx
+++ b/frontend/src/pages/InstallTaskPage.test.tsx
@@ -1,13 +1,15 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { describe, expect, it, vi } from "vitest";
 
 // No I18nProvider, so translate() returns the Chinese keys unchanged.
 import { InstallTaskPage } from "./InstallTaskPage";
 
+const mockUseTaskCenter = vi.hoisted(() => vi.fn(() => ({ tasks: [], cancelTask: vi.fn(), dismissTask: vi.fn(), progress: {}, running: {} })));
+
 vi.mock("../state/TaskCenterContext", async (importOriginal) => ({
   ...await importOriginal<typeof import("../state/TaskCenterContext")>(),
-  useTaskCenter: () => ({ tasks: [], cancelTask: vi.fn(), dismissTask: vi.fn(), progress: {}, running: false }),
+  useTaskCenter: mockUseTaskCenter,
 }));
 
 describe("InstallTaskPage without a matching task", () => {
@@ -26,5 +28,36 @@ describe("InstallTaskPage without a matching task", () => {
     expect(screen.getByText("暂无任务")).toBeTruthy();
     expect(screen.getByText(/安装结果请在环境总览中查看/)).toBeTruthy();
     expect(screen.getByRole("button", { name: "进入总览" })).toBeTruthy();
+  });
+});
+
+describe("InstallTaskPage update route", () => {
+  it("renders a completed update task and its log", () => {
+    mockUseTaskCenter.mockReturnValue({
+      tasks: [{
+        id: "update:openclaw",
+        kind: "update",
+        target: "openclaw",
+        title: "更新 OpenClaw",
+        route: "/tasks/update/openclaw",
+        progressTarget: "openclaw",
+        state: "success",
+        message: "更新完成",
+        log: "$ npm update -g openclaw\nupdated\n",
+        startedAt: 1,
+      }],
+      cancelTask: vi.fn(),
+      dismissTask: vi.fn(),
+      progress: {},
+      running: {},
+    } as never);
+    render(
+      <MemoryRouter initialEntries={["/tasks/update/openclaw"]}>
+        <Routes><Route path="/tasks/update/:agentId" element={<InstallTaskPage />} /></Routes>
+      </MemoryRouter>,
+    );
+    expect(screen.getByText("更新完成 · 更新 OpenClaw")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "查看安装日志" }));
+    expect(screen.getByText(/npm update -g openclaw/)).toBeTruthy();
   });
 });

--- a/frontend/src/pages/InstallTaskPage.test.tsx
+++ b/frontend/src/pages/InstallTaskPage.test.tsx
@@ -57,6 +57,7 @@ describe("InstallTaskPage update route", () => {
       </MemoryRouter>,
     );
     expect(screen.getByText("更新完成 · 更新 OpenClaw")).toBeTruthy();
+    expect(screen.queryByText(/已下载/)).toBeNull();
     expect(screen.getByText(/npm update -g openclaw/)).toBeTruthy();
   });
 });

--- a/frontend/src/pages/InstallTaskPage.tsx
+++ b/frontend/src/pages/InstallTaskPage.tsx
@@ -1,4 +1,4 @@
-import { useNavigate, useParams } from "react-router-dom";
+import { useLocation, useNavigate, useParams } from "react-router-dom";
 
 import { DownloadProgress } from "../components/DownloadProgress";
 import { LogDisclosure } from "../components/LogDisclosure";
@@ -9,7 +9,9 @@ import { installTaskRoute, useTaskCenter } from "../state/TaskCenterContext";
 export function InstallTaskPage() {
   const { t } = useI18n();
   const navigate = useNavigate();
-  const { agentId = "", kind = "install" } = useParams();
+  const location = useLocation();
+  const { agentId = "" } = useParams();
+  const kind = location.pathname.startsWith("/tasks/update/") ? "update" : "install";
   const { tasks, cancelTask, dismissTask } = useTaskCenter();
   const target = decodeURIComponent(agentId);
   const task = tasks.find((item) => item.kind === kind && item.target === target);

--- a/frontend/src/pages/InstallTaskPage.tsx
+++ b/frontend/src/pages/InstallTaskPage.tsx
@@ -42,8 +42,8 @@ export function InstallTaskPage() {
       onPrimary={() => navigate("/overview")}
       footerNote={running ? t("请保持此窗口打开") : undefined}
     >
-      {task.progressTarget ? <DownloadProgress target={task.progressTarget} pending={running} /> : null}
-      <LogDisclosure log={task.log || ""} open />
+      {task.progressTarget ? <DownloadProgress target={task.progressTarget} pending={running} showSize={task.kind === "download"} /> : null}
+      <LogDisclosure log={task.log || ""} open showEmpty={task.kind !== "download"} />
       {running ? (
         <button className="button button-secondary task-close-action" type="button" onClick={() => cancelTask(task.id)}>{t("取消任务")}</button>
       ) : (

--- a/frontend/src/pages/InstallTaskPage.tsx
+++ b/frontend/src/pages/InstallTaskPage.tsx
@@ -43,11 +43,11 @@ export function InstallTaskPage() {
       footerNote={running ? t("请保持此窗口打开") : undefined}
     >
       {task.progressTarget ? <DownloadProgress target={task.progressTarget} pending={running} /> : null}
-      <LogDisclosure log={task.log || ""} open={running} />
+      <LogDisclosure log={task.log || ""} open />
       {running ? (
-        <button className="button button-secondary" type="button" onClick={() => cancelTask(task.id)}>{t("取消任务")}</button>
+        <button className="button button-secondary task-close-action" type="button" onClick={() => cancelTask(task.id)}>{t("取消任务")}</button>
       ) : (
-        <button className="button button-secondary" type="button" onClick={() => { dismissTask(task.id); navigate("/overview"); }}>{t("关闭任务")}</button>
+        <button className="button button-secondary task-close-action" type="button" onClick={() => { dismissTask(task.id); navigate("/overview"); }}>{t("关闭任务")}</button>
       )}
     </PageScaffold>
   );

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -1106,6 +1106,8 @@
   overflow-wrap: anywhere;
 }
 
+.task-close-action { margin-top: 12px; }
+
 .summary-item {
   min-width: 0;
   min-height: 86px;

--- a/internal/app/install_test.go
+++ b/internal/app/install_test.go
@@ -52,10 +52,11 @@ func TestInstallResultWirePreservesFieldPresence(t *testing.T) {
 }
 
 type installAppRunner struct {
-	paths   map[string]string
-	calls   [][]string
-	envs    []map[string]string
-	started [][]string
+	paths    map[string]string
+	calls    [][]string
+	envs     []map[string]string
+	started  [][]string
+	exitCode int
 }
 
 func (r *installAppRunner) Start(argv []string, _ map[string]string) error {
@@ -76,7 +77,7 @@ func (r *installAppRunner) Run(_ context.Context, argv []string, env map[string]
 	if len(argv) > 1 && argv[1] == "--version" {
 		return process.Result{Args: argv, ExitCode: 0, Stdout: "tool 1.0.0"}, nil
 	}
-	return process.Result{Args: argv, ExitCode: 0}, nil
+	return process.Result{Args: argv, ExitCode: r.exitCode}, nil
 }
 
 type installAppDoer func(*http.Request) (*http.Response, error)

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/MaimoryLab/OneAgent/internal/catalog"
@@ -63,8 +64,12 @@ func (u *UseCases) UpdateAgent(ctx context.Context, agentID string, listeners ..
 		}
 		args = append(args, "--registry="+registry)
 	}
-	if _, err := runtime.Run(ctx, args, install.NPMEnvironment(runtime, npm, registry), install.DefaultCommandTimeout); err != nil {
+	result, err := runtime.Run(ctx, args, install.NPMEnvironment(runtime, npm, registry), install.DefaultCommandTimeout)
+	if err != nil {
 		return AgentUpdateResult{}, oneerrors.New(oneerrors.InternalError, "Unable to update "+agent.Name, oneerrors.WithStatus(500), oneerrors.WithRetryable(true), oneerrors.WithCause(err))
+	}
+	if result.ExitCode != 0 {
+		return AgentUpdateResult{}, oneerrors.New(oneerrors.AgentInstallFailed, fmt.Sprintf("Unable to update %s: command exited with code %d", agent.Name, result.ExitCode), oneerrors.WithRetryable(true))
 	}
 	return AgentUpdateResult{Agent: agentID, Package: agent.Package.Name, Command: strings.Join(args, " ")}, nil
 }

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -57,6 +57,10 @@ func (u *UseCases) UpdateAgent(ctx context.Context, agentID string, listeners ..
 	args := []string{npm, "update", "-g", agent.Package.Name}
 	registry := u.packageRegistry(ctx, "")
 	if registry != "" {
+		registry, err = install.ResolveRegistry(registry)
+		if err != nil {
+			return AgentUpdateResult{}, err
+		}
 		args = append(args, "--registry="+registry)
 	}
 	if _, err := runtime.Run(ctx, args, install.NPMEnvironment(runtime, npm, registry), install.DefaultCommandTimeout); err != nil {

--- a/internal/app/update_test.go
+++ b/internal/app/update_test.go
@@ -1,0 +1,26 @@
+package app
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	"github.com/MaimoryLab/OneAgent/internal/platform"
+)
+
+func TestUpdateAgentResolvesMirrorRegistry(t *testing.T) {
+	home := t.TempDir()
+	runner := &installAppRunner{paths: map[string]string{"npm": "/fake/npm", "codex": "/fake/codex"}}
+	core := NewUseCases(StatusOptions{Home: home, Platform: platform.For("linux", "amd64"), Runner: runner})
+	if _, err := core.SaveSettings(context.Background(), Settings{PreferMirror: true}); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := core.UpdateAgent(context.Background(), "codex"); err != nil {
+		t.Fatal(err)
+	}
+	const registry = "https://registry.npmmirror.com/"
+	if !slices.Contains(runner.calls[0], "--registry="+registry) || runner.envs[0]["npm_config_registry"] != registry {
+		t.Fatalf("update call = %v env = %v, want resolved mirror registry", runner.calls[0], runner.envs[0])
+	}
+}

--- a/internal/app/update_test.go
+++ b/internal/app/update_test.go
@@ -5,6 +5,7 @@ import (
 	"slices"
 	"testing"
 
+	oneerrors "github.com/MaimoryLab/OneAgent/internal/errors"
 	"github.com/MaimoryLab/OneAgent/internal/platform"
 )
 
@@ -22,5 +23,15 @@ func TestUpdateAgentResolvesMirrorRegistry(t *testing.T) {
 	const registry = "https://registry.npmmirror.com/"
 	if !slices.Contains(runner.calls[0], "--registry="+registry) || runner.envs[0]["npm_config_registry"] != registry {
 		t.Fatalf("update call = %v env = %v, want resolved mirror registry", runner.calls[0], runner.envs[0])
+	}
+}
+
+func TestUpdateAgentFailsOnNonZeroExitCode(t *testing.T) {
+	home := t.TempDir()
+	runner := &installAppRunner{paths: map[string]string{"npm": "/fake/npm", "codex": "/fake/codex"}, exitCode: 1}
+	core := NewUseCases(StatusOptions{Home: home, Platform: platform.For("linux", "amd64"), Runner: runner})
+
+	if _, err := core.UpdateAgent(context.Background(), "codex"); err == nil || oneerrors.As(err).Code != oneerrors.AgentInstallFailed {
+		t.Fatalf("non-zero update exit should fail, got %v", err)
 	}
 }

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -138,7 +138,11 @@ func InstallAgent(ctx context.Context, runtime Runtime, agent catalog.Agent, opt
 	}
 	current := ""
 	if executable != "" {
-		current = InstalledVersion(ctx, runtime, agent)
+		var versionErr error
+		current, versionErr = installedVersion(ctx, runtime, agent)
+		if versionErr != nil {
+			return Result{}, oneerrors.New(oneerrors.AgentInstallFailed, fmt.Sprintf("%s version check failed", agent.Name), oneerrors.WithRetryable(true), oneerrors.WithCause(versionErr))
+		}
 		if version == "" || current == version {
 			result.Version = current
 			return result, nil
@@ -222,10 +226,35 @@ func InstallAgent(ctx context.Context, runtime Runtime, agent catalog.Agent, opt
 	result.Installed = true
 	result.Version = version
 	if result.Version == "" {
-		result.Version = InstalledVersion(ctx, runtime, agent)
+		result.Version, runErr = installedVersion(ctx, runtime, agent)
+		if runErr != nil {
+			return Result{}, oneerrors.New(oneerrors.AgentInstallFailed, fmt.Sprintf("%s version check failed", agent.Name), oneerrors.WithRetryable(true), oneerrors.WithCause(runErr))
+		}
 	}
 	result.Registry = registry
 	return result, nil
+}
+
+func installedVersion(ctx context.Context, runtime Runtime, agent catalog.Agent) (string, error) {
+	if agent.Command == "" || runtime.Runner == nil {
+		return "", nil
+	}
+	executable, ok := runtime.Runner.LookPath(agent.Command)
+	if !ok || executable == "" {
+		return "", nil
+	}
+	args := append([]string{executable}, agent.VersionArgs...)
+	if len(agent.VersionArgs) == 0 {
+		args = append(args, "--version")
+	}
+	result, err := runtime.command(ctx, args, nil, VersionCommandTimeout)
+	if err != nil {
+		return "", err
+	}
+	if result.ExitCode != 0 {
+		return "", fmt.Errorf("exit code %d", result.ExitCode)
+	}
+	return VersionFromOutput(result.Stdout + "\n" + result.Stderr), nil
 }
 
 func requirePrerequisites(runtime Runtime, agent catalog.Agent) error {


### PR DESCRIPTION
## Summary

* fixed an error when updating npm-managed agents with mirror
* improved update log display
* correctly parse command exit status to task status


## Verification

<!-- List the exact commands and manual checks you ran. If a check was not applicable or could not run, say why. -->

- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is explained.
- [x] Relevant Go, frontend, documentation, and release-compliance checks pass locally.
- [x] UI changes include screenshots or a short recording, or this change has no UI impact.


## Change checklist

- [x] No API key, token, private configuration, or sensitive path is present in code, logs, screenshots, fixtures, or issue links.
- [x] No Wails DTO or service changed, or `frontend/bindings`, `frontend/src/backend/wails.ts`, and handwritten API types were synchronized.
- [x] No documented user-visible behavior changed, or `README.md` and `README_ZH.md` were updated together.
- [x] No distributed dependency or third-party mark was added, or `NOTICE` was updated.
- [x] Public documentation is in English; `AGENTS.md` and `docs/internal/` remain in Chinese.
