### PR TITLE
feat: read desktop Agents before command-line Agents on the overview

### DIFF
--- a/frontend/src/pages/EnvironmentOverviewPage.test.tsx
+++ b/frontend/src/pages/EnvironmentOverviewPage.test.tsx
@@ -162,4 +162,31 @@ describe("EnvironmentOverviewPage", () => {
     expect(footer.getByRole("button", { name: "安装 Agent" })).toBeTruthy();
     expect(screen.getAllByRole("button", { name: "安装 Agent" })).toHaveLength(1);
   });
+
+  // Reading order, and the only thing that fixes it: both sections render
+  // unconditionally in the installed case, so their order is whatever the JSX
+  // says and nothing else would catch a future edit that swaps them back.
+  it("puts desktop Agents above command-line Agents", () => {
+    const current = status();
+    current.desktopAgents = [desktopApp({ installed: true, version: "26.730.61309", profileId: "team" })];
+    mockState = { status: current, statusState: "success", statusError: "" };
+    renderPage();
+
+    const headings = screen.getAllByRole("heading", { name: /桌面 Agent|命令行 Agent/ });
+    expect(headings.map((heading) => heading.textContent)).toEqual(["桌面 Agent", "命令行 Agent"]);
+  });
+
+  // The desktop section is the one that can be absent -- on a platform with no
+  // supported desktop app it renders nothing -- so the empty-state pair has to
+  // hold the order too, not just the populated one.
+  it("keeps that order when both sections are empty", () => {
+    const current = status();
+    current.agents.codex.installed = false;
+    current.desktopAgents = [desktopApp()];
+    mockState = { status: current, statusState: "success", statusError: "" };
+    renderPage();
+
+    const headings = screen.getAllByRole("heading", { name: /桌面 Agent|命令行 Agent/ });
+    expect(headings.map((heading) => heading.textContent)).toEqual(["桌面 Agent", "命令行 Agent"]);
+  });
 });

--- a/frontend/src/pages/EnvironmentOverviewPage.tsx
+++ b/frontend/src/pages/EnvironmentOverviewPage.tsx
@@ -75,43 +75,6 @@ export function EnvironmentOverviewPage() {
         </>
       }
     >
-      {installed.length ? (
-        <section className="overview-section">
-          <div className="section-heading">
-            <div><h2>{t("命令行 Agent")}</h2><p>{t("共 {count} 个", { count: installed.length })}</p></div>
-          </div>
-          <div className="agent-manage-list">
-            {installed.map((item) => {
-              const agent = status.agents[item.id];
-              if (!agent) return null;
-              const profile = profileForAgent(item.id, agent);
-              return <AgentManageRow
-                key={item.id}
-                agentId={item.id}
-                catalog={item}
-                status={agent}
-                providers={status.providers}
-                profileName={profile?.label || profile?.id || ""}
-                profile={profile}
-                defaultDirectory={status.paths.launch_directory}
-                onChanged={refreshStatus}
-              />;
-            })}
-          </div>
-        </section>
-      ) : (
-        <section className="overview-section">
-          <div className="section-heading">
-            <div><h2>{t("命令行 Agent")}</h2><p>{t("共 {count} 个", { count: 0 })}</p></div>
-          </div>
-          <div className="uninstalled-agent-action">
-            <span className="visually-hidden">{t("尚未安装任何命令行 Agent")}</span>
-            <Terminal size={28} aria-hidden="true" />
-            <span>{t("按引导安装命令行 Agent")}</span>
-          </div>
-        </section>
-      )}
-
       {installedDesktopApplications.length ? (
         <section className="overview-section desktop-app-section">
           <div className="section-heading">
@@ -155,6 +118,44 @@ export function EnvironmentOverviewPage() {
           </div>
         </section>
       ) : null}
+
+      {installed.length ? (
+        <section className="overview-section">
+          <div className="section-heading">
+            <div><h2>{t("命令行 Agent")}</h2><p>{t("共 {count} 个", { count: installed.length })}</p></div>
+          </div>
+          <div className="agent-manage-list">
+            {installed.map((item) => {
+              const agent = status.agents[item.id];
+              if (!agent) return null;
+              const profile = profileForAgent(item.id, agent);
+              return <AgentManageRow
+                key={item.id}
+                agentId={item.id}
+                catalog={item}
+                status={agent}
+                providers={status.providers}
+                profileName={profile?.label || profile?.id || ""}
+                profile={profile}
+                defaultDirectory={status.paths.launch_directory}
+                onChanged={refreshStatus}
+              />;
+            })}
+          </div>
+        </section>
+      ) : (
+        <section className="overview-section">
+          <div className="section-heading">
+            <div><h2>{t("命令行 Agent")}</h2><p>{t("共 {count} 个", { count: 0 })}</p></div>
+          </div>
+          <div className="uninstalled-agent-action">
+            <span className="visually-hidden">{t("尚未安装任何命令行 Agent")}</span>
+            <Terminal size={28} aria-hidden="true" />
+            <span>{t("按引导安装命令行 Agent")}</span>
+          </div>
+        </section>
+      )}
+
       <RuntimeSection runtimes={status.runtimes ?? []} onInstalled={refreshStatus} />
     </PageScaffold>
   );


### PR DESCRIPTION
## 改动

环境总览页把「桌面 Agent」区块移到「命令行 Agent」之前，页面打开时先看到桌面 Agent。

只调整 JSX 顺序，两个区块各自的「已安装」与「空状态」分支都原样保留，运行时区块仍在最后：

```
桌面 Agent  →  命令行 Agent  →  运行时
```

## 补充的测试

`EnvironmentOverviewPage.test.tsx` 新增 2 项顺序断言。

这里有个值得说明的点：**原有 5 个测试全部通过顺序无关的方式取区块**（都是 `getByRole("heading", { name })` 再 `.closest("section")`），所以交换前后它们都通过——也就是说，此前没有任何测试守护这个顺序，将来有人把它换回去不会有任何失败。新增的两项补上这个缺口：

- 两个区块都有内容时，标题顺序为 `["桌面 Agent", "命令行 Agent"]`
- 两个区块都为空时同样成立（桌面区块是唯一可能整体不渲染的那个——平台无支持的桌面应用时返回 `null`，所以空状态那一对也需要覆盖）

**已验证这两项确实能抓住回归**：把页面还原成旧顺序后，两项均失败并给出 `expected [ '命令行 Agent', '桌面 Agent' ] to deeply equal [ '桌面 Agent', '命令行 Agent' ]`；恢复后全部通过。

## 验证

```
pnpm exec vitest run src/pages/EnvironmentOverviewPage.test.tsx   # 7 通过（新增 2）
pnpm run test        # 49 文件 / 388 通过
pnpm run build       # 通过，无 tsc 报错
pnpm run test:e2e    # 6 通过（真实 Go 后端，含落到总览页的完整引导流程）
```

一点说明：浏览器预览（`pnpm run dev`）连不上本地 BootAgent 服务，总览页在那里只渲染错误态、区块根本不挂载，因此这个改动无法用预览截图验证。实际渲染顺序由 jsdom 测试断言文档顺序、并由带真实后端的 e2e 覆盖。

🤖 Generated with [Claude Code](https://claude.com/claude-code)