### PR TITLE
fix: give Provider and Profile cards a consistent height

### DIFF
--- a/frontend/src/components/CardUsers.test.tsx
+++ b/frontend/src/components/CardUsers.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { CardUsers } from "./CardUsers";
+import { I18nProvider } from "../i18n";
+
+function show(count: number) {
+  const users = Array.from({ length: count }, (_, index) => ({ id: `a${index}`, name: `Agent ${index}` }));
+  render(<I18nProvider><CardUsers users={users} /></I18nProvider>);
+}
+
+describe("CardUsers", () => {
+  it("names every Agent while they fit", () => {
+    show(3);
+    expect(screen.getByText("Agent 0")).toBeTruthy();
+    expect(screen.getByText("Agent 2")).toBeTruthy();
+    expect(screen.queryByText(/^\+/)).toBeNull();
+  });
+
+  // The cap is a layout constraint, not a stylistic one: .card-users wraps, so an
+  // uncapped list added a row of chips at a time and a bound card grew taller than
+  // an unbound one in the same grid row. Asserting the chip count -- not just the
+  // "+N" label -- is what keeps that from regressing.
+  it("collapses the rest into +N once past three", () => {
+    show(8);
+    const chips = document.querySelectorAll(".card-user-chip");
+    expect(chips.length).toBe(4);
+    expect(screen.getByText("+5")).toBeTruthy();
+    expect(screen.queryByText("Agent 3")).toBeNull();
+  });
+
+  it("keeps the hidden names recoverable on hover", () => {
+    show(6);
+    const overflow = document.querySelector(".card-user-chip.is-overflow");
+    expect(overflow?.getAttribute("title")).toContain("Agent 5");
+  });
+
+  it("says so when nothing is bound", () => {
+    show(0);
+    expect(document.querySelector(".card-users.is-empty")).toBeTruthy();
+    expect(document.querySelectorAll(".card-user-chip").length).toBe(0);
+  });
+});

--- a/frontend/src/components/CardUsers.tsx
+++ b/frontend/src/components/CardUsers.tsx
@@ -1,0 +1,47 @@
+import { useI18n } from "../i18n";
+
+/** How many Agent chips a card shows before the rest collapse into "+N".
+ *
+ *  Three matches requiredByHint in internal/app/runtime.go, which renders
+ *  "A, B, C +2" for the same kind of list. One convention for "too many to
+ *  name" is worth more than a per-page choice.
+ *
+ *  The cap exists for layout, not brevity: .card-users wraps, so an uncapped
+ *  list grew the card by a row of chips at a time. With eight configurable
+ *  Agents that reached +36px, which is what made a bound card tower over an
+ *  unbound one in the same grid row. */
+const VISIBLE_CHIPS = 3;
+
+export interface CardUser {
+  id: string;
+  name: string;
+}
+
+/** The Agent chips on a Provider or Profile card.
+ *
+ *  Shared rather than duplicated per page: both cards sit in grids that use the
+ *  same rule (.provider-list / .profile-list), so a change to how many chips a
+ *  card shows has to reach both or the two pages drift apart. */
+export function CardUsers({ users }: { users: readonly CardUser[] }) {
+  const { locale, t } = useI18n();
+  if (!users.length) {
+    return <span className="card-users is-empty">{t("暂无 Agent 使用")}</span>;
+  }
+  const shown = users.slice(0, VISIBLE_CHIPS);
+  const hidden = users.slice(VISIBLE_CHIPS);
+  return (
+    <span className="card-users">
+      {shown.map((user) => (
+        <span className="card-user-chip" key={user.id}>{user.name}</span>
+      ))}
+      {hidden.length ? (
+        // title, not a tooltip component: the names are the only thing the
+        // collapsed chip hides, and they are worth recovering on hover without
+        // adding an interactive control to a card that is already dense.
+        <span className="card-user-chip is-overflow" title={hidden.map((user) => user.name).join(locale === "en" ? ", " : "、")}>
+          +{hidden.length}
+        </span>
+      ) : null}
+    </span>
+  );
+}

--- a/frontend/src/pages/ProfilesPage.tsx
+++ b/frontend/src/pages/ProfilesPage.tsx
@@ -3,6 +3,7 @@ import { useState, type FormEvent } from "react";
 import { useNavigate } from "react-router-dom";
 
 import { api, describeFailure, isCancellationError } from "../backend/api";
+import { CardUsers } from "../components/CardUsers";
 import { PageScaffold } from "../components/PageScaffold";
 import { ProviderModelPicker } from "../components/ProviderModelPicker";
 import { ProviderSegment } from "../components/ProviderSegment";
@@ -470,11 +471,7 @@ export function ProfilesPage() {
                   API mode: {protocolOf(profile) || "-"}
                 </p>
                 <footer>
-                  {users.length ? (
-                    <span className="card-users">
-                      {users.map((agent) => <span className="card-user-chip" key={agent.id}>{agent.name}</span>)}
-                    </span>
-                  ) : <span className="card-users is-empty">{t("暂无 Agent 使用")}</span>}
+                  <CardUsers users={users} />
                   <button
                     className="button button-secondary"
                     type="button"

--- a/frontend/src/pages/ProvidersPage.tsx
+++ b/frontend/src/pages/ProvidersPage.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState, type FormEvent } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 
 import { api, describeFailure } from "../backend/api";
+import { CardUsers } from "../components/CardUsers";
 import { PageScaffold } from "../components/PageScaffold";
 import { SecureKeyField } from "../components/SecureKeyField";
 import { useI18n } from "../i18n";
@@ -280,16 +281,22 @@ export function ProvidersPage({ create = false }: { create?: boolean }) {
                   ) : null}
                 </span>
               </header>
+              {/* The Anthropic row always occupies its slot. It used to render
+                  only when the endpoint was set, which made an OpenAI-only
+                  Provider one row shorter than its neighbours in the same grid
+                  row. Stating the absence also answers the question the missing
+                  row left the user to infer. */}
               <dl className="provider-endpoints">
                 <div><dt>{t("OpenAI 兼容")}</dt><dd>{meta.base_url}</dd></div>
-                {meta.anthropic_base_url ? <div><dt>{t("Anthropic 兼容")}</dt><dd>{meta.anthropic_base_url}</dd></div> : null}
+                <div>
+                  <dt>{t("Anthropic 兼容")}</dt>
+                  {meta.anthropic_base_url
+                    ? <dd>{meta.anthropic_base_url}</dd>
+                    : <dd className="is-unsupported">{t("不支持")}</dd>}
+                </div>
               </dl>
               <footer>
-                {users.length ? (
-                  <span className="card-users">
-                    {users.map((agentId) => <span className="card-user-chip" key={agentId}>{nameOf(agentId)}</span>)}
-                  </span>
-                ) : <span className="card-users is-empty">{t("暂无 Agent 使用")}</span>}
+                <CardUsers users={users.map((agentId) => ({ id: agentId, name: nameOf(agentId) }))} />
                 <span className={`provider-key-state${meta.has_key ? " has-key" : ""}`}>
                   <KeyRound size={12} />{meta.has_key ? t("已保存 Key") : t("未保存 Key")}
                 </span>

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -1940,6 +1940,11 @@
   white-space: nowrap;
 }
 
+/* An absent endpoint is stated rather than omitted, so it must not read as a URL:
+   the tertiary colour is the same one .card-users.is-empty uses for "nothing
+   here". */
+.provider-endpoints dd.is-unsupported { color: var(--text-tertiary); }
+
 /* .card-users / .card-user-chip are shared by the Provider and Profile cards.
    Named for the role, not the page: the Profile card used to borrow
    .provider-user-chip, so narrowing the Provider chip would have reshaped a
@@ -1954,6 +1959,15 @@
 .card-users.is-empty {
   color: var(--text-tertiary);
   font-size: 11px;
+}
+
+/* The "+N" chip reads as a count rather than another Agent name, so it drops the
+   chip border and carries the muted colour the empty state already uses. */
+.card-user-chip.is-overflow {
+  border-color: transparent;
+  background: none;
+  padding-inline: 2px;
+  color: var(--text-tertiary);
 }
 
 /* Matched to .agent-manage-pill -- same border, padding and radius. Without the


### PR DESCRIPTION
Closes #164.

## What was wrong

Cards in the same grid row had visibly different bottom edges. Measured at 1280px before the change:

```
第 1 行:  DeepSeek 124px  |  Moonshot 104px   <- same row, 20px apart
第 2 行:  Novita   124px  |  PPIO     124px
```

Two independent variables fed the height, and the worst realistic combination was **129px vs 185px — a 1.43× spread**.

## Why not `align-items: stretch`

Switching the grid to `stretch` does equalize the row, and I verified that (`[124, 104, 124, 124]` → `[124, 124, 124, 124]`). I did not take it, for two reasons:

- It only moves the whitespace *inside* the shorter card. The mismatch becomes a blank strip rather than a ragged edge.
- It makes the tallest card set the row. One Provider with eight bound Agents would drag its whole row to 185px, and the empty cards next to it would show a large void — worse than the original problem.

The two variables are removed instead, so the heights match without the grid having to force them. The existing `align-items: start` and the comment defending it stay as they are, and remain correct.

## Change 1 — the Anthropic row always occupies its slot (worth 20px)

It previously rendered only when `anthropic_base_url` was set, so an OpenAI-only Provider was one row shorter. It now shows `不支持` / `Unsupported` in the tertiary colour.

This has a second benefit beyond layout: the user could previously only infer "this Provider does not serve Anthropic" from a missing row. Now it says so.

```
Moonshot:  OpenAI 兼容      https://api.moonshot.cn
           Anthropic 兼容   不支持
```

## Change 2 — Agent chips cap at three, then "+N" (worth 36px, and unbounded)

`.card-users` wraps with no row limit, so height scaled with the number of bindings — with eight configurable Agents that is a real case, not a hypothetical. Chips now cap at three with the rest collapsed:

```
8 bound Agents  ->  3 chips + "+5"
```

Three matches `requiredByHint` in `internal/app/runtime.go:246`, which already renders `"A, B, C +2"` for the same kind of list. Reusing the existing convention seemed better than picking a second one. The hidden names stay recoverable from the chip's `title`.

## Both pages, one component

`#164` noted that `.profile-list` shares the grid rule with `.provider-list`. Both pages also had the same chip markup, so the chips move into a shared `CardUsers` component rather than being fixed twice — otherwise the next change to the cap reaches one page and not the other. The Profile card gets the cap for free.

## Verification

Measured in the running app, not inferred from CSS:

| viewport | columns | card heights | rows with mismatched heights |
| --- | --- | --- | --- |
| 700px | 1 | 144 / 144 / 144 / 144 | 0 |
| 1280px | 2 | 124 / 124 / 124 / 124 | 0 |
| 1900px | 3 | 144 / 144 / 144 / 144 | 0 |

No card overflows horizontally and the page has no horizontal scroll at 700px. Checked in **both locales**, since the absent-endpoint label is translated — English renders `Unsupported` and heights stay equal at 144px.

`go test ./...` 14 packages pass. Frontend: 346 tests across 44 files (4 new), `tsc --noEmit` clean, build clean, and all 6 Wails E2E specs pass.

The new `CardUsers` test asserts the **chip count**, not just the presence of the "+N" label — the cap is a layout constraint, and only counting the rendered chips catches a regression that keeps the label while uncapping the list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)