### PR TITLE
feat: verify a Provider's endpoint and key from its editor

### DIFF
--- a/frontend/bindings/github.com/MaimoryLab/OneAgent/internal/binding/models.ts
+++ b/frontend/bindings/github.com/MaimoryLab/OneAgent/internal/binding/models.ts
@@ -129,6 +129,15 @@ export interface ProbeRequest {
     "api_key": string;
     "model": string;
     "agents": string[] | null;
+
+    /**
+     * AnthropicBaseURL and Draft let the Provider editor test what is on screen
+     * before it is saved. Draft is explicit rather than inferred from a non-empty
+     * base URL: the wizard also sends a base URL, and silently switching it to
+     * draft resolution would stop it reading the stored record.
+     */
+    "anthropic_base_url": string;
+    "draft": boolean;
 }
 
 export interface ProbeResponse {

--- a/frontend/src/backend/wails.test.ts
+++ b/frontend/src/backend/wails.test.ts
@@ -141,7 +141,9 @@ describe("Wails backend adapter", () => {
     await expect(wailsApi.readTransferFile()).resolves.toBe("contents");
     await expect(wailsApi.writeTransferFile("contents")).resolves.toBeUndefined();
 
-    expect(bridge.probe).toHaveBeenCalledWith({ provider: "custom", api_base_url: "https://proxy.test/v1", api_key: "secret", model: "m", agents: null });
+    // The wizard names neither new field, so both must default: draft false keeps
+    // it resolving the stored Provider, which is what it relies on.
+    expect(bridge.probe).toHaveBeenCalledWith({ provider: "custom", api_base_url: "https://proxy.test/v1", api_key: "secret", model: "m", agents: null, anthropic_base_url: "", draft: false });
     expect(bridge.getProvider).toHaveBeenCalledWith({ id: "acme" });
     expect(bridge.deleteProvider).toHaveBeenCalledWith({ id: "acme" });
     // 0 means "use the Go default" rather than a duplicated number here.

--- a/frontend/src/backend/wails.ts
+++ b/frontend/src/backend/wails.ts
@@ -118,13 +118,26 @@ export const wailsApi = {
     call(() => DesktopAgentService.Open({ agent_id: agentId })).then(() => undefined),
   configureDesktopAgent: (agentId: string, profileId: string): CancellableRequest<DesktopAgentProfileResult> =>
     call(() => DesktopAgentService.Configure({ agent_id: agentId, profile_id: profileId })) as CancellableRequest<DesktopAgentProfileResult>,
-  probe: (input: { provider: ProviderId; apiBaseUrl: string; apiKey: string; model: string; agents?: string[] }): Promise<ProbeResponse> =>
+  probe: (input: {
+    provider: ProviderId;
+    apiBaseUrl: string;
+    apiKey: string;
+    model: string;
+    agents?: string[];
+    // Set by the Provider editor to test the endpoints and key on screen rather
+    // than the stored record. Defaulted here so the wizard's calls keep resolving
+    // from storage without naming either field.
+    anthropicBaseUrl?: string;
+    draft?: boolean;
+  }): Promise<ProbeResponse> =>
     call(() => ProviderService.Probe({
       provider: input.provider,
       api_base_url: input.apiBaseUrl,
       api_key: input.apiKey,
       model: input.model,
       agents: input.agents?.length ? input.agents : null,
+      anthropic_base_url: input.anthropicBaseUrl ?? "",
+      draft: input.draft ?? false,
     })) as Promise<ProbeResponse>,
   models: (input: { provider: ProviderId; apiBaseUrl: string; apiKey: string }): Promise<ModelsResponse> =>
     call(() => ProviderService.ListModels({

--- a/frontend/src/i18n.tsx
+++ b/frontend/src/i18n.tsx
@@ -148,6 +148,12 @@ const english = {
   "确认": "Review",
   "尚未测试连接": "Connection not tested",
   "正在验证端点和 Key": "Validating endpoint and key",
+  "验证可用性": "Test connection",
+  "验证中": "Testing",
+  "测试模型（可选）": "Test model (optional)",
+  "留空则自动选择": "Leave empty to choose automatically",
+  "仅用于本次验证，不会写入模型服务配置": "Used for this test only; never written to the Provider record",
+  "请先填写至少一个 Base URL": "Fill in at least one base URL first",
   "连接失败": "Connection failed",
   // Per-protocol verdicts. One failing protocol used to overwrite the single
   // reported result, hiding that another had passed.

--- a/frontend/src/pages/ProvidersPage.test.tsx
+++ b/frontend/src/pages/ProvidersPage.test.tsx
@@ -223,6 +223,82 @@ describe("ProvidersPage", () => {
     await waitFor(() => expect(save).toHaveBeenCalledWith(expect.objectContaining({ id: "acme", base_url: "https://api.acme.test", api_key: "sk-acme", create: true })));
   });
 
+  // The point of #157: the endpoint and key are entered here, so a wrong one
+  // should be caught here rather than only on the Agent page.
+  it("tests the endpoints and key currently in the editor without saving them", async () => {
+    const probe = vi.spyOn(api, "probe").mockResolvedValue({
+      ok: true, reachable: true, status: 200, message: "连接成功", error_code: null,
+      retryable: false, protocols: {}, model: "model-a", auto_selected_model: false,
+    });
+    const save = vi.spyOn(api, "saveProvider");
+    renderPage({ codex: null });
+    fireEvent.click(screen.getByRole("button", { name: "新增模型服务" }));
+    fireEvent.change(screen.getByLabelText("OpenAI 兼容 Base URL"), { target: { value: "https://api.acme.test" } });
+    fireEvent.change(screen.getByLabelText("Anthropic 兼容 Base URL"), { target: { value: "https://api.acme.test/anthropic" } });
+    fireEvent.change(screen.getByLabelText("API Key"), { target: { value: "sk-acme" } });
+    fireEvent.click(screen.getByRole("button", { name: /验证可用性/ }));
+
+    // draft: true is what lets an unsaved Provider be probed at all, and both
+    // endpoints travel so each field is tested against what the user typed.
+    await waitFor(() => expect(probe).toHaveBeenCalledWith(expect.objectContaining({
+      apiBaseUrl: "https://api.acme.test",
+      anthropicBaseUrl: "https://api.acme.test/anthropic",
+      apiKey: "sk-acme",
+      draft: true,
+    })));
+    await waitFor(() => expect(screen.getByText("连接成功")).toBeTruthy());
+    // The whole point of testing before saving: a key that turns out to be wrong
+    // must not have been written to disk on the way.
+    expect(save).not.toHaveBeenCalled();
+  });
+
+  it("sends an optional test model, and leaves it out of the saved record", async () => {
+    const probe = vi.spyOn(api, "probe").mockResolvedValue({
+      ok: true, reachable: true, status: 200, message: "连接成功", error_code: null,
+      retryable: false, protocols: {}, model: "typed-model", auto_selected_model: false,
+    });
+    const save = vi.spyOn(api, "saveProvider").mockResolvedValue({
+      entry: { id: "acme", name: "Acme", home: "", base_url: "https://api.acme.test", anthropic_base_url: "", api_key: "sk-acme", built_in: false },
+      reapplied: null, failures: null,
+    });
+    renderPage({ codex: null });
+    fireEvent.click(screen.getByRole("button", { name: "新增模型服务" }));
+    fireEvent.change(screen.getByLabelText("名称"), { target: { value: "Acme" } });
+    fireEvent.change(screen.getByLabelText("OpenAI 兼容 Base URL"), { target: { value: "https://api.acme.test" } });
+    fireEvent.change(screen.getByLabelText("测试模型（可选）"), { target: { value: "typed-model" } });
+    fireEvent.click(screen.getByRole("button", { name: /验证可用性/ }));
+    await waitFor(() => expect(probe).toHaveBeenCalledWith(expect.objectContaining({ model: "typed-model" })));
+
+    // The test model belongs to the test, not to the Provider: saving must not
+    // carry it into the stored record, which has no field for it.
+    fireEvent.click(screen.getByRole("button", { name: /^保存$/ }));
+    await waitFor(() => expect(save).toHaveBeenCalled());
+    expect(save.mock.calls[0][0]).not.toHaveProperty("model");
+  });
+
+  it("cannot test a Provider with no endpoint to test against", () => {
+    renderPage({ codex: null });
+    fireEvent.click(screen.getByRole("button", { name: "新增模型服务" }));
+    expect(screen.getByRole("button", { name: /验证可用性/ })).toBeDisabled();
+  });
+
+  it("reports a failed verification without blocking the save", async () => {
+    vi.spyOn(api, "probe").mockResolvedValue({
+      ok: false, reachable: true, status: 401, message: "unauthorized",
+      error_code: "API_KEY_REJECTED", retryable: false, protocols: {}, model: "model-a",
+      auto_selected_model: false,
+    });
+    renderPage({ codex: null });
+    fireEvent.click(screen.getByRole("button", { name: "新增模型服务" }));
+    fireEvent.change(screen.getByLabelText("OpenAI 兼容 Base URL"), { target: { value: "https://api.acme.test" } });
+    fireEvent.click(screen.getByRole("button", { name: /验证可用性/ }));
+
+    await waitFor(() => expect(screen.getByText(/API Key 被拒绝/)).toBeTruthy());
+    // A failed test is information, not a gate: the user may be saving a Provider
+    // whose key they will paste later.
+    expect(screen.getByRole("button", { name: /^保存$/ })).not.toBeDisabled();
+  });
+
   // The ID is a storage key the user should not have to invent, but a collision is
   // now refused rather than silently overwriting -- so the suggested value has to
   // be one that is actually free.

--- a/frontend/src/pages/ProvidersPage.tsx
+++ b/frontend/src/pages/ProvidersPage.tsx
@@ -1,15 +1,17 @@
-import { ExternalLink, KeyRound, Pencil, Plus, Save, Trash2, X } from "lucide-react";
+import { ExternalLink, FlaskConical, KeyRound, Pencil, Plus, Save, Trash2, X } from "lucide-react";
 import { useEffect, useRef, useState, type FormEvent } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 
 import { api, describeFailure } from "../backend/api";
+import { ConnectionStatus } from "../components/ConnectionStatus";
 import { PageScaffold } from "../components/PageScaffold";
 import { SecureKeyField } from "../components/SecureKeyField";
 import { useI18n } from "../i18n";
 import { confirmDelete } from "../state/confirmDelete";
 import { useWizard } from "../state/WizardContext";
 import { byProviderCreatedAt } from "../state/ranking";
-import type { ProviderEntry } from "../types/api";
+import type { AsyncState } from "../state/wizardReducer";
+import type { ProbeResponse, ProviderEntry } from "../types/api";
 
 const emptyProvider: ProviderEntry = {
   id: "",
@@ -53,6 +55,15 @@ export function ProvidersPage({ create = false }: { create?: boolean }) {
   const [busy, setBusy] = useState(false);
   const [failure, setFailure] = useState("");
   const [applied, setApplied] = useState("");
+  // Local rather than the wizard reducer's connection state: that one belongs to
+  // the setup flow, and sharing it would let a test here overwrite what the
+  // wizard is showing, and the reverse.
+  const [probeState, setProbeState] = useState<AsyncState>("idle");
+  const [probeResult, setProbeResult] = useState<ProbeResponse | null>(null);
+  // Optional. Empty means the backend picks one, and ConnectionStatus already
+  // explains a failure caused by an auto-selected model -- which is why this is
+  // not required to press the button.
+  const [probeModel, setProbeModel] = useState("");
   const requestedReturn = searchParams.get("returnTo");
   const requestedProvider = searchParams.get("provider");
   const returnTo = requestedReturn?.startsWith("/") && !requestedReturn.startsWith("//") ? requestedReturn : "/providers";
@@ -61,7 +72,38 @@ export function ProvidersPage({ create = false }: { create?: boolean }) {
   const nameOf = (agentId: string) =>
     status?.catalog.find((item) => item.id === agentId)?.name || agentId;
 
+  /**
+   * Which protocols the test covers, expressed as the Agent IDs the probe API
+   * takes. Derived from the endpoints the user filled in: an Anthropic base URL is
+   * only meaningful if something speaks Anthropic Messages to it.
+   *
+   * The Agent IDs are a means of naming protocols, not a claim about those Agents
+   * -- `protocolsForAgents` is the backend's only entry point for choosing them.
+   * An empty list would default to OpenAI alone, which would silently skip the
+   * Anthropic field.
+   */
+  const probeAgentIds = (() => {
+    if (!editor) return [];
+    const agents: string[] = [];
+    if (editor.base_url.trim()) agents.push("opencode");
+    if (editor.anthropic_base_url?.trim()) agents.push("claude-code");
+    return agents;
+  })();
+  // Nothing to test against: both endpoint fields are empty and this Provider has
+  // no stored endpoints to fall back on.
+  const canProbe = Boolean(editor && (probeAgentIds.length || (!creating && status?.providers[editor.id])));
+
+  // A result describes the values that produced it, so opening or closing the
+  // editor has to drop it rather than leave a verdict about another Provider on
+  // screen.
+  const clearProbe = () => {
+    setProbeState("idle");
+    setProbeResult(null);
+    setProbeModel("");
+  };
+
   const closeEditor = () => {
+    clearProbe();
     if (create) navigate(returnTo);
     else {
       setEditor(null);
@@ -73,6 +115,7 @@ export function ProvidersPage({ create = false }: { create?: boolean }) {
     setBusy(true);
     setFailure("");
     setApplied("");
+    clearProbe();
     try {
       setEditor(await api.getProvider(providerId));
       setCreating(false);
@@ -80,6 +123,44 @@ export function ProvidersPage({ create = false }: { create?: boolean }) {
       setFailure(describeFailure(error, t("无法读取模型服务"), t).message);
     } finally {
       setBusy(false);
+    }
+  };
+
+  /**
+   * Tests the endpoints and key currently in the editor, without saving them.
+   *
+   * `draft: true` is what makes that possible: the backend otherwise resolves the
+   * Provider from disk, so a new Provider could not be tested at all and an edited
+   * endpoint would be tested in its old form.
+   *
+   * Nothing is written here. The key travels to the local backend for the request
+   * and is persisted only when the user presses Save -- testing a key that turns
+   * out to be wrong must not leave it on disk.
+   */
+  const testConnection = async () => {
+    if (!editor) return;
+    setProbeState("loading");
+    setProbeResult(null);
+    setFailure("");
+    try {
+      const result = await api.probe({
+        provider: editor.id.trim(),
+        apiBaseUrl: editor.base_url.trim(),
+        anthropicBaseUrl: editor.anthropic_base_url?.trim() || "",
+        apiKey: editor.api_key,
+        model: probeModel.trim(),
+        // Which protocols to probe follows from which endpoints the user filled
+        // in, not from a selected Agent: this page has no Agent context, and the
+        // question here is whether the endpoints work.
+        agents: probeAgentIds,
+        draft: true,
+      });
+      setProbeResult(result);
+      setProbeState(result.ok ? "success" : "error");
+    } catch (error) {
+      setProbeResult(null);
+      setProbeState("error");
+      setFailure(describeFailure(error, t("连接测试失败"), t).message);
     }
   };
 
@@ -237,6 +318,37 @@ export function ProvidersPage({ create = false }: { create?: boolean }) {
                 from here instead of asking again. */}
             <div className="provider-editor-wide">
               <SecureKeyField value={editor.api_key} onChange={(value) => setEditor({ ...editor, api_key: value })} />
+            </div>
+            {/* Verifying here rather than only on the Agent page, which is what
+                #157 asked for: the endpoint and key are entered above, so this is
+                where a wrong one should be caught. */}
+            <div className="provider-editor-wide provider-verify">
+              <div className="provider-verify-row">
+                <div className="field-stack">
+                  <label htmlFor="provider-probe-model">{t("测试模型（可选）")}</label>
+                  <input
+                    id="provider-probe-model"
+                    value={probeModel}
+                    onChange={(event) => setProbeModel(event.target.value)}
+                    placeholder={t("留空则自动选择")}
+                    spellCheck={false}
+                    autoCorrect="off"
+                    autoCapitalize="none"
+                  />
+                  <small>{t("仅用于本次验证，不会写入模型服务配置")}</small>
+                </div>
+                <button
+                  className="button button-secondary"
+                  type="button"
+                  onClick={() => void testConnection()}
+                  disabled={!canProbe || probeState === "loading" || busy}
+                  title={canProbe ? t("验证可用性") : t("请先填写至少一个 Base URL")}
+                >
+                  <FlaskConical size={15} />
+                  {probeState === "loading" ? t("验证中") : t("验证可用性")}
+                </button>
+              </div>
+              <ConnectionStatus state={probeState} result={probeResult} />
             </div>
           </div>
           <footer>

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -1800,6 +1800,33 @@
 .provider-editor-wide,
 .profile-editor-wide { grid-column: 1 / -1; }
 
+/* Separated from the fields above by a rule rather than only by gap: this block
+   performs an action and reports a result, so it is not another field to fill in. */
+.provider-verify {
+  min-width: 0;
+  padding-top: 14px;
+  border-top: 1px solid var(--border-faint);
+  display: grid;
+  gap: 10px;
+}
+
+/* The button aligns to the input's baseline, not the label's, so it does not ride
+   up next to the field's caption. */
+.provider-verify-row {
+  min-width: 0;
+  display: flex;
+  align-items: start;
+  gap: 10px;
+}
+
+.provider-verify-row .field-stack { min-width: 0; flex: 1; }
+.provider-verify-row .button { flex: 0 0 auto; margin-top: 22px; }
+
+@media (max-width: 600px) {
+  .provider-verify-row { flex-direction: column; align-items: stretch; }
+  .provider-verify-row .button { margin-top: 0; }
+}
+
 .icon-button {
   width: 30px;
   height: 30px;

--- a/internal/app/provider.go
+++ b/internal/app/provider.go
@@ -21,6 +21,13 @@ type ProviderProbeOptions struct {
 	APIKey     string
 	Model      string
 	AgentIDs   []string
+	// AnthropicBaseURL and Draft serve the Provider editor's "test this before I
+	// save it" button. Draft says the endpoints above are the ones to probe even
+	// when the Provider is not on disk yet; without it an unsaved Provider cannot
+	// be tested at all, and an Anthropic base cannot be tested separately from the
+	// OpenAI one. The wizard leaves both unset and keeps resolving from storage.
+	AnthropicBaseURL string
+	Draft            bool
 }
 
 type ProviderProbeResult struct {
@@ -50,7 +57,13 @@ func (u *UseCases) ProbeProvider(ctx context.Context, options ProviderProbeOptio
 	if u == nil || u.provider == nil {
 		return ProviderProbeResult{}, oneerrors.New(oneerrors.InternalError, "Provider probing is not configured", oneerrors.WithStatus(501))
 	}
-	target, err := u.providers.Resolve(options.Provider, options.APIBaseURL)
+	resolve := u.providers.Resolve
+	if options.Draft {
+		resolve = func(id, openAIBase string) (provider.Entry, error) {
+			return u.providers.ResolveDraft(id, openAIBase, options.AnthropicBaseURL)
+		}
+	}
+	target, err := resolve(options.Provider, options.APIBaseURL)
 	if err != nil {
 		return ProviderProbeResult{}, err
 	}

--- a/internal/app/provider_test.go
+++ b/internal/app/provider_test.go
@@ -38,6 +38,95 @@ func providerUseCases(t *testing.T, doer provider.HTTPDoer) *UseCases {
 	}, provider.NewClient(doer))
 }
 
+// The Provider editor tests what is on screen, which is not on disk yet, so the
+// probe has to accept an ID it cannot look up. Resolve refuses one -- that is the
+// right behaviour for the wizard and is asserted separately below.
+func TestProbeProviderTestsADraftProviderNotYetSaved(t *testing.T) {
+	var seen []string
+	core := providerUseCases(t, appProviderDoer(func(request *http.Request) (*http.Response, error) {
+		seen = append(seen, request.URL.String()+" auth="+request.Header.Get("Authorization"))
+		return appProviderResponse(http.StatusNoContent, ""), nil
+	}))
+	result, err := core.ProbeProvider(context.Background(), ProviderProbeOptions{
+		Provider: "not-saved-yet", APIBaseURL: "https://api.draft.test/openai",
+		APIKey: "typed-key", Model: "model-a", AgentIDs: []string{"opencode"}, Draft: true,
+	})
+	if err != nil || !result.Primary.OK {
+		t.Fatalf("draft probe = %#v, err=%v", result, err)
+	}
+	if len(seen) != 1 || !strings.Contains(seen[0], "api.draft.test") || !strings.Contains(seen[0], "Bearer typed-key") {
+		t.Fatalf("draft probe requests = %v", seen)
+	}
+}
+
+// Each editor field is probed against what the user typed in it. Resolve clears
+// AnthropicBaseURL whenever an OpenAI base is supplied, which would send the
+// Anthropic probe to the OpenAI host and report a verdict about the wrong
+// endpoint.
+func TestProbeProviderTestsBothDraftEndpointsIndependently(t *testing.T) {
+	seen := map[string]string{}
+	var seenMu sync.Mutex
+	core := providerUseCases(t, appProviderDoer(func(request *http.Request) (*http.Response, error) {
+		seenMu.Lock()
+		defer seenMu.Unlock()
+		seen[request.URL.Path] = request.URL.Host
+		return appProviderResponse(http.StatusNoContent, ""), nil
+	}))
+	result, err := core.ProbeProvider(context.Background(), ProviderProbeOptions{
+		Provider:         "not-saved-yet",
+		APIBaseURL:       "https://openai.draft.test/v1",
+		AnthropicBaseURL: "https://anthropic.draft.test",
+		APIKey:           "typed-key",
+		Model:            "model-a",
+		AgentIDs:         []string{"opencode", "claude-code"},
+		Draft:            true,
+	})
+	if err != nil || !result.Primary.OK || len(result.Protocols) != 2 {
+		t.Fatalf("two-endpoint draft probe = %#v, err=%v", result, err)
+	}
+	if seen["/v1/chat/completions"] != "openai.draft.test" {
+		t.Fatalf("OpenAI probe went to %q", seen["/v1/chat/completions"])
+	}
+	if seen["/v1/messages"] != "anthropic.draft.test" {
+		t.Fatalf("Anthropic probe went to %q, want anthropic.draft.test", seen["/v1/messages"])
+	}
+}
+
+// A draft with no endpoints at all is the built-in Provider case: only the key is
+// being tested, so the catalog endpoints still apply.
+func TestProbeProviderDraftWithoutEndpointsUsesTheStoredProvider(t *testing.T) {
+	var host string
+	core := providerUseCases(t, appProviderDoer(func(request *http.Request) (*http.Response, error) {
+		host = request.URL.Host
+		return appProviderResponse(http.StatusNoContent, ""), nil
+	}))
+	if _, err := core.ProbeProvider(context.Background(), ProviderProbeOptions{
+		Provider: "ppio", APIKey: "typed-key", Model: "model-a", AgentIDs: []string{"opencode"}, Draft: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if host != "api.ppio.com" {
+		t.Fatalf("keyless-endpoint draft probe went to %q", host)
+	}
+}
+
+// The guard on the change above: without Draft, an unknown ID must still fail
+// rather than silently probing whatever base URL came with the request. A typo'd
+// Provider ID reported as a connection result would be a wrong verdict.
+func TestProbeProviderStillRefusesAnUnknownProviderWithoutDraft(t *testing.T) {
+	core := providerUseCases(t, appProviderDoer(func(*http.Request) (*http.Response, error) {
+		t.Fatal("an unknown Provider was probed")
+		return nil, nil
+	}))
+	_, err := core.ProbeProvider(context.Background(), ProviderProbeOptions{
+		Provider: "not-saved-yet", APIBaseURL: "https://api.draft.test/openai",
+		APIKey: "typed-key", Model: "model-a", AgentIDs: []string{"opencode"},
+	})
+	if err == nil || oneerrors.As(err).Code != oneerrors.InvalidRequest {
+		t.Fatalf("unknown Provider without Draft = %v", err)
+	}
+}
+
 func TestProbeProviderAggregatesAgentProtocols(t *testing.T) {
 	seen := make([]string, 0)
 	var seenMu sync.Mutex

--- a/internal/binding/services.go
+++ b/internal/binding/services.go
@@ -228,11 +228,13 @@ func (s *ProviderService) Probe(ctx context.Context, request ProbeRequest) (Prob
 		return ProbeResponse{}, notReady("Provider probing is not configured")
 	}
 	result, err := s.core.ProbeProvider(ctx, app.ProviderProbeOptions{
-		Provider:   request.Provider,
-		APIBaseURL: request.APIBaseURL,
-		APIKey:     request.APIKey,
-		Model:      request.Model,
-		AgentIDs:   request.Agents,
+		Provider:         request.Provider,
+		APIBaseURL:       request.APIBaseURL,
+		APIKey:           request.APIKey,
+		Model:            request.Model,
+		AgentIDs:         request.Agents,
+		AnthropicBaseURL: request.AnthropicBaseURL,
+		Draft:            request.Draft,
 	})
 	if err != nil {
 		return ProbeResponse{}, err
@@ -489,6 +491,12 @@ type ProbeRequest struct {
 	APIKey     string   `json:"api_key"`
 	Model      string   `json:"model"`
 	Agents     []string `json:"agents"`
+	// AnthropicBaseURL and Draft let the Provider editor test what is on screen
+	// before it is saved. Draft is explicit rather than inferred from a non-empty
+	// base URL: the wizard also sends a base URL, and silently switching it to
+	// draft resolution would stop it reading the stored record.
+	AnthropicBaseURL string `json:"anthropic_base_url"`
+	Draft            bool   `json:"draft"`
 }
 
 type ModelsRequest struct {

--- a/internal/provider/store.go
+++ b/internal/provider/store.go
@@ -112,6 +112,53 @@ func (s Store) Resolve(id, explicitBase string) (Entry, error) {
 	return entry, err
 }
 
+// ResolveDraft resolves the endpoints a caller supplies directly, for testing a
+// Provider the user is still editing and has not saved. Resolve cannot serve
+// this: it reads the stored record, so an ID that is not on disk yet fails, and
+// it clears AnthropicBaseURL whenever an OpenAI base is overridden, which leaves
+// the Anthropic endpoint in the editor untestable.
+//
+// Both bases are honoured independently so each field in the editor is probed
+// against what the user actually typed.
+//
+// A draft with neither base falls back to Resolve rather than erroring: that is
+// the built-in Provider case, where the endpoints come from the catalog and only
+// the key is being tested.
+func (s Store) ResolveDraft(id, openAIBase, anthropicBase string) (Entry, error) {
+	id = strings.TrimSpace(id)
+	openAIBase = strings.TrimSpace(openAIBase)
+	anthropicBase = strings.TrimSpace(anthropicBase)
+	if openAIBase == "" && anthropicBase == "" {
+		return s.Resolve(id, "")
+	}
+	// Kept only for its display name and probe fallback model; a saved record must
+	// not contribute endpoints here, or a stale stored base would be probed while
+	// the editor showed a different one.
+	entry := Entry{ID: id, Name: "Custom", FallbackModel: catalog.FallbackProbeModel(id)}
+	if saved, err := s.Get(id); err == nil {
+		entry.Name = saved.Name
+		entry.FallbackModel = saved.FallbackModel
+		entry.DefaultModel = saved.DefaultModel
+	}
+	var err error
+	if openAIBase != "" {
+		if entry.BaseURL, err = ValidateBaseURL(openAIBase); err != nil {
+			return Entry{}, err
+		}
+	}
+	if anthropicBase != "" {
+		if entry.AnthropicBaseURL, err = ValidateBaseURL(anthropicBase); err != nil {
+			return Entry{}, err
+		}
+	}
+	// BaseFor falls back to BaseURL for every protocol, so an Anthropic-only draft
+	// would otherwise probe an empty URL for OpenAI.
+	if entry.BaseURL == "" {
+		entry.BaseURL = entry.AnthropicBaseURL
+	}
+	return entry, nil
+}
+
 func (entry Entry) BaseFor(protocol string) string {
 	if protocol == ProtocolAnthropic && entry.AnthropicBaseURL != "" {
 		return entry.AnthropicBaseURL


### PR DESCRIPTION
Closes #157.

Testing a Provider was only possible from the Agent setup flow, so the page where the base URL and key are actually entered could not say whether they worked. This adds a verification block under the key field, reusing `ConnectionStatus` — it already reports per protocol, separates a rejected key from a model that cannot chat, and localises the failure copy.

## Two backend limits blocked this

Both confirmed by running the path, not by reading it:

- `Store.Resolve` reads the stored record, so an ID that is not on disk fails with `Unknown Provider` — exactly the state the editor is in while creating one.
- It also clears `AnthropicBaseURL` whenever an OpenAI base is supplied, so the editor's second endpoint field could not be tested at all. `BaseFor` would have sent the Anthropic probe to the OpenAI host and reported a verdict about the wrong endpoint.

`ResolveDraft` answers both by honouring the endpoints the caller passes, independently, reached only through a new `Draft` flag.

**`Resolve` is deliberately untouched.** An unknown Provider without `Draft` must still fail, because a typo'd ID reported as a connection result would be a wrong verdict. There is a test asserting exactly that. `Draft` is explicit rather than inferred from a non-empty base URL, since the wizard also sends one and silently switching it to draft resolution would stop it reading the stored record.

## Behaviour decisions

**Nothing is persisted by verifying.** The key reaches the local backend for the request and is written only when the user presses Save, so testing a key that turns out to be wrong does not leave it on disk. A failed test does not block saving either — the user may be filling in a key later.

**The test model is optional and belongs to the test, not the Provider.** It is never written to the stored record, which has no field for it. Left empty, the backend picks one, and `ConnectionStatus` already explains a failure caused by that choice.

**Which protocols get probed follows from which endpoint fields are filled in**, not from a selected Agent: this page has no Agent context, and the question here is whether the endpoints work. The Agent IDs in the request are how `protocolsForAgents` is addressed, not a claim about those Agents.

Probe state is local to the page rather than the wizard reducer's, so a test here and the wizard's cannot overwrite each other.

## Testing

- `go test ./...` — all pass; `go vet` and `gofmt -l` clean
- `pnpm test` — 350 passed (44 files); `tsc --noEmit` clean
- `task package` — builds; ran the resulting `OneAgent.app` on macOS 15 arm64

End-to-end against the compiled server-mode binary and a controlled fake provider (200 for the right key, 401 for a wrong one):

| case | result |
| --- | --- |
| unsaved Provider + correct key | `ok=true, 200` |
| same endpoint + wrong key | `ok=false, 401, API_KEY_REJECTED` |
| unknown Provider without `draft` | refused: `Unknown Provider` |
| both endpoints filled | `openai` and `anthropic` each `ok=true` |

The fake provider's request log proves these were real requests rather than stubbed responses — port 8777 received `/v1/chat/completions` and 8778 received `/v1/messages`, each with the right key. That per-endpoint split is the bug the `ResolveDraft` change fixes.

One note for reviewers: the repo's e2e build tag (`core_e2e.go`) replaces the HTTP client with a stub that always returns 204, so a probe run under `-tags e2e` will report success for any key. That is intentional for browser tests, but it means functional verification of this path has to run without that tag.

## Layout

Geometry checked in a browser at 1280px and 560px: the separator renders, the button sits on the input's row, the narrow breakpoint stacks, and the failure state does not overflow.

Includes the merge of `main`'s #165 (card height + `CardUsers`), which touched the same two files; both sides' features coexist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
