### PR TITLE
Stop bounding the OTA body transfer by wall clock

### DIFF
--- a/cmd/bootagent-desktop/main_wails.go
+++ b/cmd/bootagent-desktop/main_wails.go
@@ -32,6 +32,10 @@ func configureUpdater(appInstance *application.App) binding.UpdateBackend {
 		// Every release ships platform-specific installers plus one OTA .zip.
 		// Only the .zip is a format the updater unpacks.
 		AssetMatcher: binding.ExtractableAssetMatcher,
+		// Supplied rather than left nil: the provider's own default carries a
+		// 30-second Client.Timeout, which bounds the body transfer too and so
+		// made the update impossible on a slow link. See NewUpdateHTTPClient.
+		HTTPClient: binding.NewUpdateHTTPClient(),
 	})
 	if err != nil {
 		slog.Error("BootAgent updater provider is unavailable", "error", err)

--- a/internal/binding/update_client.go
+++ b/internal/binding/update_client.go
@@ -1,0 +1,65 @@
+package binding
+
+import (
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/MaimoryLab/BootAgent/internal/process"
+)
+
+// UpdateStallTimeout is how long the OTA download may receive nothing before it
+// is abandoned. It matches install.DownloadStallTimeout: a stalled socket is
+// unambiguous, and an HTTP body has no reason to go quiet for two minutes and
+// then recover.
+const UpdateStallTimeout = 120 * time.Second
+
+// updateDialTimeout and updateResponseHeaderTimeout bound the phases that should
+// be fast even on a slow link. Only the body transfer is left unbounded, and
+// stall detection covers that.
+const (
+	updateDialTimeout           = 30 * time.Second
+	updateResponseHeaderTimeout = 60 * time.Second
+)
+
+// NewUpdateHTTPClient returns the client the GitHub release provider should use.
+//
+// It deliberately sets no Client.Timeout. That field bounds the whole request
+// including reading the body, so the provider's own default of 30 seconds was a
+// wall-clock budget for the entire OTA transfer: the largest asset is around
+// 7 MB, which made the update impossible below roughly 242 KB/s and identical on
+// every retry, since each attempt restarts the same budget from zero. A user on
+// a working-but-slow link was told the update had failed when nothing was wrong.
+//
+// What replaces it is the split internal/install already uses: phase timeouts
+// for the parts that should be quick, and stall detection for the body, which
+// ends a dead transfer without ever penalising a slow one.
+func NewUpdateHTTPClient() *http.Client {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.DialContext = (&net.Dialer{Timeout: updateDialTimeout}).DialContext
+	transport.TLSHandshakeTimeout = updateDialTimeout
+	transport.ResponseHeaderTimeout = updateResponseHeaderTimeout
+	return &http.Client{Transport: &stallGuardTransport{base: transport, timeout: UpdateStallTimeout}}
+}
+
+// stallGuardTransport applies the stall bound to responses whose body is read by
+// code we do not own.
+//
+// The provider streams the asset inside its own Download method, so there is no
+// copy loop here to wrap -- the response body on the way out is the only hook.
+// The request's context is what the wrapper watches, which is also what makes
+// the task centre's cancel button work during the body transfer rather than only
+// between phases.
+type stallGuardTransport struct {
+	base    http.RoundTripper
+	timeout time.Duration
+}
+
+func (t *stallGuardTransport) RoundTrip(request *http.Request) (*http.Response, error) {
+	response, err := t.base.RoundTrip(request)
+	if err != nil || response == nil || response.Body == nil {
+		return response, err
+	}
+	response.Body = process.StallGuardedBody(request.Context(), response.Body, t.timeout)
+	return response, nil
+}

--- a/internal/binding/update_client_test.go
+++ b/internal/binding/update_client_test.go
@@ -1,0 +1,167 @@
+package binding
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/MaimoryLab/BootAgent/internal/process"
+)
+
+// The defect this guards: as an http.Client.Timeout, 30 seconds bounded the body
+// transfer too, so the OTA download died on any link slower than about
+// 242 KB/s -- and identically on every retry, since each attempt restarted the
+// same budget. A client that sets Timeout at all reintroduces that.
+func TestUpdateClientSetsNoWallClockTimeout(t *testing.T) {
+	if got := NewUpdateHTTPClient().Timeout; got != 0 {
+		t.Fatalf("update client Timeout = %v, want 0 so a slow body is not cut off", got)
+	}
+}
+
+// The phases that should be quick even on a slow link stay bounded. Without
+// these, removing Client.Timeout would leave a dead host hanging on connect.
+func TestUpdateClientBoundsTheFastPhases(t *testing.T) {
+	transport, ok := NewUpdateHTTPClient().Transport.(*stallGuardTransport)
+	if !ok {
+		t.Fatalf("update client transport = %T, want *stallGuardTransport", NewUpdateHTTPClient().Transport)
+	}
+	base, ok := transport.base.(*http.Transport)
+	if !ok {
+		t.Fatalf("guard base = %T, want *http.Transport", transport.base)
+	}
+	if base.TLSHandshakeTimeout != updateDialTimeout {
+		t.Errorf("TLSHandshakeTimeout = %v, want %v", base.TLSHandshakeTimeout, updateDialTimeout)
+	}
+	if base.ResponseHeaderTimeout != updateResponseHeaderTimeout {
+		t.Errorf("ResponseHeaderTimeout = %v, want %v", base.ResponseHeaderTimeout, updateResponseHeaderTimeout)
+	}
+	if base.DialContext == nil {
+		t.Error("DialContext is nil, so the dial is unbounded")
+	}
+	if transport.timeout != UpdateStallTimeout {
+		t.Errorf("stall timeout = %v, want %v", transport.timeout, UpdateStallTimeout)
+	}
+}
+
+// The point of the change: a transfer that keeps arriving, however slowly, runs
+// to completion. This one dribbles bytes for longer than its own stall window
+// and well past the interval between writes, which is what the old wall-clock
+// bound would have killed.
+func TestUpdateClientCompletesASlowButMovingTransfer(t *testing.T) {
+	const chunks = 12
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		flusher, _ := writer.(http.Flusher)
+		for range chunks {
+			_, _ = writer.Write([]byte("x"))
+			if flusher != nil {
+				flusher.Flush()
+			}
+			time.Sleep(20 * time.Millisecond)
+		}
+	}))
+	defer server.Close()
+
+	// A stall window far shorter than the whole transfer: 12 chunks 20ms apart
+	// runs ~240ms in total, so a wall-clock bound of 60ms would fail this while
+	// stall detection lets it through -- no single gap ever reaches 60ms.
+	client := &http.Client{Transport: &stallGuardTransport{base: http.DefaultTransport, timeout: 60 * time.Millisecond}}
+	response, err := client.Get(server.URL)
+	if err != nil {
+		t.Fatalf("slow transfer failed to start: %v", err)
+	}
+	defer response.Body.Close()
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatalf("slow-but-moving transfer was abandoned: %v", err)
+	}
+	if len(body) != chunks {
+		t.Fatalf("read %d bytes, want %d", len(body), chunks)
+	}
+}
+
+// The complement: removing the wall-clock bound must not make a dead socket hang
+// forever. A body that sends headers and then never another byte still ends.
+func TestUpdateClientAbandonsAStalledTransfer(t *testing.T) {
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		writer.Header().Set("Content-Length", "4096")
+		writer.WriteHeader(http.StatusOK)
+		if flusher, ok := writer.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		<-release
+	}))
+	defer func() {
+		close(release)
+		server.Close()
+	}()
+
+	client := &http.Client{Transport: &stallGuardTransport{base: http.DefaultTransport, timeout: 150 * time.Millisecond}}
+	response, err := client.Get(server.URL)
+	if err != nil {
+		t.Fatalf("request failed before the body: %v", err)
+	}
+	defer response.Body.Close()
+	started := time.Now()
+	if _, err := io.ReadAll(response.Body); !errors.Is(err, process.ErrStalled) {
+		t.Fatalf("stalled body error = %v, want ErrStalled", err)
+	}
+	if elapsed := time.Since(started); elapsed > 10*time.Second {
+		t.Fatalf("stall detection took %v", elapsed)
+	}
+}
+
+// Cancelling has to reach a transfer that is already streaming, not just one
+// between phases -- the task centre's cancel button is the user's only way out
+// of a download that is moving too slowly to be worth waiting for.
+func TestUpdateClientCancelReachesTheBodyTransfer(t *testing.T) {
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		writer.Header().Set("Content-Length", "4096")
+		writer.WriteHeader(http.StatusOK)
+		if flusher, ok := writer.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		<-release
+	}))
+	defer func() {
+		close(release)
+		server.Close()
+	}()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Long enough that the stall watchdog cannot be what ends this.
+	client := &http.Client{Transport: &stallGuardTransport{base: http.DefaultTransport, timeout: time.Hour}}
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, server.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	response, err := client.Do(request)
+	if err != nil {
+		t.Fatalf("request failed before the body: %v", err)
+	}
+	defer response.Body.Close()
+	go func() {
+		time.Sleep(80 * time.Millisecond)
+		cancel()
+	}()
+	if _, err := io.ReadAll(response.Body); !errors.Is(err, context.Canceled) {
+		t.Fatalf("cancelled body error = %v, want context.Canceled", err)
+	}
+}
+
+// A disabled stall bound must hand the body back untouched, so a caller that
+// already has its own bound is not double-guarded.
+func TestStallGuardedBodyPassesThroughWhenDisabled(t *testing.T) {
+	body := io.NopCloser(io.LimitReader(nil, 0))
+	if got := process.StallGuardedBody(context.Background(), body, 0); got != body {
+		t.Error("zero stall timeout should return the body unchanged")
+	}
+	if got := process.StallGuardedBody(context.Background(), nil, time.Second); got != nil {
+		t.Error("a nil body should stay nil")
+	}
+}

--- a/internal/process/process.go
+++ b/internal/process/process.go
@@ -114,6 +114,43 @@ func CopyWithStallTimeout(ctx context.Context, destination io.Writer, source io.
 // quiet" from "the overall budget ran out".
 var ErrStalled = errors.New("transfer stalled: no data received within the stall timeout")
 
+// StallGuardedBody applies the same stall bound as CopyWithStallTimeout to a
+// body the caller does not copy itself.
+//
+// CopyWithStallTimeout owns the copy loop, which is no use when the reading
+// happens somewhere we do not control -- a dependency that takes an
+// *http.Client and streams the response internally. Wrapping the body is the
+// only hook left, so this hands back a ReadCloser that fails with ErrStalled
+// once no bytes have arrived for stallTimeout, and reports the context's error
+// if that is cancelled first.
+//
+// Closing the returned value stops the watchdog and closes body. stallTimeout
+// <= 0 returns body unchanged, so a caller with its own bound is unaffected.
+func StallGuardedBody(ctx context.Context, body io.ReadCloser, stallTimeout time.Duration) io.ReadCloser {
+	if body == nil || stallTimeout <= 0 {
+		return body
+	}
+	tracked := &stallReader{ctx: ctx, source: body, timeout: stallTimeout}
+	tracked.touch()
+	return &guardedBody{tracked: tracked, body: body, stop: tracked.watch()}
+}
+
+type guardedBody struct {
+	tracked *stallReader
+	body    io.ReadCloser
+	stop    func()
+	once    sync.Once
+}
+
+func (g *guardedBody) Read(buffer []byte) (int, error) { return g.tracked.Read(buffer) }
+
+func (g *guardedBody) Close() error {
+	// Once, because the watchdog's stop channel is closed rather than sent on,
+	// and http.Client may close a body more than once on the error paths.
+	g.once.Do(g.stop)
+	return g.body.Close()
+}
+
 // stallReader wraps a body so a watchdog can observe whether reads are still
 // arriving. It does not interrupt Read itself -- that is impossible for an
 // arbitrary io.Reader -- it closes the underlying body when one is available,


### PR DESCRIPTION
Closes #181.

## The bug

`configureUpdater` left `github.Config.HTTPClient` nil, so the provider fell back to its own default:

```go
// pkg/updater/providers/github/github.go:100
client = &http.Client{Timeout: 30 * time.Second}
```

`Client.Timeout` bounds **the entire request including reading the body**, and the provider streams the release asset through that same client (`Download` → `followAndStrip` → `p.client`). So 30 seconds was a wall-clock budget for the whole download.

**This made the failure unconditional, not unlucky.** The largest OTA asset is ~7 MB, which puts the floor at roughly **242 KB/s (1.9 Mbps) sustained**. Below that the update can never succeed — and retrying cannot help, because every attempt restarts the same budget from zero. A user on a working-but-slow connection was told the update failed when nothing was wrong.

## Why the fix looks like this

Runtime downloads had this identical bug and it is already fixed. `internal/install/bootstrap.go:22-54` records the reasoning, down to the same sentence:

> as an `http.Client.Timeout` it bounded the whole request including the body, so a transfer that was still making progress died anyway

The self-updater was missed only because its client is constructed inside the Wails dependency rather than in our code, so it never came under that rule. This applies the same split rather than inventing a new one:

- **Phase timeouts** — dial, TLS handshake, response header. The parts that should be fast on any link stay bounded, so removing the wall clock does not leave a dead host hanging on connect.
- **Stall detection on the body** — abandon only when *no bytes at all* arrive for 120s. Slowness is never punished; a genuinely dead socket still ends.

`github.Config` exposes `HTTPClient`, so no fork of the dependency is needed.

## The one structural wrinkle

Stall detection has to wrap the response body, because the reading happens inside the provider's `Download` where there is no copy loop to hook — so the client gets a `RoundTripper` that wraps `resp.Body` on the way out.

`process.StallGuardedBody` exposes the machinery `CopyWithStallTimeout` already owned, for callers that don't do their own copying. The underlying `stallReader` is unchanged, including the part that matters most: it *closes* the body to unblock a read parked in the network stack, since a flag alone wouldn't be noticed until the read returned on its own — which is the case being escaped.

Watching the request's context there has a second effect worth naming: the task centre's cancel button now reaches a transfer that is **already streaming**, not just one between phases.

## Tests

Five new tests in `internal/binding/update_client_test.go`. The load-bearing one is `TestUpdateClientCompletesASlowButMovingTransfer` — 12 chunks 20ms apart, ~240ms total, against a 60ms stall window. It passes because no single gap reaches 60ms, and it is exactly what a wall-clock bound would kill.

I verified it has teeth by reintroducing the bug: adding `Timeout: 60ms` back to that client fails the test with the real production error —

```
slow-but-moving transfer was abandoned: context deadline exceeded
  (Client.Timeout or context cancellation while reading body)
```

The others cover: no `Client.Timeout` is set at all, the fast phases stay bounded, a stalled body still ends with `ErrStalled`, cancel reaches the body transfer, and a disabled stall bound hands the body back untouched.

## Verification

- `go build ./...`, `go vet ./...` — clean
- `go test -race ./...` — **16 packages pass**, no failures
- `python3 scripts/check-docs.py` — ok, 64 markdown files
- `python3 scripts/generate_third_party_licenses.py --check` — clean
- staticcheck not installed locally; left to CI

## Note

The 120s stall window matches `install.DownloadStallTimeout` deliberately, rather than being tuned separately — a stalled socket is equally unambiguous in both cases, and two different numbers for the same judgement would just drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
