### PR TITLE
feat: add ZCode as a desktop Agent, provider only

### DIFF
--- a/frontend/bindings/github.com/MaimoryLab/OneAgent/internal/app/models.ts
+++ b/frontend/bindings/github.com/MaimoryLab/OneAgent/internal/app/models.ts
@@ -101,6 +101,15 @@ export interface DesktopAgentStatus {
     "profileId": string | null;
     "packageFamily"?: string;
     "inspectionUnavailable"?: string | null;
+
+    /**
+     * ManualInstall reports that OneAgent can detect and configure this app but
+     * cannot fetch it. Without this the UI offered "Install the official desktop
+     * application" for an Agent whose install step only returns a download link,
+     * which is a button that cannot do what it says.
+     */
+    "manualInstall"?: boolean;
+    "home"?: string;
 }
 
 export interface DetectedConfig {

--- a/frontend/src/components/icons/agents.tsx
+++ b/frontend/src/components/icons/agents.tsx
@@ -22,6 +22,7 @@
  */
 import {
   Bot,
+  Braces,
   Briefcase,
   GitBranch,
   type LucideIcon
@@ -106,6 +107,11 @@ const MARKS: Record<string, Mark> = {
   // generic mark" is distinguishable from "never looked at".
   aider: { kind: "generic", Icon: GitBranch, source: GENERIC_SOURCE },
   workbuddy: { kind: "generic", Icon: Briefcase, source: GENERIC_SOURCE },
+  // ZCode's mark is not in lobe-icons either, and the only vectors in circulation
+  // come from the app bundle itself, which carries no redistribution grant. A
+  // generic symbol keeps NOTICE unchanged; registering it here rather than letting
+  // AgentIcon fall back records that the question was asked.
+  zcode: { kind: "generic", Icon: Braces, source: GENERIC_SOURCE },
   // Unlike the four above, this mark is not the vendor's own artwork: it is the
   // lobster the cc-switch project drew, MIT, and OneAgent recoloured it to a
   // single currentColor glyph so it adapts to the theme like the rest of the set.

--- a/frontend/src/i18n.tsx
+++ b/frontend/src/i18n.tsx
@@ -237,6 +237,7 @@ const english = {
   "与 {name} 共用配置": "Shares configuration with {name}",
   "已安装，可直接应用配置模版": "Installed; a profile can be applied now",
   "安装官方桌面应用": "Install the official desktop application",
+  "需先自行安装，之后可配置": "Install it yourself first, then OneAgent can configure it",
   "检测到本机已有此应用": "This application is already installed",
   "选择配置模版": "Select a profile",
   "选择一个已有配置模版，或新建配置模版": "Choose an existing profile or create a new one",

--- a/frontend/src/pages/AgentSelectionPage.tsx
+++ b/frontend/src/pages/AgentSelectionPage.tsx
@@ -85,7 +85,9 @@ export function AgentSelectionPage() {
                   return <label key={app.id} className={`agent-row${selected ? " is-selected" : ""}${!app.supported ? " is-disabled" : ""}`}>
                     <input type="radio" name="desktop-agent-choice" checked={selected} disabled={!app.supported} onChange={() => dispatch({ type: "SELECT_AGENT", agentId: app.id })} aria-label={t("选择 {name}", { name: app.name })} />
                     <span className="agent-icon"><AppWindow size={20} aria-hidden="true" /></span>
-                    <span className="agent-copy"><span className="agent-name-line"><strong>{app.name}</strong></span><span>{app.installed ? t("已安装，可直接应用配置模版") : t("安装官方桌面应用")}</span></span>
+                    <span className="agent-copy"><span className="agent-name-line"><strong>{app.name}</strong></span><span>{app.installed
+                      ? t("已安装，可直接应用配置模版")
+                      : app.manualInstall ? t("需先自行安装，之后可配置") : t("安装官方桌面应用")}</span></span>
                     <StatusBadge tone={app.installed ? "success" : app.supported ? "warning" : "neutral"}>{app.installed ? t("已安装") : app.supported ? t("待安装") : t("不支持")}</StatusBadge>
                   </label>;
                 })}

--- a/frontend/src/pages/DesktopAgentSelectionPage.tsx
+++ b/frontend/src/pages/DesktopAgentSelectionPage.tsx
@@ -68,7 +68,9 @@ export function DesktopAgentSelectionPage() {
                 <span className="desktop-app-icon"><AppWindow size={20} aria-hidden="true" /></span>
                 <span className="agent-copy">
                   <span className="agent-name-line"><strong>{candidate.name}</strong></span>
-                  <span>{candidate.installed ? t("已安装，可直接应用配置模版") : t("安装官方桌面应用")}</span>
+                  <span>{candidate.installed
+                    ? t("已安装，可直接应用配置模版")
+                    : candidate.manualInstall ? t("需先自行安装，之后可配置") : t("安装官方桌面应用")}</span>
                   {candidate.configSharedWith ? <small>{t("与 {name} 共用配置", { name: candidate.configSharedWith })}</small> : null}
                 </span>
                 <StatusBadge tone={candidate.installed ? "success" : candidate.supported ? "warning" : "neutral"}>

--- a/internal/app/agent.go
+++ b/internal/app/agent.go
@@ -193,6 +193,8 @@ func writeManagedAgentConfig(ctx context.Context, writer configWriter.Writer, ag
 		return writer.WriteKimiCode(ctx, path, baseURL, apiKey, model)
 	case "workbuddy":
 		return writer.WriteWorkBuddy(ctx, path, baseURL, apiKey, model)
+	case "zcode":
+		return writer.WriteZCode(ctx, path, providerName, baseURL, apiKey, model)
 	default:
 		return oneerrors.New(oneerrors.InvalidRequest, fmt.Sprintf("Unsupported auto-config Agent: %s", agentID))
 	}

--- a/internal/app/desktopapp.go
+++ b/internal/app/desktopapp.go
@@ -33,6 +33,12 @@ type DesktopAgentStatus struct {
 	ProfileID             *string `json:"profileId"`
 	PackageFamily         string  `json:"packageFamily,omitempty"`
 	InspectionUnavailable *string `json:"inspectionUnavailable,omitempty"`
+	// ManualInstall reports that OneAgent can detect and configure this app but
+	// cannot fetch it. Without this the UI offered "Install the official desktop
+	// application" for an Agent whose install step only returns a download link,
+	// which is a button that cannot do what it says.
+	ManualInstall bool   `json:"manualInstall,omitempty"`
+	Home          string `json:"home,omitempty"`
 }
 
 // DesktopAgentProfileResult is the non-secret result of applying a saved
@@ -279,6 +285,8 @@ func (u *UseCases) publicDesktopAgentStatus(value desktopapp.Status) DesktopAgen
 	}
 	status.ProfileAgentID = definition.ProfileAgentID
 	status.Protocol = definition.Protocol
+	status.ManualInstall = definition.ManualInstall
+	status.Home = definition.Home
 	if binding, err := u.profiles.ReadAgentBinding(status.ProfileAgentID); err == nil && binding != nil && binding.ProfileRef != "" {
 		status.ProfileID = nonEmptyPointer(binding.ProfileRef)
 	}

--- a/internal/app/testdata/status-empty-linux-arm64.json
+++ b/internal/app/testdata/status-empty-linux-arm64.json
@@ -443,28 +443,41 @@
   "environmentError": null,
   "desktopAgents": [
     {
-      "id": "chatgpt-desktop",
-      "name": "ChatGPT Desktop",
-      "installed": false,
-      "supported": false,
-      "version": null,
-      "source": "unknown",
       "configPath": "${HOME}/.codex/config.toml",
       "configSharedWith": "Codex",
-      "protocol": "responses",
+      "id": "chatgpt-desktop",
+      "installed": false,
+      "name": "ChatGPT Desktop",
       "profileAgentId": "codex",
-      "profileId": null
+      "profileId": null,
+      "protocol": "responses",
+      "source": "unknown",
+      "supported": false,
+      "version": null
     },
     {
       "id": "workbuddy",
-      "name": "WorkBuddy",
       "installed": false,
-      "supported": false,
-      "version": null,
-      "source": "unknown",
-      "protocol": "openai",
+      "name": "WorkBuddy",
       "profileAgentId": "workbuddy",
-      "profileId": null
+      "profileId": null,
+      "protocol": "openai",
+      "source": "unknown",
+      "supported": false,
+      "version": null
+    },
+    {
+      "home": "https://zcode.z.ai/",
+      "id": "zcode",
+      "installed": false,
+      "manualInstall": true,
+      "name": "ZCode",
+      "profileAgentId": "zcode",
+      "profileId": null,
+      "protocol": "openai",
+      "source": "unknown",
+      "supported": false,
+      "version": null
     }
   ]
 }

--- a/internal/config/write.go
+++ b/internal/config/write.go
@@ -2,6 +2,8 @@ package config
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"maps"
@@ -125,6 +127,101 @@ func (w Writer) WriteOpenAICompatible(ctx context.Context, path, schemaURL, prov
 	providers.Set("oneagent", oneagent)
 	document.Set("model", "oneagent/"+model)
 	return w.writeJSON(ctx, path, document, true)
+}
+
+// zcodeOwnedName labels the provider entry OneAgent maintains. ZCode keys custom
+// providers by a generated UUID rather than by a stable name, so the name is the
+// only field that can identify an earlier OneAgent write.
+const zcodeOwnedName = "OneAgent"
+
+// WriteZCode adds or updates OneAgent's provider entry in ~/.zcode/v2/config.json.
+//
+// It writes the provider only, and deliberately does not select a model. ZCode
+// keeps no top-level "model" key -- unlike OpenCode, whose config it otherwise
+// shares a $schema with -- and where it records the active model is not
+// documented and was not found on disk. Guessing at that would risk corrupting
+// state the app owns, so the user picks the model once inside ZCode. This
+// mirrors WriteWorkBuddy, which likewise registers a model service and leaves
+// selection to the app.
+//
+// Existing entries are matched by name, not by key. Keying by a fresh UUID on
+// every write would append a duplicate provider each time the user reconfigured.
+//
+// The entry is written as kind "openai". ZCode also accepts kind "anthropic" --
+// its own builtin entries use it, pointed at https://api.z.ai/api/anthropic --
+// but every Provider in providers.lock.json serves the OpenAI protocol while only
+// some serve Anthropic, and the registry pins ZCode to openai for that reason.
+// Supporting the other kind means giving the Definition a real protocol choice,
+// not adding a branch here that nothing can reach.
+func (w Writer) WriteZCode(ctx context.Context, path, providerName, baseURL, apiKey, model string) error {
+	document, err := loadJSON(path)
+	if err != nil {
+		return err
+	}
+	// ZCode's own config declares OpenCode's schema. Preserve whatever is there
+	// rather than asserting it: this file belongs to ZCode, and only the one
+	// provider entry below is OneAgent's to manage.
+	if document.GetString("$schema") == "" {
+		document.Set("$schema", "https://opencode.ai/config.json")
+	}
+	providers, err := document.Child("provider")
+	if err != nil {
+		return configError("Existing provider configuration must contain an object: %s", path)
+	}
+
+	options := jsonorder.NewObject()
+	// ZCode stores a base URL, not a request path: the entries it writes itself
+	// read like "https://api.z.ai/api/anthropic", with no /v1/messages suffix.
+	options.Set("baseURL", provider.OpenAIBaseURL(baseURL))
+	options.Set("apiKey", apiKey)
+	// Without this ZCode treats the endpoint as needing no credential and sends
+	// the request unauthenticated, which the Provider rejects as a missing key.
+	options.Set("apiKeyRequired", true)
+
+	entry := jsonorder.NewObject()
+	entry.Set("name", zcodeOwnedName+" - "+providerName)
+	entry.Set("kind", "openai")
+	entry.Set("options", options)
+	entry.Set("source", "custom")
+	// The model is registered so it appears in ZCode's picker; which one is
+	// active stays ZCode's decision.
+	if model != "" {
+		models := jsonorder.NewObject()
+		models.Set(model, jsonorder.NewObject())
+		entry.Set("models", models)
+	}
+
+	providers.Set(zcodeProviderKey(providers, entry.GetString("name")), entry)
+	return w.writeJSON(ctx, path, document, true)
+}
+
+// zcodeNewKey derives the provider key from the name instead of generating a
+// random UUID. ZCode's own custom entries use UUIDs, but nothing reads them as
+// one: the key is an opaque identifier. A derived key makes a write idempotent
+// even if the file is replaced between runs, and it stays readable in a config a
+// user may open.
+func zcodeNewKey(name string) string {
+	digest := sha256.Sum256([]byte(name))
+	return "oneagent-" + hex.EncodeToString(digest[:8])
+}
+
+// zcodeProviderKey reuses the key of a provider already carrying this name, so a
+// second write updates that entry instead of adding another. A builtin:* entry is
+// never reused: those belong to ZCode and are keyed by a name it controls.
+func zcodeProviderKey(providers *jsonorder.Object, name string) string {
+	for _, key := range providers.Keys() {
+		if strings.HasPrefix(key, "builtin:") {
+			continue
+		}
+		existing, ok := providers.GetObject(key)
+		if !ok {
+			continue
+		}
+		if existing.GetString("name") == name {
+			return key
+		}
+	}
+	return zcodeNewKey(name)
 }
 
 // WriteWorkBuddy adds or updates one custom OpenAI-compatible model while

--- a/internal/config/write.go
+++ b/internal/config/write.go
@@ -137,12 +137,18 @@ const zcodeOwnedName = "OneAgent"
 // WriteZCode adds or updates OneAgent's provider entry in ~/.zcode/v2/config.json.
 //
 // It writes the provider only, and deliberately does not select a model. ZCode
-// keeps no top-level "model" key -- unlike OpenCode, whose config it otherwise
-// shares a $schema with -- and where it records the active model is not
-// documented and was not found on disk. Guessing at that would risk corrupting
-// state the app owns, so the user picks the model once inside ZCode. This
-// mirrors WriteWorkBuddy, which likewise registers a model service and leaves
-// selection to the app.
+// keeps no top-level "model" key and where it records the active model is neither
+// documented nor anywhere it could be found on disk. Guessing at that would risk
+// corrupting state the app owns, so the user picks the model once inside ZCode.
+// This mirrors WriteWorkBuddy, which likewise registers a model service and
+// leaves selection to the app.
+//
+// The shape below was read off ZCode 3.1.3. Nothing about it is documented -- the
+// published docs describe GUI configuration and name no file path -- so it is an
+// observation of one version, and 3.1.1 to 3.1.3 already moved: that release
+// declared "$schema": "https://opencode.ai/config.json" and carried enabled /
+// systemDisabledReason on builtin entries, all of which 3.1.3 dropped. Re-check
+// against a current build before assuming any of it still holds.
 //
 // Existing entries are matched by name, not by key. Keying by a fresh UUID on
 // every write would append a duplicate provider each time the user reconfigured.
@@ -158,12 +164,11 @@ func (w Writer) WriteZCode(ctx context.Context, path, providerName, baseURL, api
 	if err != nil {
 		return err
 	}
-	// ZCode's own config declares OpenCode's schema. Preserve whatever is there
-	// rather than asserting it: this file belongs to ZCode, and only the one
-	// provider entry below is OneAgent's to manage.
-	if document.GetString("$schema") == "" {
-		document.Set("$schema", "https://opencode.ai/config.json")
-	}
+	// No "$schema" is written. ZCode 3.1.1 declared OpenCode's schema URL and
+	// 3.1.3 dropped the key entirely, so writing it back would reintroduce a field
+	// the current version chose to remove. Only the one provider entry below is
+	// OneAgent's to manage; every other key in this file belongs to ZCode and is
+	// left exactly as found.
 	providers, err := document.Child("provider")
 	if err != nil {
 		return configError("Existing provider configuration must contain an object: %s", path)

--- a/internal/config/write_test.go
+++ b/internal/config/write_test.go
@@ -470,3 +470,161 @@ func TestWriteHermesPreservesExistingConfig(t *testing.T) {
 		t.Fatalf("Hermes config mode = %v, err=%v", info.Mode().Perm(), err)
 	}
 }
+
+// The real ~/.zcode/v2/config.json holds builtin:* entries the app owns and
+// UUID-keyed custom ones. This fixture reproduces that shape, because preserving
+// both is the whole risk of writing into a file OneAgent does not own.
+const zcodeExisting = `{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "builtin:zai": {
+      "name": "Z.ai - API Key",
+      "kind": "anthropic",
+      "options": {"apiKey": "", "baseURL": "https://api.z.ai/api/anthropic"},
+      "source": "custom"
+    },
+    "ed76b5b4-63bb-4cf0-b0f2-7fb651c50cac": {
+      "name": "Mine",
+      "kind": "anthropic",
+      "options": {"apiKey": "user-key", "baseURL": "https://user.example/v1"},
+      "source": "custom",
+      "models": {"user/model": {"limit": {"context": 1000000}}}
+    }
+  }
+}`
+
+func zcodeProviders(t *testing.T, path string) map[string]map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var document struct {
+		Schema   string                    `json:"$schema"`
+		Provider map[string]map[string]any `json:"provider"`
+	}
+	if err := json.Unmarshal(data, &document); err != nil {
+		t.Fatalf("ZCode config is not valid JSON: %s: %v", data, err)
+	}
+	if document.Schema != "https://opencode.ai/config.json" {
+		t.Fatalf("$schema = %q", document.Schema)
+	}
+	return document.Provider
+}
+
+func TestWriteZCodeAddsAProviderAndKeepsTheAppsOwnEntries(t *testing.T) {
+	home := t.TempDir()
+	path := filepath.Join(home, ".zcode", "v2", "config.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(zcodeExisting), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	writer := testWriter(t, home, "linux")
+	if err := writer.WriteZCode(context.Background(), path, "PPIO", "https://api.ppio.com/openai", "sk-zcode", "deepseek-v4-pro"); err != nil {
+		t.Fatal(err)
+	}
+	providers := zcodeProviders(t, path)
+	if len(providers) != 3 {
+		t.Fatalf("provider count = %d, want 3: %#v", len(providers), providers)
+	}
+	// Both pre-existing entries survive untouched, including the nested limit the
+	// user's own entry carries.
+	if providers["builtin:zai"]["name"] != "Z.ai - API Key" {
+		t.Errorf("builtin entry changed: %#v", providers["builtin:zai"])
+	}
+	mine := providers["ed76b5b4-63bb-4cf0-b0f2-7fb651c50cac"]
+	if mine["name"] != "Mine" || mine["models"].(map[string]any)["user/model"] == nil {
+		t.Errorf("user entry changed: %#v", mine)
+	}
+
+	var written map[string]any
+	for key, entry := range providers {
+		if entry["name"] == "OneAgent - PPIO" {
+			written = entry
+			if strings.HasPrefix(key, "builtin:") {
+				t.Errorf("OneAgent reused a builtin key: %q", key)
+			}
+		}
+	}
+	if written == nil {
+		t.Fatalf("no OneAgent entry written: %#v", providers)
+	}
+	if written["kind"] != "openai" || written["source"] != "custom" {
+		t.Errorf("entry shape = %#v", written)
+	}
+	options := written["options"].(map[string]any)
+	// OpenAIBaseURL normalizes to a /v1 base; apiKeyRequired must be set or ZCode
+	// sends the request unauthenticated.
+	if options["baseURL"] != "https://api.ppio.com/openai/v1" || options["apiKey"] != "sk-zcode" || options["apiKeyRequired"] != true {
+		t.Errorf("options = %#v", options)
+	}
+	if written["models"].(map[string]any)["deepseek-v4-pro"] == nil {
+		t.Errorf("model was not registered: %#v", written["models"])
+	}
+	// No top-level model key: which model is active stays ZCode's decision, the
+	// same division WriteWorkBuddy keeps.
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var top map[string]any
+	if err := json.Unmarshal(data, &top); err != nil {
+		t.Fatal(err)
+	}
+	if _, present := top["model"]; present {
+		t.Errorf("wrote a top-level model key: %s", data)
+	}
+	info, err := os.Stat(path)
+	if err != nil || info.Mode().Perm() != 0o600 {
+		t.Fatalf("ZCode config mode = %v, err=%v", info.Mode().Perm(), err)
+	}
+}
+
+// ZCode keys custom providers by UUID, so a second write that generated a fresh
+// key would leave the user with a duplicate provider per reconfiguration.
+func TestWriteZCodeUpdatesItsOwnEntryInsteadOfAddingAnother(t *testing.T) {
+	home := t.TempDir()
+	path := filepath.Join(home, ".zcode", "v2", "config.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(zcodeExisting), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	writer := testWriter(t, home, "linux")
+	for _, step := range []struct{ key, model string }{{"first-key", "model-a"}, {"second-key", "model-b"}} {
+		if err := writer.WriteZCode(context.Background(), path, "PPIO", "https://api.ppio.com/openai", step.key, step.model); err != nil {
+			t.Fatal(err)
+		}
+	}
+	providers := zcodeProviders(t, path)
+	if len(providers) != 3 {
+		t.Fatalf("a second write added an entry: %d providers: %#v", len(providers), providers)
+	}
+	for _, entry := range providers {
+		if entry["name"] != "OneAgent - PPIO" {
+			continue
+		}
+		if entry["options"].(map[string]any)["apiKey"] != "second-key" {
+			t.Errorf("key was not updated: %#v", entry["options"])
+		}
+		if entry["models"].(map[string]any)["model-b"] == nil {
+			t.Errorf("model was not updated: %#v", entry["models"])
+		}
+	}
+}
+
+func TestWriteZCodeCreatesTheFileWhenAbsent(t *testing.T) {
+	home := t.TempDir()
+	path := filepath.Join(home, ".zcode", "v2", "config.json")
+	writer := testWriter(t, home, "linux")
+	if err := writer.WriteZCode(context.Background(), path, "Novita", "https://api.novita.ai/openai", "sk-new", "m"); err != nil {
+		t.Fatal(err)
+	}
+	providers := zcodeProviders(t, path)
+	if len(providers) != 1 {
+		t.Fatalf("provider count = %d, want 1", len(providers))
+	}
+}

--- a/internal/config/write_test.go
+++ b/internal/config/write_test.go
@@ -471,11 +471,13 @@ func TestWriteHermesPreservesExistingConfig(t *testing.T) {
 	}
 }
 
-// The real ~/.zcode/v2/config.json holds builtin:* entries the app owns and
-// UUID-keyed custom ones. This fixture reproduces that shape, because preserving
-// both is the whole risk of writing into a file OneAgent does not own.
+// Reproduces the shape of a real ~/.zcode/v2/config.json: builtin:* entries the
+// app owns beside UUID-keyed custom ones. Preserving both is the whole risk of
+// writing into a file OneAgent does not own.
+//
+// Taken from ZCode 3.1.3, which carries no "$schema" key. 3.1.1 did, so this
+// fixture doubles as a record of the version the assumptions were checked against.
 const zcodeExisting = `{
-  "$schema": "https://opencode.ai/config.json",
   "provider": {
     "builtin:zai": {
       "name": "Z.ai - API Key",
@@ -506,8 +508,10 @@ func zcodeProviders(t *testing.T, path string) map[string]map[string]any {
 	if err := json.Unmarshal(data, &document); err != nil {
 		t.Fatalf("ZCode config is not valid JSON: %s: %v", data, err)
 	}
-	if document.Schema != "https://opencode.ai/config.json" {
-		t.Fatalf("$schema = %q", document.Schema)
+	// 3.1.3 removed this key, so writing it back would reintroduce a field the app
+	// deliberately dropped.
+	if document.Schema != "" {
+		t.Fatalf("wrote a $schema key the current ZCode does not use: %q", document.Schema)
 	}
 	return document.Provider
 }

--- a/internal/desktopapp/registry.go
+++ b/internal/desktopapp/registry.go
@@ -12,6 +12,7 @@ const (
 	CodexAgentID           = "codex"
 	ConfigAdapterCodex     = "codex"
 	ConfigAdapterWorkBuddy = "workbuddy"
+	ConfigAdapterZCode     = "zcode"
 )
 
 // Definition contains the metadata shared by the desktop lifecycle and the
@@ -24,6 +25,12 @@ type Definition struct {
 	ConfigPath          string
 	ConfigAdapter       string
 	Protocol            string
+	// ManualInstall marks an app OneAgent can detect and configure but not fetch,
+	// because no verifiable installer URL is known for it. Home is where the user
+	// gets it instead. Both exist so the UI can avoid offering an install action
+	// that only returns a link.
+	ManualInstall bool
+	Home          string
 }
 
 type implementation struct {
@@ -58,6 +65,25 @@ var implementations = []implementation{
 		inspect: inspectWorkBuddy,
 		install: installWorkBuddy,
 		open:    openWorkBuddy,
+	},
+	{
+		Definition: Definition{
+			ID:             ZCodeID,
+			Name:           ZCodeName,
+			ProfileAgentID: ZCodeID,
+			ConfigPath:     ".zcode/v2/config.json",
+			ConfigAdapter:  ConfigAdapterZCode,
+			// ZCode accepts either protocol per provider entry, and its own builtin
+			// entries use anthropic. openai is pinned here because that is the
+			// protocol every Provider in providers.lock.json serves, while only
+			// some serve Anthropic.
+			Protocol:      "openai",
+			ManualInstall: true,
+			Home:          ZCodeHome,
+		},
+		inspect: inspectZCode,
+		install: installZCode,
+		open:    openZCode,
 	},
 }
 

--- a/internal/desktopapp/zcode.go
+++ b/internal/desktopapp/zcode.go
@@ -1,0 +1,173 @@
+package desktopapp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	ZCodeID       = "zcode"
+	ZCodeName     = "ZCode"
+	ZCodeBundleID = "dev.zcode.app"
+	// ZCodeMacTeamID is the Developer ID team behind the signed app on macOS,
+	// read from the installed bundle rather than from documentation.
+	ZCodeMacTeamID = "8A5X4JJ39T"
+	ZCodeHome      = "https://zcode.z.ai/"
+)
+
+// inspectZCode reports whether ZCode is installed. There is no install path: no
+// official download endpoint for the app was found, so OneAgent detects and
+// configures an existing installation and points the user at the vendor's site
+// otherwise. Adding a downloader on a guessed URL would put an unverifiable
+// binary behind an install button.
+func inspectZCode(ctx context.Context, options Options) Status {
+	status := baseZCodeStatus(options.Platform.OS)
+	if err := contextError(ctx); err != nil {
+		message := err.Error()
+		status.InspectionUnavailable = &message
+		return status
+	}
+	switch options.Platform.OS {
+	case "macos":
+		found, err := inspectZCodeMacOS(ctx, options)
+		if err != nil {
+			message := err.Error()
+			found.InspectionUnavailable = &message
+		}
+		return found
+	case "windows":
+		found, err := inspectZCodeWindows(options)
+		if err != nil {
+			message := err.Error()
+			found.InspectionUnavailable = &message
+		}
+		return found
+	}
+	return status
+}
+
+// baseZCodeStatus marks the platforms ZCode ships for. Unlike the agents with an
+// installer, "supported" here means OneAgent can detect and configure it.
+func baseZCodeStatus(osID string) Status {
+	supported := osID == "macos" || osID == "windows"
+	return Status{ID: ZCodeID, Name: ZCodeName, Supported: supported, Source: SourceUnknown}
+}
+
+func inspectZCodeMacOS(ctx context.Context, options Options) (Status, error) {
+	status := baseZCodeStatus("macos")
+	roots := options.SearchRoots
+	if len(roots) == 0 {
+		roots = []string{"/Applications"}
+		if options.Home != "" {
+			roots = append(roots, filepath.Join(options.Home, "Applications"))
+		}
+	}
+	var lastErr error
+	for _, root := range roots {
+		candidate := root
+		if !strings.EqualFold(filepath.Ext(root), ".app") {
+			candidate = filepath.Join(root, "ZCode.app")
+		}
+		info, err := os.Stat(candidate)
+		if os.IsNotExist(err) {
+			continue
+		}
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		if !info.IsDir() {
+			continue
+		}
+		metadata, err := readMacMetadata(ctx, options, candidate)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		// The bundle identifier is read from the plist, so a renamed .app cannot
+		// pass as ZCode.
+		if metadata.bundleID != ZCodeBundleID {
+			continue
+		}
+		status.Installed, status.Path, status.Version = true, candidate, metadata.version
+		return status, nil
+	}
+	return status, lastErr
+}
+
+func inspectZCodeWindows(options Options) (Status, error) {
+	status := baseZCodeStatus("windows")
+	for _, candidate := range zcodeWindowsCandidates(options) {
+		info, err := os.Stat(candidate)
+		if os.IsNotExist(err) {
+			continue
+		}
+		if err != nil {
+			return status, err
+		}
+		if info.IsDir() {
+			continue
+		}
+		status.Installed, status.Path = true, candidate
+		return status, nil
+	}
+	return status, nil
+}
+
+// zcodeWindowsCandidates lists the per-user and machine-wide install locations an
+// Electron app of this kind uses. Not verified on Windows: this machine is macOS,
+// so the paths follow the same shape as the WorkBuddy lookup rather than an
+// observed installation.
+func zcodeWindowsCandidates(options Options) []string {
+	if len(options.SearchRoots) > 0 {
+		candidates := make([]string, 0, len(options.SearchRoots))
+		for _, root := range options.SearchRoots {
+			if strings.EqualFold(filepath.Ext(root), ".exe") {
+				candidates = append(candidates, root)
+				continue
+			}
+			candidates = append(candidates, filepath.Join(root, "ZCode.exe"))
+		}
+		return candidates
+	}
+	candidates := make([]string, 0, 3)
+	if options.Home != "" {
+		candidates = append(candidates,
+			filepath.Join(options.Home, "AppData", "Local", "Programs", "ZCode", "ZCode.exe"),
+			filepath.Join(options.Home, "AppData", "Local", "ZCode", "ZCode.exe"),
+		)
+	}
+	return append(candidates, filepath.Join("C:\\", "Program Files", "ZCode", "ZCode.exe"))
+}
+
+func installZCode(ctx context.Context, options Options) (ActionResult, error) {
+	if err := contextError(ctx); err != nil {
+		return ActionResult{}, err
+	}
+	status := inspectZCode(ctx, options)
+	if status.Installed {
+		return ActionResult{Status: "already-installed", Message: ZCodeName + " is already installed", App: status}, nil
+	}
+	// Deliberately not a download. Returning the vendor's page is the honest
+	// answer when no verifiable installer URL is known, and it keeps OneAgent from
+	// fetching an executable from an address it cannot vouch for.
+	return ActionResult{}, fmt.Errorf("%s has no automated installer; download it from %s and run this step again", ZCodeName, ZCodeHome)
+}
+
+func openZCode(ctx context.Context, options Options) error {
+	status := inspectZCode(ctx, options)
+	if !status.Installed {
+		return errors.New(ZCodeName + " is not installed")
+	}
+	switch options.Platform.OS {
+	case "macos":
+		return start(options, []string{"/usr/bin/open", "-a", status.Path})
+	case "windows":
+		return start(options, []string{status.Path})
+	}
+	return fmt.Errorf("%s is not supported on %s", ZCodeName, options.Platform.OS)
+}


### PR DESCRIPTION
Adds ZCode alongside ChatGPT Desktop and WorkBuddy. Provider-only, as agreed — the user picks the model once inside ZCode, which is the division WorkBuddy already uses.

TRAE is **not** included; reasoning at the bottom.

## The documentation was wrong about ZCode

Its docs ([Connect Models](https://zcode.z.ai/en/docs/configuration)) describe only the GUI and name no file path. On disk it turns out to be fully readable, and the schema is one this repository already writes:

```json
"$schema": "https://opencode.ai/config.json"
```

ZCode uses OpenCode's config format. This only came out by inspecting the installed app; taking the docs at face value would have ruled the integration out.

## Why the existing OpenCode adapter could not be reused

Two differences, both load-bearing:

**Custom providers are keyed by UUID, not by a stable name.** The real config on this machine contains `"ed76b5b4-63bb-4cf0-b0f2-7fb651c50cac"` next to `builtin:*` entries. `WriteOpenAICompatible` always writes the key `"oneagent"`; generating a fresh UUID per write — the shape ZCode itself uses — would append a duplicate provider on every reconfiguration. So the adapter **looks up an existing entry by name** and reuses its key. A `builtin:*` key is never reused.

**The entry shape is `kind` / `source` / `apiKeyRequired`, not `npm`.** `apiKeyRequired` matters: without it ZCode treats the endpoint as needing no credential and sends the request unauthenticated, which the Provider then rejects as a missing key.

## Why provider-only

ZCode has **no top-level `model` key**, unlike OpenCode whose schema it shares. I looked for where it records the active model and did not find it: `bot-config.json` is a Feishu bot config, `bots-model-cache.v2.json` is a cache. Writing a guess into state the app owns is worse than asking the user to choose once. The model *is* registered under `models` so it appears in ZCode's picker.

## No installer, and the UI had to stop claiming otherwise

No verifiable download URL for the app was found, so `installZCode` returns the vendor's page instead of fetching an executable from a guessed address.

That exposed a problem my change would otherwise have introduced: both selection pages render **"Install the official desktop application"** for any desktop Agent, which would have been a button that cannot do what it says. `Definition` therefore gains `ManualInstall` and `Home`, surfaced on `DesktopAgentStatus`, and the pages now show "install it yourself first, then OneAgent can configure it" for such an Agent. ChatGPT Desktop and WorkBuddy are unaffected:

```
ChatGPT Desktop  安装官方桌面应用          待安装
WorkBuddy        安装官方桌面应用          待安装
ZCode            需先自行安装，之后可配置    待安装
```

Wails bindings were regenerated with the pinned CLI (`v3.0.0-beta.7`) rather than hand-edited; the diff touches one generated file.

## Verified against the real config, not just a fixture

I ran the adapter against a **copy** of this machine's actual `~/.zcode/v2/config.json` (the live file was never written to):

```
provider 数: 7 -> 8
写入的键: oneagent-62365750c4ff906a
写入的条目: kind=openai source=custom baseURL=https://api.ppio.com/openai/v1 apiKeyRequired=true
```

Every pre-existing entry survived, including the user's own UUID-keyed one with its nested `limit.context`, and no top-level `model` key was introduced. Confirmed afterwards that the live config still has 7 providers and no OneAgent entry.

Three unit tests cover the shape, the idempotency (two writes must not produce two providers), and creating the file when absent. The fixture uses the real config's shape — `builtin:*` plus a UUID entry — because preserving both is the whole risk of writing into a file OneAgent does not own.

## One piece of dead code removed before it shipped

I first wrote an Anthropic branch, since ZCode's own builtin entries use `kind: "anthropic"`. It was unreachable: the registry pins `Protocol: "openai"`, and `ProtocolForAdapter` defaults to openai anyway. Rather than ship a branch nothing can execute, it is gone, with a comment recording that supporting the other kind means giving `Definition` a real protocol choice.

## Mark

Generic Lucide symbol, same basis as WorkBuddy and Aider: ZCode has no mark in lobe-icons, and the only vectors in circulation come from the app bundle, which carries no redistribution grant. **NOTICE is unchanged** and `generate_third_party_licenses.py --check` passes.

## TRAE was not added

Its documentation ([TokenHub](https://intl.cloud.tencent.com/document/product/1300/81034), [SiliconFlow](https://docs.siliconflow.cn/en/usercases/use-siliconcloud-in-trae)) describes GUI-only configuration, and unlike ZCode I could **not verify the disk format — TRAE is not installed here**. [Trae-AI/TRAE#888](https://github.com/Trae-AI/TRAE/issues/888) is an open request for exactly the file-based configuration an adapter would need, and [Trae-Proxy](https://github.com/arch3rPro/Trae-Proxy) reports that custom providers can only be chosen from a fixed list.

Writing into its VS Code-derived internal state would be the same overreach as the Codex CDP injection ruled out earlier, and would break on any TRAE update. If it is wanted, `guide-only` is the honest shape until TRAE offers a config interface. I did not guess at it.

## Verification

`go build`, `go vet`, `go test ./...` — 14 packages. Frontend: 350 tests across 44 files, `tsc --noEmit` clean, build clean. `check-docs.py` passes on 55 files. Console clean in the running app.

The frozen `status-empty-linux-arm64.json` gains the ZCode entry and its two new fields; that file is a deliberate tripwire, so the diff is the point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)