### PR TITLE
fix: pass paths to PowerShell via environment instead of -Command args

### DIFF
--- a/internal/desktopapp/desktopapp.go
+++ b/internal/desktopapp/desktopapp.go
@@ -500,7 +500,8 @@ type windowsPackage struct {
 }
 
 func chatGPTWindowsPackageQuery() []string {
-	script := `$items = @(
+	script := `[Console]::OutputEncoding = [Text.Encoding]::UTF8
+$items = @(
   Get-AppxPackage -Name 'OpenAI.Codex' -ErrorAction SilentlyContinue
   Get-AppxPackage -Name 'OpenAI.CodexBeta' -ErrorAction SilentlyContinue
   Get-AppxPackage -Name 'OpenAI.ChatGPT-Desktop' -ErrorAction SilentlyContinue
@@ -510,7 +511,8 @@ $items | Sort-Object Version -Descending | Select-Object -First 1 Name,PackageFu
 }
 
 func chatGPTWindowsStartAppsQuery() []string {
-	script := `Get-StartApps | Where-Object { $_.AppID -like 'OpenAI.Codex_*!App' -or $_.AppID -like 'OpenAI.CodexBeta_*!App' -or $_.AppID -like 'OpenAI.ChatGPT-Desktop_*!App' } | Select-Object -First 1 -ExpandProperty AppID`
+	script := `[Console]::OutputEncoding = [Text.Encoding]::UTF8
+Get-StartApps | Where-Object { $_.AppID -like 'OpenAI.Codex_*!App' -or $_.AppID -like 'OpenAI.CodexBeta_*!App' -or $_.AppID -like 'OpenAI.ChatGPT-Desktop_*!App' } | Select-Object -First 1 -ExpandProperty AppID`
 	return []string{"powershell.exe", "-NoProfile", "-NonInteractive", "-Command", script}
 }
 

--- a/internal/desktopapp/desktopapp_test.go
+++ b/internal/desktopapp/desktopapp_test.go
@@ -755,3 +755,69 @@ func TestVerifyMacOSAppRejectsNonNotarizedDeveloperIDSource(t *testing.T) {
 		t.Fatalf("verification continued after Gatekeeper failure: %#v", runner.calls)
 	}
 }
+
+func TestVerifyWindowsInstallerPassesPathViaEnvironment(t *testing.T) {
+	runner := &scriptedRunner{results: []process.Result{{
+		ExitCode: 0,
+		Stdout:   `{"Status":"Valid","StatusMessage":"Signature verified.","Publisher":"Microsoft Corporation","Organization":"Microsoft Corporation","Subject":"CN=Microsoft Corporation, O=Microsoft Corporation","Issuer":"CN=Microsoft Marketplace CA G 024"}`,
+	}}}
+	installerPath := `C:\Users\test with spaces\ChatGPT's installer.exe`
+
+	if err := verifyChatGPTWindowsInstaller(context.Background(), Options{Runner: runner}, installerPath); err != nil {
+		t.Fatalf("verifyChatGPTWindowsInstaller() error = %v", err)
+	}
+	if len(runner.calls) != 1 {
+		t.Fatalf("verification calls = %#v", runner.calls)
+	}
+	argv := runner.calls[0]
+	// powershell -Command treats trailing tokens as command text, not $args, so
+	// the installer path must never be appended to argv.
+	if argv[len(argv)-1] != argv[4] || len(argv) != 5 {
+		t.Fatalf("installer path appended to powershell argv: %#v", argv)
+	}
+	script := argv[4]
+	if !strings.Contains(script, "$env:BOOTAGENT_VERIFY_PATH") {
+		t.Fatalf("verification script does not read the path environment variable: %q", script)
+	}
+	if got := runner.environments[0]["BOOTAGENT_VERIFY_PATH"]; got != installerPath {
+		t.Fatalf("BOOTAGENT_VERIFY_PATH = %q, want %q", got, installerPath)
+	}
+}
+
+func TestWorkBuddyWindowsVersionPassesPathViaEnvironment(t *testing.T) {
+	runner := &scriptedRunner{results: []process.Result{{ExitCode: 0, Stdout: "5.3.11\n"}}}
+	path := `C:\Users\test\AppData\Local\Programs\WorkBuddy\WorkBuddy.exe`
+
+	version := workBuddyWindowsVersion(context.Background(), Options{Runner: runner}, path)
+	if version == nil || *version != "5.3.11" {
+		t.Fatalf("workBuddyWindowsVersion() = %v, want 5.3.11", version)
+	}
+	argv := runner.calls[0]
+	if len(argv) != 5 {
+		t.Fatalf("version query appended arguments to powershell argv: %#v", argv)
+	}
+	if !strings.Contains(argv[4], "$env:BOOTAGENT_VERSION_PATH") {
+		t.Fatalf("version script does not read the path environment variable: %q", argv[4])
+	}
+	if got := runner.environments[0]["BOOTAGENT_VERSION_PATH"]; got != path {
+		t.Fatalf("BOOTAGENT_VERSION_PATH = %q, want %q", got, path)
+	}
+}
+
+func TestWorkBuddyStartAppsQueryPassesNameViaEnvironment(t *testing.T) {
+	argv, environment := workBuddyStartAppsQuery(workBuddyIntl)
+	if len(argv) != 5 {
+		t.Fatalf("start-apps query argv = %#v", argv)
+	}
+	script := argv[4]
+	if strings.Contains(script, "WorkBuddy") {
+		t.Fatalf("display name interpolated into the script: %q", script)
+	}
+	if !strings.Contains(script, "$env:BOOTAGENT_APP_NAME") {
+		t.Fatalf("start-apps script does not read the name environment variable: %q", script)
+	}
+	expectedName := strings.TrimSuffix(workBuddyIntl.appName, ".app")
+	if got := environment["BOOTAGENT_APP_NAME"]; got != expectedName {
+		t.Fatalf("BOOTAGENT_APP_NAME = %q, want %q", got, expectedName)
+	}
+}

--- a/internal/desktopapp/windows_verify.go
+++ b/internal/desktopapp/windows_verify.go
@@ -50,8 +50,8 @@ func verifyWindowsInstallerPublisher(ctx context.Context, options Options, insta
 	result, err := runWithEnvironment(
 		options,
 		ctx,
-		append(windowsAuthenticodeQuery(), installerPath),
-		nil,
+		windowsAuthenticodeQuery(),
+		map[string]string{"BOOTAGENT_VERIFY_PATH": installerPath},
 		installTimeout,
 	)
 	if err != nil {
@@ -97,7 +97,8 @@ func approvedWindowsSigner(value string, allowed []string) bool {
 }
 
 func windowsAuthenticodeQuery() []string {
-	const script = `$signature = Get-AuthenticodeSignature -LiteralPath $args[0]
+	const script = `[Console]::OutputEncoding = [Text.Encoding]::UTF8
+$signature = Get-AuthenticodeSignature -LiteralPath $env:BOOTAGENT_VERIFY_PATH
 $certificate = $signature.SignerCertificate
 $organization = ""
 $publisher = ""

--- a/internal/desktopapp/workbuddy.go
+++ b/internal/desktopapp/workbuddy.go
@@ -201,7 +201,8 @@ func inspectWorkBuddyWindows(ctx context.Context, edition workBuddyEdition, opti
 			return status, nil
 		}
 	}
-	result, err := run(options, ctx, workBuddyStartAppsQuery(edition), inspectTimeout)
+	argv, environment := workBuddyStartAppsQuery(edition)
+	result, err := runWithEnvironment(options, ctx, argv, environment, inspectTimeout)
 	if err != nil {
 		return status, err
 	}
@@ -258,8 +259,9 @@ func workBuddyWindowsCandidates(edition workBuddyEdition, options Options) []str
 }
 
 func workBuddyWindowsVersion(ctx context.Context, options Options, path string) *string {
-	argv := []string{"powershell.exe", "-NoProfile", "-NonInteractive", "-Command", `(Get-Item -LiteralPath $args[0]).VersionInfo.ProductVersion`, path}
-	result, err := runWithEnvironment(options, ctx, argv, nil, inspectTimeout)
+	const script = `[Console]::OutputEncoding = [Text.Encoding]::UTF8
+(Get-Item -LiteralPath $env:BOOTAGENT_VERSION_PATH).VersionInfo.ProductVersion`
+	result, err := runWithEnvironment(options, ctx, []string{"powershell.exe", "-NoProfile", "-NonInteractive", "-Command", script}, map[string]string{"BOOTAGENT_VERSION_PATH": path}, inspectTimeout)
 	if err != nil || result.ExitCode != 0 {
 		return nil
 	}
@@ -267,11 +269,14 @@ func workBuddyWindowsVersion(ctx context.Context, options Options, path string) 
 }
 
 // workBuddyStartAppsQuery matches on the Start menu display name, which carries
-// no ".app" suffix.
-func workBuddyStartAppsQuery(edition workBuddyEdition) []string {
+// no ".app" suffix. The name reaches the script through an environment variable
+// rather than string interpolation, so quoting in the display name cannot alter
+// the script. Returns the argv and environment map for runWithEnvironment.
+func workBuddyStartAppsQuery(edition workBuddyEdition) ([]string, map[string]string) {
 	name := strings.TrimSuffix(edition.appName, ".app")
-	script := `Get-StartApps | Where-Object { $_.Name -eq '` + name + `' } | Select-Object -First 1 Name,AppID | ConvertTo-Json -Compress`
-	return []string{"powershell.exe", "-NoProfile", "-NonInteractive", "-Command", script}
+	const script = `[Console]::OutputEncoding = [Text.Encoding]::UTF8
+Get-StartApps | Where-Object { $_.Name -eq $env:BOOTAGENT_APP_NAME } | Select-Object -First 1 Name,AppID | ConvertTo-Json -Compress`
+	return []string{"powershell.exe", "-NoProfile", "-NonInteractive", "-Command", script}, map[string]string{"BOOTAGENT_APP_NAME": name}
 }
 
 func installWorkBuddy(edition workBuddyEdition) func(context.Context, Options) (ActionResult, error) {


### PR DESCRIPTION
## 问题

`powershell.exe -Command <script> <path>` 会把脚本字符串之后的所有 token 拼进命令文本，而不是变成 `$args`。这导致两个连锁错误（见 Windows 端安装日志）：

1. `Get-AuthenticodeSignature -LiteralPath $args[0]` 收到 `$null` → `ParameterArgumentValidationErrorNullNotAllowed`
2. 安装包路径被接到脚本最后一行 `ConvertTo-Json -Compress` 之后 → `InputObjectNotBound`

## 影响面

- **所有 Windows 桌面应用安装全部失败**：`verifyWindowsInstallerPublisher` 是 ChatGPT Desktop、WorkBuddy（国内/国际版）、ZCode 四条 Windows 安装链路共用的验签入口，验签必然报错，安装中断。
- **WorkBuddy 版本探测静默失效**：`workBuddyWindowsVersion` 用了相同的错误模式，失败返回 nil，表现为已安装的 WorkBuddy 永远显示不出版本号。
- **注入隐患**：`workBuddyStartAppsQuery` 把应用显示名直接拼进 PowerShell 单引号字符串。
- **中文 Windows 上报错乱码**：PowerShell 按 GBK 输出、BootAgent 按 UTF-8 解码，错误原文全部变成菱形问号。

## 修复

统一改为**通过环境变量传参**（`runWithEnvironment` 原生支持），彻底绕开 `-Command` 的拼接语义与路径引号转义问题：

- 验签脚本改读 `$env:BOOTAGENT_VERIFY_PATH`，argv 不再携带路径
- 版本查询改读 `$env:BOOTAGENT_VERSION_PATH`
- StartApps 查询改读 `$env:BOOTAGENT_APP_NAME`，消除字符串拼接
- 全部 5 个 PowerShell 脚本开头统一 `[Console]::OutputEncoding = [Text.Encoding]::UTF8`

macOS 侧（codesign/spctl/plutil/hdiutil/ditto）均为正常 argv 传参，审查后无需改动。

## 测试

新增 3 个测试，断言路径/名称只通过环境变量到达、不出现在 argv 或脚本文本中（验签测试使用含空格和单引号的路径）：

- `TestVerifyWindowsInstallerPassesPathViaEnvironment`
- `TestWorkBuddyWindowsVersionPassesPathViaEnvironment`
- `TestWorkBuddyStartAppsQueryPassesNameViaEnvironment`

```
go vet ./internal/desktopapp/   # 通过
go test ./internal/desktopapp/  # ok（含 3 个新测试）
go build ./... && go test ./... # 全仓通过
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)