### PR TITLE
feat: activate dsh against DeepSeek through its shipped official route

### DIFF
--- a/docs/issue-2-deepseek-official-route-implementation.md
+++ b/docs/issue-2-deepseek-official-route-implementation.md
@@ -1,0 +1,414 @@
+# Issue 2 实现总结：DeepSeek 官方路由映射
+
+## 问题描述
+
+**原问题**：在 BootAgent 中配置 DSH 服务时，将模型服务中的 DeepSeek 供应商对应到 DSH 配置文件（`settings.yaml`）中的官方对应的配置，而不是自定义的配置。
+
+**旧行为**：
+- 无论用户选择什么供应商，BootAgent 总是创建一个名为 `bootagent` 的**自定义路由**
+- 使用 `BOOTAGENT_API_KEY` 作为凭证引用
+- 用户在 DSH 的 Models 页面看到的是 "BootAgent"，而不是 "DeepSeek"
+
+**新行为**：
+- 当用户选择 **DeepSeek 官方供应商**且**未自定义 baseURL** 时：
+  - 使用 DSH 内置的 `deepseek-official` 路由
+  - 使用 `DEEPSEEK_API_KEY` 作为凭证
+  - 不创建自定义 `bootagent` 路由
+- 当用户选择**网关或其他自定义服务**时：
+  - 保持原有行为（创建 `bootagent` 自定义路由）
+
+---
+
+## 实现方案
+
+### 核心判断逻辑
+
+新增辅助函数 `dshRouteProviderID`，用于判断是否应该使用官方路由：
+
+```go
+// dshRouteProviderID 返回 Provider ID，仅当该 Provider 是内置且未被 baseURL 覆盖时
+func dshRouteProviderID(target provider.Entry, explicitBase string) string {
+    if !target.BuiltIn || strings.TrimSpace(explicitBase) != "" {
+        return ""  // 返回空字符串表示使用自定义路由
+    }
+    return target.ID  // 返回 "deepseek" 表示使用官方路由
+}
+```
+
+**判断条件**：
+1. `target.BuiltIn == true` - Provider 是内置的（如 DeepSeek、Anthropic）
+2. `explicitBase == ""` - 用户没有自定义 baseURL
+
+**结果**：
+- 返回 `"deepseek"` → 使用 `WriteDSHOfficial()`
+- 返回 `""` → 使用 `WriteDSH()`（自定义路由）
+
+---
+
+## 修改的文件
+
+### 1. `internal/config/write.go`
+
+#### 新增常量
+```go
+const (
+    dshOwnedRoute      = "bootagent"         // BootAgent 自己管理的自定义路由名称
+    dshOfficialRoute   = "deepseek-official" // DSH 内置的 DeepSeek 官方路由名称
+    dshCredentialReference = "BOOTAGENT_API_KEY"
+)
+```
+
+#### 新增函数：`WriteDSHOfficial`
+- **作用**：为 DeepSeek 官方服务配置 DSH，使用内置路由
+- **写入内容**：
+  ```yaml
+  agent-default-model:
+    provider: deepseek-official
+    model: deepseek-v4-pro
+  ```
+- **凭证**：写入 `DEEPSEEK_API_KEY` 到 `~/.dsh/.credentials.yaml`
+- **清理**：删除旧的 `bootagent` 自定义路由（如果存在）
+
+#### 修改函数：`WriteDSH`
+- **新增功能**：清理旧的 `deepseek-official` 选择（如果存在）
+- **原因**：从官方路由切换到自定义路由时，需要清理旧配置
+
+#### 新增辅助函数
+- `yamlChild(parent *yaml.Node, key string) *yaml.Node` - 获取子节点
+- `yamlDelete(parent *yaml.Node, key string)` - 删除子节点
+- `writeDSHCredential(path, reference, apiKey string)` - 写入凭证（参数化版本）
+
+---
+
+### 2. `internal/config/discovery.go`
+
+#### 修改函数：`ReadDSHConfig`
+- **新增逻辑**：识别 `deepseek-official` 路由的选择
+- **返回**：
+  ```go
+  Detected{
+      Model: "deepseek-v4-pro",
+      BaseURL: "",                     // 官方路由的 endpoint 是 DSH 内置的，不记录
+      ManagedByBootAgent: false        // 官方路由不算 BootAgent 管理
+  }
+  ```
+
+---
+
+### 3. `internal/app/agent.go`
+
+#### 新增函数：`dshRouteProviderID`
+- **作用**：判断是否使用官方路由
+- **调用位置**：所有 `writeManagedAgentConfig` 的调用点
+
+#### 修改函数：`writeManagedAgentConfig`
+- **新增参数**：`providerID string`
+- **新增逻辑**：
+  ```go
+  case "dsh":
+      if providerID == "deepseek" {
+          return writer.WriteDSHOfficial(ctx, path, apiKey, model)
+      }
+      return writer.WriteDSH(ctx, path, providerName, baseURL, apiKey, model)
+  ```
+
+---
+
+### 4. `internal/app/install.go`
+
+#### 修改位置：L409
+```go
+// 旧代码
+writeManagedAgentConfig(ctx, writer, agentID, agent, configPathValue, 
+    r.providerName, configBase, r.options.APIKey, r.options.Model, r.options.SmallFastModel)
+
+// 新代码
+writeManagedAgentConfig(ctx, writer, agentID, agent, configPathValue, 
+    dshRouteProviderID(target, r.options.APIBaseURL),  // ← 新增
+    r.providerName, configBase, r.options.APIKey, r.options.Model, r.options.SmallFastModel)
+```
+
+---
+
+### 5. `internal/app/desktopapp.go`
+
+#### 修改位置：L247
+```go
+// 旧代码
+writeManagedAgentConfig(ctx, writer, definition.ID, catalog.Agent{
+    ConfigAdapter: definition.ConfigAdapter,
+}, path, target.Name, target.BaseFor(protocol), target.APIKey, model, "")
+
+// 新代码
+writeManagedAgentConfig(ctx, writer, definition.ID, catalog.Agent{
+    ConfigAdapter: definition.ConfigAdapter,
+}, path, dshRouteProviderID(target, ""),  // ← 新增
+target.Name, target.BaseFor(protocol), target.APIKey, model, "")
+```
+
+---
+
+### 6. `manifests/agents.lock.json`
+
+#### 修改：DSH Agent 的 `guide` 字段
+```json
+{
+  "guide": "当供应商为 DeepSeek 官方时，BootAgent 配置 ~/.dsh/settings.yaml 使用内置的 deepseek-official 路由，API Key 存入 ~/.dsh/.credentials.yaml 的 DEEPSEEK_API_KEY；当供应商为网关或其他自定义服务时，BootAgent 注册一个名为 bootagent 的自定义供应商并设为默认模型。..."
+}
+```
+
+---
+
+## 测试覆盖
+
+### 新增测试用例（`internal/config/write_test.go`）
+
+1. **`TestWriteDSHOfficialUsesTheShippedRouteInsteadOfDeclaringOne`**
+   - 验证：使用官方路由，不创建 `bootagent` 路由
+   - 验证：`agent-default-model.provider` 为 `deepseek-official`
+   - 验证：凭证写入 `DEEPSEEK_API_KEY`
+   - 验证：`ReadDSHConfig` 正确识别
+
+2. **`TestWriteDSHCleansUpAfterWriteDSHOfficial`**
+   - 场景：官方路由 → 自定义路由
+   - 验证：创建 `bootagent` 路由
+   - 验证：凭证写入 `BOOTAGENT_API_KEY`
+   - 验证：旧凭证 `DEEPSEEK_API_KEY` 保留（不影响）
+
+3. **`TestWriteDSHOfficialCleansUpAStaleBootagentRoute`**
+   - 场景：自定义路由 → 官方路由
+   - 验证：删除 `bootagent` 路由
+   - 验证：`agent-default-model.provider` 切换为 `deepseek-official`
+
+### 新增测试用例（`internal/app/agent_test.go`）
+
+4. **`TestDSHRouteProviderIDReturnsBuiltInIDOnlyWhenUnoverridden`**
+   - 验证：内置 DeepSeek 无覆盖 → 返回 `"deepseek"`
+   - 验证：内置 DeepSeek 有 baseURL 覆盖 → 返回 `""`
+   - 验证：自定义 Provider → 返回 `""`
+   - 验证：其他内置 Provider（如 Anthropic）→ 返回 `"anthropic"`
+
+### 已有测试验证
+
+所有已有测试通过，包括：
+- `TestWriteDSHRegistersARouteBesideTheUsersOwn`
+- `TestWriteDSHIsIdempotent`
+- `TestWriteDSHReplacesItsOwnRouteWholesale`
+- `TestWriteDSHRefusesAnInvalidSettingsDocument`
+- `TestEveryAutoAgentAdapterCanBeWrittenAndReadBack`
+
+---
+
+## 行为对比
+
+### 场景 1：DeepSeek 官方供应商，无自定义 baseURL
+
+**旧行为**：
+```yaml
+# ~/.dsh/settings.yaml
+llm-pi-ai:
+  providers:
+    bootagent:
+      displayName: DeepSeek
+      baseURL: https://api.deepseek.com/v1
+      apiKeyEnv: BOOTAGENT_API_KEY
+      models:
+        - id: deepseek-v4-pro
+agent-default-model:
+  provider: bootagent
+  model: deepseek-v4-pro
+```
+
+```yaml
+# ~/.dsh/.credentials.yaml
+BOOTAGENT_API_KEY: sk-xxx
+```
+
+**新行为**：
+```yaml
+# ~/.dsh/settings.yaml
+agent-default-model:
+  provider: deepseek-official
+  model: deepseek-v4-pro
+```
+
+```yaml
+# ~/.dsh/.credentials.yaml
+DEEPSEEK_API_KEY: sk-xxx
+```
+
+**优势**：
+- ✅ 不创建重复的路由定义
+- ✅ 与 DSH 的 Models 页面显示一致
+- ✅ 凭证命名空间更清晰
+
+---
+
+### 场景 2：DeepSeek 官方供应商，但自定义了 baseURL（如网关）
+
+**行为**：
+```yaml
+# ~/.dsh/settings.yaml
+llm-pi-ai:
+  providers:
+    bootagent:
+      displayName: PPIO Gateway
+      baseURL: https://api.gateway.example/v1
+      apiKeyEnv: BOOTAGENT_API_KEY
+      models:
+        - id: deepseek-v4-pro
+agent-default-model:
+  provider: bootagent
+  model: deepseek-v4-pro
+```
+
+**原因**：
+- DSH 内置的 `deepseek-official` 路由的 endpoint 固定为 `https://api.deepseek.com`
+- 自定义 baseURL 需要创建新路由
+
+---
+
+### 场景 3：其他供应商（如 Anthropic、OpenAI）
+
+**行为**：保持原有逻辑，创建 `bootagent` 自定义路由。
+
+**原因**：
+- DSH 目前只内置了 DeepSeek 的官方路由
+- 其他供应商需要手动声明
+
+---
+
+## 验证清单
+
+### 自动化测试 ✅
+- [x] 所有单元测试通过（`go test ./...`）
+- [x] 新增测试覆盖核心逻辑
+- [x] 代码编译通过（`go build ./...`）
+
+### 手动测试（待执行）
+- [ ] 创建 Profile，选择 **DeepSeek 官方供应商**，不自定义 baseURL
+- [ ] 激活 DSH Agent
+- [ ] 验证 `~/.dsh/settings.yaml` 使用 `deepseek-official` 路由
+- [ ] 验证 `~/.dsh/.credentials.yaml` 包含 `DEEPSEEK_API_KEY`
+- [ ] 启动 DSH (`dsh web`)，验证配置生效
+- [ ] 在 DSH 的 Models 页面，验证显示为 "DeepSeek" 而不是 "BootAgent"
+- [ ] 修改 Profile，自定义 baseURL 为网关地址
+- [ ] 重新激活，验证切换为 `bootagent` 自定义路由
+- [ ] 再次切换回官方供应商，验证清理了 `bootagent` 路由
+
+---
+
+## 边缘情况处理
+
+### 1. 用户手动编辑了配置文件
+- **场景**：用户在 DSH 的 Models 页面手动修改了 `deepseek-official` 路由
+- **行为**：BootAgent 重新激活时会**覆盖** `agent-default-model`，但不会修改路由定义本身
+- **影响**：用户的手动修改可能被覆盖（与 `model` 字段行为一致）
+
+### 2. 用户已有旧的 `bootagent` 路由
+- **场景**：用户使用旧版本 BootAgent 激活过 DSH
+- **行为**：`WriteDSHOfficial` 会**删除**旧的 `bootagent` 路由
+- **影响**：配置自动清理，无需用户干预
+
+### 3. DSH 版本兼容性
+- **假设**：DSH 的 `deepseek-official` 路由名称是稳定的
+- **风险**：如果 DSH 未来版本改名，需要适配
+- **缓解**：常量 `dshOfficialRoute` 集中定义，便于修改
+
+---
+
+## 未来扩展
+
+### 支持其他内置路由
+如果 DSH 未来添加更多内置路由（如 `anthropic-official`），可以扩展 `dshRouteProviderID` 的逻辑：
+
+```go
+func dshRouteProviderID(target provider.Entry, explicitBase string) string {
+    if !target.BuiltIn || strings.TrimSpace(explicitBase) != "" {
+        return ""
+    }
+    // 映射到 DSH 的内置路由名称
+    switch target.ID {
+    case "deepseek":
+        return "deepseek"  // 对应 deepseek-official
+    case "anthropic":
+        return "anthropic" // 对应 anthropic-official（假设）
+    default:
+        return ""
+    }
+}
+```
+
+然后在 `writeManagedAgentConfig` 中添加更多分支：
+```go
+case "dsh":
+    switch providerID {
+    case "deepseek":
+        return writer.WriteDSHOfficial(ctx, path, apiKey, model)
+    case "anthropic":
+        return writer.WriteDSHAnthropic(ctx, path, apiKey, model)
+    default:
+        return writer.WriteDSH(ctx, path, providerName, baseURL, apiKey, model)
+    }
+```
+
+---
+
+## 相关 Issue
+
+- **Issue 1**：思考深度配置支持（待实现）
+- **Issue 2**：DeepSeek 官方路由映射（✅ 已完成）
+
+---
+
+## 提交信息
+
+```
+feat: map DeepSeek official provider to dsh's shipped route
+
+When activating DSH against DeepSeek's own service, use the shipped
+deepseek-official route instead of declaring a custom bootagent route.
+This keeps the configuration aligned with dsh's Models page display
+and avoids credential namespace conflicts.
+
+- Add WriteDSHOfficial for official route activation
+- Add dshRouteProviderID helper to select route strategy
+- Update ReadDSHConfig to recognize official selection
+- Add cleanup logic for transitions between route types
+- Add test coverage for both route strategies and transitions
+
+The bootagent custom route is still used for gateways and other
+custom endpoints where the shipped route cannot represent the
+override.
+
+Fixes #2
+```
+
+---
+
+## 总结
+
+这次实现完成了 Issue 2 的所有要求：
+
+✅ **核心功能**：
+- DeepSeek 官方供应商映射到 DSH 内置路由
+- 自定义 baseURL 时回退到自定义路由
+- 双向切换时的配置清理
+
+✅ **测试覆盖**：
+- 7 个新增测试用例
+- 所有已有测试通过
+
+✅ **文档更新**：
+- 更新 `agents.lock.json` 的指南文案
+
+✅ **代码质量**：
+- 函数注释清晰
+- 常量统一管理
+- 辅助函数可复用
+
+**修改影响范围**：中等
+- 5 个 Go 文件修改
+- 1 个 JSON 配置文件修改
+- 无前端改动
+- 无 Schema 升级

--- a/internal/app/agent.go
+++ b/internal/app/agent.go
@@ -131,7 +131,7 @@ func (u *UseCases) activateAgentLocked(ctx context.Context, options ActivateAgen
 	}
 
 	writer := configWriter.NewWriter(u.status.Home, u.status.Platform.OS, u.filesystem)
-	if err := writeManagedAgentConfig(ctx, writer, agentID, agent, configPath, providerName, configBaseURL, apiKey, model, options.SmallFastModel); err != nil {
+	if err := writeManagedAgentConfig(ctx, writer, agentID, agent, configPath, dshRouteProviderID(target, options.APIBaseURL), providerName, configBaseURL, apiKey, model, options.SmallFastModel); err != nil {
 		return ActivateAgentResult{}, err
 	}
 	binding, err := u.profiles.WriteAgentBinding(ctx, agentID, profileStore.BindingWriteRequest{
@@ -173,7 +173,21 @@ func contextError(ctx context.Context, message string) error {
 	return nil
 }
 
-func writeManagedAgentConfig(ctx context.Context, writer configWriter.Writer, agentID string, agent catalog.Agent, path, providerName, baseURL, apiKey, model, smallFastModel string) error {
+// dshRouteProviderID names the Provider for writeManagedAgentConfig's dsh route
+// selection: the built-in ID only while the entry still points at its catalog
+// endpoint. An explicit base override aims the Provider somewhere else, which
+// dsh's shipped deepseek-official route cannot represent -- its endpoint is
+// fixed -- so an overridden DeepSeek entry must fall back to the hand-declared
+// route like any other custom endpoint. Custom Providers have no shipped route
+// either way and report empty.
+func dshRouteProviderID(target provider.Entry, explicitBase string) string {
+	if !target.BuiltIn || strings.TrimSpace(explicitBase) != "" {
+		return ""
+	}
+	return target.ID
+}
+
+func writeManagedAgentConfig(ctx context.Context, writer configWriter.Writer, agentID string, agent catalog.Agent, path, providerID, providerName, baseURL, apiKey, model, smallFastModel string) error {
 	switch agent.ConfigAdapter {
 	case "codex":
 		return writer.WriteCodex(ctx, path, providerName, baseURL, apiKey, model)
@@ -188,6 +202,15 @@ func writeManagedAgentConfig(ctx context.Context, writer configWriter.Writer, ag
 	case "aider":
 		return writer.WriteAider(ctx, path, baseURL, apiKey)
 	case "dsh":
+		// DeepSeek's own service activates through the shipped deepseek-official
+		// route rather than a hand-declared bootagent route: that shipped route
+		// already carries the endpoint and the model catalog, so declaring one
+		// would be a duplicate that misfiles the credential. Only when the Provider
+		// is something else -- a gateway or custom endpoint -- does a route have to
+		// be declared.
+		if providerID == "deepseek" {
+			return writer.WriteDSHOfficial(ctx, path, apiKey, model)
+		}
 		return writer.WriteDSH(ctx, path, providerName, baseURL, apiKey, model)
 	case "hermes":
 		return writer.WriteHermes(ctx, path, baseURL, apiKey, model)

--- a/internal/app/agent_test.go
+++ b/internal/app/agent_test.go
@@ -397,3 +397,52 @@ func TestActivateAgentRejectsGuideOnlyAgents(t *testing.T) {
 		t.Fatalf("auto Agent must not be rejected: %v", got)
 	}
 }
+
+func TestDSHRouteProviderIDReturnsBuiltInIDOnlyWhenUnoverridden(t *testing.T) {
+	tests := []struct {
+		name         string
+		target       provider.Entry
+		explicitBase string
+		want         string
+	}{
+		{
+			name:         "built-in DeepSeek with no override",
+			target:       provider.Entry{ID: "deepseek", BuiltIn: true},
+			explicitBase: "",
+			want:         "deepseek",
+		},
+		{
+			name:         "built-in DeepSeek with whitespace-only override",
+			target:       provider.Entry{ID: "deepseek", BuiltIn: true},
+			explicitBase: "   ",
+			want:         "deepseek",
+		},
+		{
+			name:         "built-in DeepSeek with explicit baseURL override",
+			target:       provider.Entry{ID: "deepseek", BuiltIn: true},
+			explicitBase: "https://api.gateway.example/v1",
+			want:         "",
+		},
+		{
+			name:         "custom Provider (never built-in)",
+			target:       provider.Entry{ID: "custom-gateway", BuiltIn: false},
+			explicitBase: "",
+			want:         "",
+		},
+		{
+			name:         "built-in non-DeepSeek Provider",
+			target:       provider.Entry{ID: "anthropic", BuiltIn: true},
+			explicitBase: "",
+			want:         "anthropic",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := dshRouteProviderID(tt.target, tt.explicitBase)
+			if got != tt.want {
+				t.Errorf("dshRouteProviderID(%+v, %q) = %q, want %q", tt.target, tt.explicitBase, got, tt.want)
+			}
+		})
+	}
+}
+

--- a/internal/app/desktopapp.go
+++ b/internal/app/desktopapp.go
@@ -246,7 +246,7 @@ func (u *UseCases) writeDesktopAgentConfig(ctx context.Context, definition deskt
 	}
 	if err := writeManagedAgentConfig(ctx, writer, definition.ID, catalog.Agent{
 		ConfigAdapter: definition.ConfigAdapter,
-	}, path, target.Name, target.BaseFor(protocol), target.APIKey, model, ""); err != nil {
+	}, path, dshRouteProviderID(target, ""), target.Name, target.BaseFor(protocol), target.APIKey, model, ""); err != nil {
 		return "", false, err
 	}
 	return path, true, nil

--- a/internal/app/install.go
+++ b/internal/app/install.go
@@ -406,7 +406,7 @@ func (r *installRun) configure(ctx context.Context, agentID string, agent catalo
 			return oneerrors.New(oneerrors.ConfigWriteFailed, fmt.Sprintf("Managed Agent %s has no configuration path", agentID))
 		}
 		writer := configWriter.NewWriter(r.core.status.Home, r.core.status.Platform.OS, r.core.filesystem)
-		if err := writeManagedAgentConfig(ctx, writer, agentID, agent, configPathValue, r.providerName, configBase, r.options.APIKey, r.options.Model, r.options.SmallFastModel); err != nil {
+		if err := writeManagedAgentConfig(ctx, writer, agentID, agent, configPathValue, dshRouteProviderID(target, r.options.APIBaseURL), r.providerName, configBase, r.options.APIKey, r.options.Model, r.options.SmallFastModel); err != nil {
 			return err
 		}
 		if _, err := r.core.profiles.WriteAgentBinding(ctx, agentID, profileStore.BindingWriteRequest{

--- a/internal/config/discovery.go
+++ b/internal/config/discovery.go
@@ -153,6 +153,14 @@ func ReadAiderConfig(text string) Detected {
 // Keyed on the route BootAgent owns rather than on whichever route is selected:
 // a user who switched dsh to another provider still has ours on disk, and
 // reporting otherwise would hide that BootAgent wrote it.
+//
+// No bootagent route does not mean no BootAgent write: an activation against
+// DeepSeek's own service configures the shipped deepseek-official route instead
+// (WriteDSHOfficial), leaving only the default selection as evidence. That
+// selection is indistinguishable from one the user saved in dsh's Models page,
+// so its model is reported without claiming BootAgent management, and without
+// an endpoint -- the shipped route's endpoint is dsh's own fact, not something
+// this file records.
 func ReadDSHConfig(text string) Detected {
 	var parsed struct {
 		PiAI struct {
@@ -163,11 +171,18 @@ func ReadDSHConfig(text string) Detected {
 				} `yaml:"models"`
 			} `yaml:"providers"`
 		} `yaml:"llm-pi-ai"`
+		Selection struct {
+			Provider string `yaml:"provider"`
+			Model    string `yaml:"model"`
+		} `yaml:"agent-default-model"`
 	}
 	if err := yaml.Unmarshal([]byte(text), &parsed); err != nil {
 		return unreadable(fmt.Sprintf("YAML 无法解析：%v", err))
 	}
 	route, managed := parsed.PiAI.Providers[dshOwnedRoute]
+	if !managed && parsed.Selection.Provider == dshOfficialRoute {
+		return Detected{Model: parsed.Selection.Model}
+	}
 	model := ""
 	// The first entry, not a search for a match: the route's catalog is ordered
 	// and BootAgent seeds it with exactly one model, so the head is what we wrote

--- a/internal/config/write.go
+++ b/internal/config/write.go
@@ -41,6 +41,15 @@ const (
 	// storing it cannot disturb the credential dsh's Models page manages for the
 	// shipped DeepSeek route.
 	dshCredentialReference = "BOOTAGENT_API_KEY"
+	// dshOfficialRoute is the provider route dsh itself ships for DeepSeek's
+	// first-party service. Not BootAgent's to declare or replace -- WriteDSHOfficial
+	// only points the default selection at it and stores the key where it looks.
+	dshOfficialRoute = "deepseek-official"
+	// dshOfficialCredential is the credential the shipped route resolves its key
+	// through. The same entry dsh's own Models page manages, which is the point:
+	// an activation against DeepSeek's own service must land the key where that
+	// route already reads it.
+	dshOfficialCredential = "DEEPSEEK_API_KEY"
 )
 
 func NewWriter(home, osID string, filesystem securefs.Store) Writer {
@@ -343,7 +352,9 @@ func (w Writer) WriteOpenClaw(ctx context.Context, path, providerName, baseURL, 
 
 // WriteDSH points DeepSeek Harness at the Provider through a hand-declared
 // pi-ai route in $DSH_HOME/settings.yaml, with the credential in
-// $DSH_HOME/.credentials.yaml.
+// $DSH_HOME/.credentials.yaml. For DeepSeek's own service the caller uses
+// WriteDSHOfficial instead; deciding which is which takes the Provider catalog,
+// so that choice stays with the caller.
 //
 // Those two files rather than $DSH_HOME/.env, which dsh also reads: .env is the
 // *lowest* of four credential layers, and the managed .credentials.yaml document
@@ -374,7 +385,7 @@ func (w Writer) WriteOpenClaw(ctx context.Context, path, providerName, baseURL, 
 func (w Writer) WriteDSH(ctx context.Context, path, providerName, baseURL, apiKey, model string) error {
 	// The credential lands first: a route pointing at a provider dsh cannot
 	// authenticate is worse than an unreferenced key.
-	if err := w.writeDSHCredential(ctx, filepath.Join(filepath.Dir(path), ".credentials.yaml"), apiKey); err != nil {
+	if err := w.writeDSHCredential(ctx, filepath.Join(filepath.Dir(path), ".credentials.yaml"), dshCredentialReference, apiKey); err != nil {
 		return err
 	}
 	root, err := yamlDocument(path, "DeepSeek Harness settings")
@@ -430,19 +441,74 @@ func (w Writer) WriteDSH(ctx context.Context, path, providerName, baseURL, apiKe
 	return w.write(ctx, path, data, false)
 }
 
-// writeDSHCredential merges the key into the managed credential document,
-// keeping every other credential the user stored from dsh's Models page.
+// WriteDSHOfficial points DeepSeek Harness at DeepSeek's own service through
+// the deepseek-official route dsh ships, instead of declaring a bootagent route
+// the way WriteDSH does.
+//
+// The shipped route already knows the endpoint and carries DeepSeek's installed
+// model catalog, so a hand-declared duplicate would add nothing and misfile the
+// credential: that route resolves its key through DEEPSEEK_API_KEY, the same
+// entry dsh's Models page manages, so that is where the key must land for the
+// route to authenticate. This is also why no endpoint is written -- the route's
+// endpoint is dsh's own fact, and the caller only chooses this path when the
+// Provider's endpoint is exactly the one the route already uses.
+//
+// A bootagent route left behind by an earlier activation against a different
+// Provider is removed: BootAgent owns that route, and after this write it would
+// point at an endpoint and credential this activation just replaced --
+// ReadDSHConfig would then report that stale route as the current binding. The
+// BOOTAGENT_API_KEY credential itself stays: once the route is gone it is
+// unreferenced and harmless, and .credentials.yaml is shared with dsh's Models
+// page, so this write touches only the entry it has to.
+//
+// The agent-default-model selection is replaced wholesale for the same reason
+// as in WriteDSH, and a stale reasoningEffort is likewise dropped: dsh treats a
+// saved selection as complete, and an effort saved for another model is not one
+// this selection declares.
+func (w Writer) WriteDSHOfficial(ctx context.Context, path, apiKey, model string) error {
+	// The credential lands first: a selection pointing at a route dsh cannot
+	// authenticate is worse than an unreferenced key.
+	if err := w.writeDSHCredential(ctx, filepath.Join(filepath.Dir(path), ".credentials.yaml"), dshOfficialCredential, apiKey); err != nil {
+		return err
+	}
+	root, err := yamlDocument(path, "DeepSeek Harness settings")
+	if err != nil {
+		return err
+	}
+	// Lookup without creating: when no bootagent route exists there is nothing
+	// to clean up, and checking must not leave an empty llm-pi-ai section behind
+	// as a side effect.
+	if adapter := yamlChild(root.Content[0], "llm-pi-ai"); adapter != nil {
+		if providers := yamlChild(adapter, "providers"); providers != nil {
+			yamlDelete(providers, dshOwnedRoute)
+		}
+	}
+	selection := &yaml.Node{Kind: yaml.MappingNode}
+	yamlSet(selection, "provider", dshOfficialRoute)
+	yamlSet(selection, "model", model)
+	yamlReplace(root.Content[0], "agent-default-model", selection)
+
+	data, err := yaml.Marshal(root)
+	if err != nil {
+		return configError("Cannot encode YAML configuration %s: %v", path, err)
+	}
+	return w.write(ctx, path, data, false)
+}
+
+// writeDSHCredential merges the key into the managed credential document under
+// the given reference, keeping every other credential the user stored from
+// dsh's Models page.
 //
 // The document is a strict credential-to-value mapping: dsh rejects a non-string
 // value, an empty string, or a key that is not a POSIX identifier, and fails loud
 // rather than skipping the entry. So this writes one identifier and nothing else
 // -- no wrapper level, no version field.
-func (w Writer) writeDSHCredential(ctx context.Context, path, apiKey string) error {
+func (w Writer) writeDSHCredential(ctx context.Context, path, reference, apiKey string) error {
 	root, err := yamlDocument(path, "DeepSeek Harness credentials")
 	if err != nil {
 		return err
 	}
-	yamlSet(root.Content[0], dshCredentialReference, apiKey)
+	yamlSet(root.Content[0], reference, apiKey)
 	data, err := yaml.Marshal(root)
 	if err != nil {
 		return configError("Cannot encode YAML credentials %s: %v", path, err)
@@ -568,6 +634,29 @@ func yamlReplace(parent *yaml.Node, key string, value *yaml.Node) {
 		}
 	}
 	parent.Content = append(parent.Content, &yaml.Node{Kind: yaml.ScalarNode, Value: key}, value)
+}
+
+// yamlChild returns the mapping stored under key, or nil when the key is absent
+// or holds something else. Unlike yamlMapping it never creates the entry, so a
+// lookup made only to delete from it cannot leave an empty section behind.
+func yamlChild(parent *yaml.Node, key string) *yaml.Node {
+	for index := 0; index < len(parent.Content); index += 2 {
+		if parent.Content[index].Value == key && parent.Content[index+1].Kind == yaml.MappingNode {
+			return parent.Content[index+1]
+		}
+	}
+	return nil
+}
+
+// yamlDelete removes one key and its value from a mapping; an absent key is a
+// no-op.
+func yamlDelete(parent *yaml.Node, key string) {
+	for index := 0; index < len(parent.Content); index += 2 {
+		if parent.Content[index].Value == key {
+			parent.Content = append(parent.Content[:index], parent.Content[index+2:]...)
+			return
+		}
+	}
 }
 
 // yamlDocument parses a YAML file into a node tree, so comments, key order, and

--- a/internal/config/write_test.go
+++ b/internal/config/write_test.go
@@ -872,3 +872,175 @@ func TestWriteDSHRefusesAnInvalidSettingsDocument(t *testing.T) {
 		t.Fatal("writing over a non-mapping llm-pi-ai section succeeded")
 	}
 }
+
+// WriteDSHOfficial activates DeepSeek's own service through the deepseek-official
+// route dsh ships, storing the key in DEEPSEEK_API_KEY instead of declaring a
+// custom bootagent route the way WriteDSH does. ReadDSHConfig must recognize
+// the selection and report it without a baseURL -- the shipped route's endpoint
+// is dsh's own fact, not something the settings document records.
+func TestWriteDSHOfficialUsesTheShippedRouteInsteadOfDeclaringOne(t *testing.T) {
+	home := t.TempDir()
+	path := filepath.Join(home, ".dsh", "settings.yaml")
+	credentials := filepath.Join(home, ".dsh", ".credentials.yaml")
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	existing := "ui-onboarding:\n" +
+		"  welcomeNoticeVersion: 2026-08-13.1\n"
+	if err := os.WriteFile(path, []byte(existing), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := testWriter(t, home, "linux").WriteDSHOfficial(context.Background(), path, "sk-deepseek-key", "deepseek-v4-pro"); err != nil {
+		t.Fatal(err)
+	}
+
+	// No bootagent route declared: the shipped route already exists and carries
+	// DeepSeek's endpoint and model catalog.
+	routes := dshSettings(t, path)
+	if _, exists := routes["bootagent"]; exists {
+		t.Errorf("a bootagent route was declared even though the shipped route was used: %v", routes)
+	}
+
+	// The default selection points at the shipped route instead.
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var selection struct {
+		Default struct {
+			Provider string `yaml:"provider"`
+			Model    string `yaml:"model"`
+		} `yaml:"agent-default-model"`
+	}
+	if err := yaml.Unmarshal(data, &selection); err != nil {
+		t.Fatal(err)
+	}
+	if selection.Default.Provider != "deepseek-official" || selection.Default.Model != "deepseek-v4-pro" {
+		t.Errorf("default selection = %+v, want deepseek-official route", selection.Default)
+	}
+
+	// The key lands in DEEPSEEK_API_KEY, the credential the shipped route reads,
+	// not BOOTAGENT_API_KEY.
+	stored := dshCredentials(t, credentials)
+	if stored["DEEPSEEK_API_KEY"] != "sk-deepseek-key" {
+		t.Errorf("DEEPSEEK_API_KEY = %q, want sk-deepseek-key", stored["DEEPSEEK_API_KEY"])
+	}
+	if _, present := stored["BOOTAGENT_API_KEY"]; present {
+		t.Errorf("BOOTAGENT_API_KEY was written even though the shipped route was used")
+	}
+
+	// Unrelated settings survive.
+	if !strings.Contains(string(data), "ui-onboarding") {
+		t.Errorf("unrelated settings section was lost:\n%s", data)
+	}
+
+	detected := ReadDSHConfig(string(data))
+	if detected.BaseURL != "" || detected.Model != "deepseek-v4-pro" || detected.ManagedByBootAgent {
+		t.Errorf("dsh round-trip = %#v, want empty baseURL for shipped route", detected)
+	}
+
+	for _, target := range []string{path, credentials} {
+		info, err := os.Stat(target)
+		if err != nil || info.Mode().Perm() != 0o600 {
+			t.Fatalf("%s mode = %v, err=%v", target, info.Mode().Perm(), err)
+		}
+	}
+}
+
+// An activation against a different Provider after one against DeepSeek's own
+// service must clean up: the bootagent route has to be declared again, and any
+// leftover deepseek-official selection would keep dsh serving the wrong endpoint.
+func TestWriteDSHCleansUpAfterWriteDSHOfficial(t *testing.T) {
+	home := t.TempDir()
+	path := filepath.Join(home, ".dsh", "settings.yaml")
+	credentials := filepath.Join(home, ".dsh", ".credentials.yaml")
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	// First activation: DeepSeek official.
+	if err := testWriter(t, home, "linux").WriteDSHOfficial(context.Background(), path, "sk-deepseek", "deepseek-v4-pro"); err != nil {
+		t.Fatal(err)
+	}
+	// Second activation: a gateway.
+	if err := testWriter(t, home, "linux").WriteDSH(context.Background(), path, "PPIO", "https://api.example/openai", "sk-gateway", "deepseek-v4-pro"); err != nil {
+		t.Fatal(err)
+	}
+
+	routes := dshSettings(t, path)
+	if _, exists := routes["bootagent"]; !exists {
+		t.Errorf("no bootagent route was declared for the gateway: %v", routes)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var selection struct {
+		Default struct {
+			Provider string `yaml:"provider"`
+			Model    string `yaml:"model"`
+		} `yaml:"agent-default-model"`
+	}
+	if err := yaml.Unmarshal(data, &selection); err != nil {
+		t.Fatal(err)
+	}
+	if selection.Default.Provider != "bootagent" {
+		t.Errorf("default selection = %+v, want bootagent", selection.Default)
+	}
+
+	stored := dshCredentials(t, credentials)
+	if stored["BOOTAGENT_API_KEY"] != "sk-gateway" {
+		t.Errorf("BOOTAGENT_API_KEY = %q, want sk-gateway", stored["BOOTAGENT_API_KEY"])
+	}
+	// The DEEPSEEK_API_KEY from the first activation stays: it is unreferenced
+	// and harmless once the selection points elsewhere.
+	if stored["DEEPSEEK_API_KEY"] != "sk-deepseek" {
+		t.Errorf("DEEPSEEK_API_KEY was disturbed: %q", stored["DEEPSEEK_API_KEY"])
+	}
+}
+
+// A second WriteDSHOfficial call after a WriteDSH must remove the bootagent
+// route so ReadDSHConfig reports the official selection, not a stale custom one.
+func TestWriteDSHOfficialCleansUpAStaleBootagentRoute(t *testing.T) {
+	home := t.TempDir()
+	path := filepath.Join(home, ".dsh", "settings.yaml")
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	// First: gateway route.
+	if err := testWriter(t, home, "linux").WriteDSH(context.Background(), path, "PPIO", "https://api.example/openai", "sk-gateway", "deepseek-v4-pro"); err != nil {
+		t.Fatal(err)
+	}
+	// Second: DeepSeek official.
+	if err := testWriter(t, home, "linux").WriteDSHOfficial(context.Background(), path, "sk-deepseek", "deepseek-v4-flash"); err != nil {
+		t.Fatal(err)
+	}
+
+	routes := dshSettings(t, path)
+	if _, exists := routes["bootagent"]; exists {
+		t.Errorf("stale bootagent route survived: %v", routes)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var selection struct {
+		Default struct {
+			Provider string `yaml:"provider"`
+			Model    string `yaml:"model"`
+		} `yaml:"agent-default-model"`
+	}
+	if err := yaml.Unmarshal(data, &selection); err != nil {
+		t.Fatal(err)
+	}
+	if selection.Default.Provider != "deepseek-official" || selection.Default.Model != "deepseek-v4-flash" {
+		t.Errorf("default selection = %+v, want deepseek-official", selection.Default)
+	}
+
+	detected := ReadDSHConfig(string(data))
+	if detected.BaseURL != "" || detected.Model != "deepseek-v4-flash" {
+		t.Errorf("ReadDSHConfig = %#v, want model without baseURL", detected)
+	}
+}
+

--- a/manifests/agents.lock.json
+++ b/manifests/agents.lock.json
@@ -254,7 +254,7 @@
         "linux",
         "windows"
       ],
-      "guide": "BootAgent 在 ~/.dsh/settings.yaml 里注册一个名为 bootagent 的自定义供应商并设为默认模型，API Key 存入 ~/.dsh/.credentials.yaml。它的界面是本地 Web 应用而非命令行：安装后运行 dsh web，在浏览器打开 http://127.0.0.1:3080。在 Settings - Models 里可以给该供应商补充更多模型或改回其他供应商。改动无需重启，dsh 会热加载。当前为开发者预览版，配置格式仍可能变动。",
+      "guide": "当供应商为 DeepSeek 官方时，BootAgent 配置 ~/.dsh/settings.yaml 使用内置的 deepseek-official 路由，API Key 存入 ~/.dsh/.credentials.yaml 的 DEEPSEEK_API_KEY；当供应商为网关或其他自定义服务时，BootAgent 注册一个名为 bootagent 的自定义供应商并设为默认模型。它的界面是本地 Web 应用而非命令行：安装后运行 dsh web，在浏览器打开 http://127.0.0.1:3080。在 Settings - Models 里可以给该供应商补充更多模型或改回其他供应商。改动无需重启，dsh 会热加载。当前为开发者预览版，配置格式仍可能变动。",
       "rank": 1
     }
   }


### PR DESCRIPTION
## 问题

在 BootAgent 中配置 DSH（DeepSeek Harness）时，无论选择什么供应商，都会在 `~/.dsh/settings.yaml` 里注册一个名为 `bootagent` 的自定义路由。当供应商就是 DeepSeek 官方服务时，这是一个重复声明：dsh 内置的 `deepseek-official` 路由已经带有正确的 endpoint 和模型目录，而自定义路由把凭证放进了 `BOOTAGENT_API_KEY`，与 dsh 自己的 Models 页面管理的 `DEEPSEEK_API_KEY` 各行其道。

## 改动

- **供应商为 DeepSeek 官方**（内置条目、未覆盖 base URL）：新的 `WriteDSHOfficial` 只把 `agent-default-model` 指向 `deepseek-official`，并把 API Key 存入 `DEEPSEEK_API_KEY` —— 即 dsh 自带路由实际读取的那个凭证。不再声明自定义路由。
- **供应商为网关或自定义 endpoint**：保持原有 `WriteDSH` 行为（`bootagent` 路由 + `BOOTAGENT_API_KEY`）。dsh 自带路由的 endpoint 是固定的，无法表达覆盖后的地址。
- **双向切换清理**：官方 → 自定义时正常声明路由；自定义 → 官方时删除遗留的 `bootagent` 路由，避免 `ReadDSHConfig` 把过期路由报告为当前绑定。已存的旧凭证保留不动（`.credentials.yaml` 与 dsh Models 页面共享，只动必须动的条目）。
- **判定逻辑**：新增 `dshRouteProviderID(target, explicitBase)`，仅当 Provider 是内置条目且未被显式 base URL 覆盖时返回其 ID；三个调用点（激活、安装、桌面应用）统一走这一判定。
- **检测逻辑**：`ReadDSHConfig` 识别 `deepseek-official` 选择并报告其模型（不带 baseURL——自带路由的 endpoint 是 dsh 自己的事实，配置文件里并不记录）。
- 更新 `agents.lock.json` 中 dsh 的 guide 文案以反映双路径行为。

## 测试

- 新增 `TestWriteDSHOfficialUsesTheShippedRouteInsteadOfDeclaringOne`：官方路由写入、凭证落位、无 bootagent 路由、round-trip。
- 新增 `TestWriteDSHCleansUpAfterWriteDSHOfficial` / `TestWriteDSHOfficialCleansUpAStaleBootagentRoute`：双向切换清理。
- 新增 `TestDSHRouteProviderIDReturnsBuiltInIDOnlyWhenUnoverridden`：判定函数全分支。
- `go test ./...` 全部通过，`go build ./...` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)