### PR TITLE
docs: sync the READMEs with what the code ships

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,8 +20,10 @@ frontend/playwright-report/
 # CI 跑 scripts/ 下的 unittest 会留下字节码
 __pycache__/
 
-# 可再生的产物：imagegen 设计稿与工具自动生成的 repowiki
+# 可再生的产物：imagegen 设计稿与工具自动生成的 repowiki。outputs/ 是同一类目录的
+# 复数写法，单数那条匹配不到它。
 output/
+outputs/
 .qoder/
 
 # Go 桌面应用的本地构建产物。
@@ -55,3 +57,13 @@ cmd/bootagent-desktop/*.syso
 # 一次性的发行走查清单：记录某个 tag 的产物校验与实测结果，对某一次发布有用，
 # 但不是长期有效的规范。留在本机备查，不进仓库。
 docs/internal/v0.3.0-full-platform-test-plan.md
+
+# 把 Release 同步到内部飞书云空间的本机运维脚本：内含私有域名与文件夹 token，
+# 且只对维护者自己的机器有意义。同目录的 launchd plist 写死了本机 HOME 与日志
+# 路径，logs/ 是它的运行时产物。三者都留在本机，不随开源仓库分发。
+scripts/sync_release_to_feishu.py
+scripts/com.bootagent.release-sync.plist
+scripts/logs/
+
+# 仓库现状速览：本机生成的一次性笔记，会随代码立刻过时，读代码比读它更可靠。
+/overview.md

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ BootAgent is a local desktop workspace for AI coding Agents. It turns a fresh ma
 - Migrates existing Codex and ChatGPT Desktop conversations into BootAgent's `bootagent` provider bucket from their Agent rows. This operation intentionally creates no history backup.
 - Connects Agents to built-in or custom Providers, with model selection and protocol-aware connection checks.
 - Saves reusable Profiles and applies the right configuration to each Agent.
+- Carries a Profile's reasoning effort (`off`, `low`, `medium`, `high`, `max`) into every Agent whose own config format documents a place for it, translating the scale to what each one accepts. Agents with no documented depth setting are left alone rather than given invented keys.
 - Bootstraps required runtimes such as Node.js, uv, and Aider's managed Python when needed.
 - Keeps long-running installs visible and cancellable in the Task Center.
 - Imports and exports Providers, Profiles, and selected MCP servers. API keys and MCP secrets are excluded by default; password-encrypted or explicitly confirmed plaintext export is also available.
@@ -31,11 +32,13 @@ BootAgent is a local desktop workspace for AI coding Agents. It turns a fresh ma
 | CLI Agents | Desktop Agents |
 | --- | --- |
 | Codex · Claude Code | ChatGPT Desktop（macOS/Windows） |
-| Kilo CLI · Aider· OpenCode | WorkBuddy（macOS/Windows） |
-| Hermes Agent · OpenClaw | |
-| Kimi Code | |
+| Kilo CLI · Aider · OpenCode | WorkBuddy · WorkBuddy AI（macOS/Windows） |
+| Hermes Agent · OpenClaw | ZCode（macOS/Windows） |
+| Kimi Code · DeepSeek Harness | |
 
 JieKou.AI, PPIO, Novita, DeepSeek and Moonshot are built in, listed in that order. Any OpenAI-compatible or Anthropic-compatible Provider can be added from the Provider page. BootAgent probes the protocol an Agent actually uses; an endpoint that only exposes a different API is rejected before configuration is written.
+
+DeepSeek Harness can also be activated against DeepSeek's own official route, which its shipped configuration already defines, instead of going through a generic OpenAI-compatible endpoint.
 
 The MCP Registry is user-level only and stored locally. It supports stdio, HTTP, and SSE servers for Claude Code, Codex, OpenCode, Kilo CLI, and Hermes. Select sync targets explicitly and apply changes when ready; clearing all targets removes the server from Agent configs but keeps it in the Registry. Deleting a server removes it from Agent configs first and from the Registry only after the application succeeds. MCP exports are selected per server and carry no Agent bindings, so they can be imported on another machine before choosing local targets.
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -19,6 +19,7 @@ BootAgent 是一个本地桌面工作台，用来统一管理 AI 编程 Agent。
 - 可从 Codex 与 ChatGPT Desktop 的 Agent 行把现有对话迁入 BootAgent 的 `bootagent` Provider 分桶；此操作按设计不创建历史备份。
 - 连接内置或自定义模型服务（Provider），选择模型，并按 Agent 实际协议检查连接。
 - 保存可复用的配置模版（Profile），一键应用到对应 Agent。
+- 把 Profile 上的思考深度（`off`、`low`、`medium`、`high`、`max`）写入每个自身配置格式有对应位置的 Agent，并按各自接受的取值做换算。没有文档化深度设置的 Agent 保持原样，不会被塞进自造的字段。
 - 按需准备 Node.js、uv，以及 Aider 所需的托管 Python 运行时。
 - 长时间安装任务在任务中心持续可见，并且可以取消。
 - 导入和导出 Provider、Profile 以及选中的 MCP 服务器；默认不导出 API Key 和 MCP 秘密，也支持密码加密或明确确认后的明文导出。
@@ -31,11 +32,13 @@ BootAgent 是一个本地桌面工作台，用来统一管理 AI 编程 Agent。
 | CLI Agent | 桌面 Agent |
 | --- | --- |
 | Codex · Claude Code | ChatGPT Desktop（macOS/Windows） |
-| Kilo CLI · Aider· OpenCode | WorkBuddy（macOS/Windows） |
-| Hermes Agent · OpenClaw | |
-| Kimi Code | |
+| Kilo CLI · Aider · OpenCode | WorkBuddy · WorkBuddy AI（macOS/Windows） |
+| Hermes Agent · OpenClaw | ZCode（macOS/Windows） |
+| Kimi Code · DeepSeek Harness | |
 
 内置 JieKou.AI、PPIO、Novita、DeepSeek 和 Moonshot，顺序如此；也可以在模型服务页面添加任意 OpenAI 兼容或 Anthropic 兼容服务。BootAgent 会按 Agent 真正使用的协议探测；如果端点只支持另一种 API，会在写入配置前拒绝它。
+
+DeepSeek Harness 除了走通用的 OpenAI 兼容端点，也可以直接激活到 DeepSeek 自己的官方线路——该线路由它出厂配置本身定义。
 
 MCP Registry 只管理用户级配置并保存在本机，支持 Claude Code、Codex、OpenCode、Kilo CLI 和 Hermes 的 stdio、HTTP、SSE 服务器。用户可以单独选择同步目标并显式应用；清空所有同步目标只会从 Agent 配置中移除服务器，仍保留在 Registry 中。点击删除后，会先从 Agent 配置中移除，应用成功后才从 Registry 中删除。MCP 导出按服务器选择且不携带 Agent 绑定，导入其他机器后可重新选择本机同步目标。
 


### PR DESCRIPTION
## 背景

两份 README 停在 8-13 的状态，v0.6.3 与 v0.6.4 落地的能力都没写进去。本次改动全部依据代码核实，而非沿用文档描述。

## README 同步（4 处）

对照 `manifests/agents.lock.json` 与 `internal/desktopapp/registry.go` 核实后：

- **补 1 个缺失的 CLI Agent**：manifest 里有 9 个，README 只列了 8 个，漏掉 **DeepSeek Harness**（#183 / #185）。
- **补 2 个缺失的桌面 Agent**：registry 注册了 4 条 Definition，README 只写了 2 个，漏掉 **WorkBuddy AI**（国际版，独立 bundle ID 与更新后端）和 **ZCode**。
- **新增思考深度能力条目**：五档取自 `internal/config/write.go:85` 的 `profileReasoningEfforts`。"只写入自身格式有对应位置的 Agent"对应 `writeManagedAgentConfig` 的实际分派——codex、opencode、kilo-cli、aider、dsh 官方路由收到 effort；claude-code、openclaw、hermes、kimi-code 不收。
- **新增 dsh 官方线路说明**：#185 的核心能力，此前完全未提。

顺带修掉 `Aider· OpenCode` 缺空格的笔误。

未改动的部分（已核实与代码一致）：Provider 列表顺序与 `providers.lock.json` 的 `order` 字段相符；MCP、下载与构建章节均无偏差。

## .gitignore

把三类本机运维文件挡在开源仓库之外：

- `scripts/sync_release_to_feishu.py` — 内含私有飞书域名与文件夹 token，且只对维护者本机有意义
- `scripts/com.bootagent.release-sync.plist` — 写死了单台机器的 HOME 与日志路径
- `scripts/logs/` — 上述 launchd 任务的运行时产物
- `overview.md` — 本机生成的一次性速览笔记，会随代码立刻过时
- `outputs/` — 既有的 `output/` 条目是单数，匹配不到这个复数目录（内含 imagegen 设计稿与 .DS_Store）

已确认这五个路径在 git 历史中提交数均为 0，因此加忽略即可，无需改写历史。所有文件保留在本机磁盘上，未删除。

## 验证

READMEs 与 .gitignore 均为文档/配置改动，不涉及代码路径，无需跑测试。已确认 `git status` 干净、被忽略的文件仍在磁盘上。

🤖 Generated with [Claude Code](https://claude.com/claude-code)