### PR TITLE
fix: keep the page footer inside the window when a notice is shown

### DIFF
--- a/frontend/src/styles/app-shell-layout.test.ts
+++ b/frontend/src/styles/app-shell-layout.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Guards the window shell against a notice above the page clipping the footer.
+ *
+ * AppWindow puts the legacy-migration notice inside .app-main, above the routed
+ * page. .app-window is `overflow: hidden` and exactly the window's height, so
+ * whatever .app-main stacks has to fit within it -- and .page-scaffold's last
+ * grid row is the footer holding the page's Back and Continue buttons.
+ *
+ * The regression this exists for: .app-main was a plain block and .page-scaffold
+ * asked for `height: 100%`. With no notice that is correct, which is why it went
+ * unnoticed. With one, the page still claimed the full window height while
+ * sitting 49px lower, so the footer ran past the clipped bottom edge -- measured
+ * at 1181x796, 49 of its 68px were cut and the Continue button lost 35 of 38px.
+ * Anyone who had ever installed the old OneAgent saw it on every page.
+ *
+ * The fix is a column that hands the notice its content height and the page the
+ * rest, so the assertions below are about which of the two owns the leftover
+ * space. jsdom resolves no layout at all, so a render test cannot catch this;
+ * the stylesheet is read as text, as input-surface.test.ts does.
+ */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+/** Comments carry `:` and property names in prose, so they must go first. */
+function sheet(name: string): string {
+  const css = readFileSync(fileURLToPath(new URL(name, import.meta.url)), "utf8");
+  return css.replace(/\/\*[\s\S]*?\*\//g, " ");
+}
+
+/**
+ * The declarations of the last block whose prelude, with whitespace collapsed,
+ * is exactly `selector`. Last rather than first because a later block at equal
+ * specificity is what actually applies.
+ */
+function declarations(css: string, selector: string): Map<string, string> {
+  const want = selector.replace(/\s+/g, " ").trim();
+  const found = new Map<string, string>();
+  let seen = false;
+  for (const block of css.matchAll(/([^{}]+)\{([^{}]*)\}/g)) {
+    if (block[1].replace(/\s+/g, " ").trim() !== want) continue;
+    seen = true;
+    found.clear();
+    for (const part of block[2].split(";")) {
+      const split = part.indexOf(":");
+      if (split < 0) continue;
+      found.set(part.slice(0, split).trim(), part.slice(split + 1).trim().replace(/\s+/g, " "));
+    }
+  }
+  expect(seen, `${selector} should exist`).toBe(true);
+  return found;
+}
+
+describe("the window shell with a notice above the page", () => {
+  it("stacks .app-main as a column so the notice and the page divide the height", () => {
+    // A block container would let each child size itself, and the page asks for
+    // the whole window -- the sum is what overflowed.
+    const rules = declarations(sheet("app.css"), ".app-main");
+    expect(rules.get("display")).toBe("flex");
+    expect(rules.get("flex-direction")).toBe("column");
+  });
+
+  it("gives the page what the notice leaves rather than the full window height", () => {
+    const rules = declarations(sheet("app.css"), ".page-scaffold");
+    // `height: 100%` is the regression itself: it measures the window, not the
+    // space left over once the notice above has taken its lines.
+    expect(rules.has("height")).toBe(false);
+    expect(rules.get("flex")).toBe("1");
+    // Without this the inner grid's content floor keeps the page from shrinking,
+    // which puts the footer back below the bottom edge.
+    expect(rules.get("min-height")).toBe("0");
+  });
+
+  it("keeps the footer as the page's own last row", () => {
+    // The footer is a fixed-height row of .page-scaffold, so the buttons stay at
+    // the bottom of the page rather than after its scrolling body.
+    const rules = declarations(sheet("app.css"), ".page-scaffold");
+    expect(rules.get("display")).toBe("grid");
+    expect(rules.get("grid-template-rows")).toBe("auto minmax(0, 1fr) var(--footer-height)");
+  });
+});

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -153,15 +153,25 @@
   max-width: 160px;
 }
 
+/* A column, not a plain block, because AppWindow may put the legacy-migration
+   notice above the routed page. As a block it stacked the two at their own
+   heights -- the page still claiming the full window -- so their sum overflowed
+   the clipped bottom of .app-window and cut the footer off. */
 .app-main {
   min-width: 0;
   min-height: 0;
+  display: flex;
+  flex-direction: column;
   background: var(--window-bg);
 }
 
 .page-scaffold {
   width: 100%;
-  height: 100%;
+  /* Takes the height the notice above it leaves, rather than the window's full
+     height: with `height: 100%` the footer -- and the buttons in it -- was
+     pushed past the bottom edge whenever a notice was present. */
+  flex: 1;
+  min-height: 0;
   display: grid;
   grid-template-rows: auto minmax(0, 1fr) var(--footer-height);
 }


### PR DESCRIPTION
Fixes #187

## 现象

装过旧版 OneAgent 的用户，每个页面底部栏的按钮都被裁掉一部分。

## 根因

`AppWindow.tsx:15` 把迁移提示条渲染在 `.app-main` 内、路由页面之前：

```tsx
<main className="app-main">
  {state.status?.migrationNotice ? <p className="provider-note">{...}</p> : null}
  {children}
</main>
```

而 `.app-main` 此前是普通 block，`.page-scaffold` 要求 `height: 100%`。**没有提示条时这是对的**——所以问题一直没被发现。有提示条时，页面被推低却仍按整个窗口高度计算自己，而 `.app-window` 是 `overflow: hidden` 且恰好等于窗口高度，于是 `.page-scaffold` 的最后一行（`var(--footer-height)`，装着 Back / Continue 按钮的 footer）被推到裁切边界之外。

## 实测数据

在 issue 截图对应的 1181x796 视口下，注入真实提示文案（含保留路径，折行 2 行 = 35px + 14px 上边距 = 49px 位移）：

| | 修复前 | 修复后 |
|---|---|---|
| `.page-scaffold` 高度 | 796px（无视上方提示） | 747px |
| footer 位置 | 777–845（窗口 796 结束） | 728–796 |
| footer 可见高度 | **19 / 68px** | 68 / 68px |
| Continue 按钮 | **38px 中被裁 35px** | 完整可见 |

900x600 + 3 行提示（53px）的最坏情况同样成立：footer 保持完整 68px 齐平底部，`.page-body` 压缩到 347px 吸收差值。

## 修复

`.app-main` 改为 flex 列，让提示条取内容高度、页面取剩余空间：

```css
.app-main { display: flex; flex-direction: column; }
.page-scaffold { flex: 1; min-height: 0; /* 取代 height: 100% */ }
```

选 flex 而非 grid，是因为它对「有 1 个还是 2 个子元素」天然自适应——grid 需要为两种情况写不同的 `grid-template-rows`，无提示时那条模板会让页面退化成内容高度。

## 测试

新增 `frontend/src/styles/app-shell-layout.test.ts`（3 项）。jsdom 不做布局计算，渲染测试抓不到这个 bug，因此沿用本仓库既有的 `input-surface.test.ts` / `cascade.test.ts` 做法——把样式表当文本读。

**已验证该测试确实能抓住此 bug**：把 CSS 还原成修复前状态后，3 项中的 2 项失败（`expected undefined to be 'flex'`、`expected true to be false`），恢复修复后全部通过。第三项守护 footer 仍是 `.page-scaffold` 的固定末行，两种状态下都应通过。

```
pnpm run test    # 49 文件 / 386 通过（新增 3 项）
pnpm run build   # 通过
go build ./... && go vet ./... && go test ./...   # 全部通过
```

浏览器实测覆盖 `/setup/agents`、`/overview`、`/providers`、`/profiles` 四条路由，footer 相对窗口底部偏移均为 0；控制台无新增错误（仅浏览器预览模式下预期的 Wails 绑定 404）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)