### PR TITLE
fix: give Kimi Code's model entry the max_context_size it now requires

### DIFF
--- a/internal/config/write.go
+++ b/internal/config/write.go
@@ -693,6 +693,15 @@ func (w Writer) WriteKimiCode(ctx context.Context, path, baseURL, apiKey, model 
 		"[models." + quoteTOML(alias) + "]",
 		"provider = " + quoteTOML(kimiOwnedName),
 		"model = " + quoteTOML(model),
+		// Mandatory since Kimi Code 0.27.0: a models entry without a positive
+		// max_context_size fails schema validation, and the CLI *ignores the whole
+		// entry* -- then refuses to start because default_model names a model that
+		// no longer exists. The value is Kimi Code's own DEFAULT_MAX_CONTEXT_SIZE
+		// (262144, read off the 0.27.0 binary), the same limit it applies when the
+		// KIMI_MODEL_MAX_CONTEXT_SIZE environment override is absent. A catalog
+		// Provider does not declare per-model context sizes, so the CLI's own
+		// default is the only value that adds no invented claim.
+		"max_context_size = 262144",
 		"",
 	}, "\n")
 	existing, err := readText(path)

--- a/internal/config/write_test.go
+++ b/internal/config/write_test.go
@@ -154,6 +154,11 @@ func TestWriteKimiCodePreservesUnmanagedEntriesAndRoundTrips(t *testing.T) {
 			t.Fatalf("Kimi Code config dropped an unmanaged entry %q: %s", keep, text)
 		}
 	}
+	// Without a positive max_context_size Kimi Code 0.27.0 discards the whole
+	// models entry and then refuses to start, so the alias must carry one.
+	if !strings.Contains(text, "max_context_size = 262144") {
+		t.Fatalf("Kimi Code models entry is missing max_context_size: %s", text)
+	}
 	// The previous alias has to be gone, or Kimi Code keeps a models entry whose
 	// provider no longer describes it.
 	if strings.Contains(text, "bootagent/old-model") || strings.Contains(text, "old-key") || strings.Contains(text, "old.example") {


### PR DESCRIPTION
## 问题

Kimi Code 0.27.0 收紧了配置校验：`[models]` 条目必须带正整数 `max_context_size`。缺失时 CLI 不只是警告，而是**把整个条目丢弃**，随后因为 `default_model` 指向一个"不存在"的模型而拒绝启动：

```
Warning: Ignored invalid config …: models.bootagent/pprouter/fusion. Run `kimi doctor` for details.
error: config.invalid: Model "bootagent/pprouter/fusion" is not configured in config.toml.
       Add a [models."…"] entry with max_context_size.
```

`kimi doctor` 给出的确切校验错误：

```
models.bootagent/….max_context_size: Invalid input: expected number, received undefined
```

BootAgent 的 `WriteKimiCode` 写的模型条目没有这个键，所以每次通过 BootAgent 激活 Kimi Code 后都无法启动。

## 修复

在受管的 `[models."bootagent/<model>"]` 条目中写入 `max_context_size = 262144`。

**取值依据**：262144 是 Kimi Code 自己的 `DEFAULT_MAX_CONTEXT_SIZE`（从 0.27.0 二进制读出），即 `KIMI_MODEL_MAX_CONTEXT_SIZE` 环境变量缺省时它使用的上限。Provider 目录不声明每个模型的上下文长度，所以 CLI 自己的默认值是唯一不发明任何额外声明的取值。

## 验证

- ✅ `go build ./...` / `go test ./internal/config ./internal/app` 全通过，`TestWriteKimiCodePreservesUnmanagedEntriesAndRoundTrips` 新增该键的断言
- ✅ 真机端到端（kimi 0.27.0）：补上该键后 `kimi doctor` 全绿、`kimi -p` 正常启动应答；缺失时按上文报错

🤖 Generated with [Claude Code](https://claude.com/claude-code)