### PR TITLE
docs: give BootAgent a slogan

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
   <img src="build/appicon.png" alt="BootAgent" width="96">
   <h1>BootAgent</h1>
-  <p>One place to install, configure, and keep your AI coding Agents ready.</p>
+  <p><strong>Many Agents. One place to manage them.</strong></p>
   <p>
     <a href="https://github.com/MaimoryLab/BootAgent/releases/latest"><img src="https://img.shields.io/github/v/release/MaimoryLab/BootAgent?display_name=tag&sort=semver" alt="Latest release"></a>
     <a href="https://github.com/MaimoryLab/BootAgent/actions/workflows/ci.yml"><img src="https://github.com/MaimoryLab/BootAgent/actions/workflows/ci.yml/badge.svg" alt="CI"></a>

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -1,7 +1,7 @@
 <div align="center">
   <img src="build/appicon.png" alt="BootAgent" width="96">
   <h1>BootAgent</h1>
-  <p>在一个地方安装、配置并维护你的 AI 编程 Agent。</p>
+  <p><strong>Agent 很多，管理只需一个。</strong></p>
   <p>
     <a href="https://github.com/MaimoryLab/BootAgent/releases/latest"><img src="https://img.shields.io/github/v/release/MaimoryLab/BootAgent?display_name=tag&sort=semver" alt="最新版本"></a>
     <a href="https://github.com/MaimoryLab/BootAgent/actions/workflows/ci.yml"><img src="https://github.com/MaimoryLab/BootAgent/actions/workflows/ci.yml/badge.svg" alt="CI"></a>


### PR DESCRIPTION
把两个 README 的头部说明句换成口号。

- 英文：**Many Agents. One place to manage them.**
- 中文：**Agent 很多，管理只需一个。**

## 为什么换

原来那行（`One place to install, configure, and keep your AI coding Agents ready.` / 「在一个地方安装、配置并维护你的 AI 编程 Agent。」）是功能罗列，而紧随其后的正文段落已经把同样的事说得更充分。让口号占这行更值：它点明项目存在的理由——编程 Agent 的数量在涨，而管理它们的面不该跟着涨。

换掉不丢信息。英文正文已承诺 "a usable, repeatable setup without asking you to edit several tool-specific config files by hand"，中文正文已列举「检测、安装、模型服务配置和日常维护」。

## 关于英文措辞

英文不是直译。「管理只需一个」直译成 "management needs only one" 读起来像机翻；`One place to manage them` 保住了中文「多 / 只需一个」的对称，又复用了这行原本就有的 "One place to" 句式，语气保持连续。它也与应用自身的词汇一致——侧边栏标题在 i18n 里正是 `Agent Manager`。

## 范围

只改这两行。打包元数据（`build/config.yml`、`build/linux/nfpm/nfpm.yaml`）里的 `Local AI development environment activator` 保持原样：那是给 `apt show` 一类场景的包描述，功能说明比口号更合适。

官网（`MaimoryLab/BootAgent-site`）的同步改动另开 PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)