### PR TITLE
feat: lead the desktop list with DSH Desktop and label it third-party

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,12 @@ BootAgent is a local desktop workspace for AI coding Agents. It turns a fresh ma
 
 | CLI Agents | Desktop Agents |
 | --- | --- |
-| Codex · Claude Code | ChatGPT Desktop（macOS/Windows） |
-| Kilo CLI · Aider · OpenCode | WorkBuddy · WorkBuddy AI（macOS/Windows） |
-| Hermes Agent · OpenClaw | ZCode（macOS/Windows） |
-| Kimi Code · DeepSeek Harness | |
+| Codex · Claude Code | DSH Desktop（macOS/Windows） |
+| Kilo CLI · Aider · OpenCode | ChatGPT Desktop（macOS/Windows） |
+| Hermes Agent · OpenClaw | WorkBuddy · WorkBuddy AI（macOS/Windows） |
+| Kimi Code · DeepSeek Harness | ZCode（macOS/Windows） |
+
+DSH Desktop heads the desktop list. It is published by anywhere-labs rather than by DeepSeek, so the download row labels it a third-party application; the DeepSeek mark beside it identifies the model it drives, not its publisher.
 
 JieKou.AI, PPIO, Novita, DeepSeek and Moonshot are built in, listed in that order. Any OpenAI-compatible or Anthropic-compatible Provider can be added from the Provider page. BootAgent probes the protocol an Agent actually uses; an endpoint that only exposes a different API is rejected before configuration is written.
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -31,10 +31,12 @@ BootAgent 是一个本地桌面工作台，用来统一管理 AI 编程 Agent。
 
 | CLI Agent | 桌面 Agent |
 | --- | --- |
-| Codex · Claude Code | ChatGPT Desktop（macOS/Windows） |
-| Kilo CLI · Aider · OpenCode | WorkBuddy · WorkBuddy AI（macOS/Windows） |
-| Hermes Agent · OpenClaw | ZCode（macOS/Windows） |
-| Kimi Code · DeepSeek Harness | |
+| Codex · Claude Code | DSH Desktop（macOS/Windows） |
+| Kilo CLI · Aider · OpenCode | ChatGPT Desktop（macOS/Windows） |
+| Hermes Agent · OpenClaw | WorkBuddy · WorkBuddy AI（macOS/Windows） |
+| Kimi Code · DeepSeek Harness | ZCode（macOS/Windows） |
+
+DSH Desktop 排在桌面 Agent 列表首位。它由 anywhere-labs 发布，而不是 DeepSeek，所以下载行会标注它是第三方应用；旁边的 DeepSeek 标识表示它驱动的模型，不代表发布方。
 
 内置 JieKou.AI、PPIO、Novita、DeepSeek 和 Moonshot，顺序如此；也可以在模型服务页面添加任意 OpenAI 兼容或 Anthropic 兼容服务。BootAgent 会按 Agent 真正使用的协议探测；如果端点只支持另一种 API，会在写入配置前拒绝它。
 

--- a/frontend/bindings/github.com/MaimoryLab/BootAgent/internal/app/models.ts
+++ b/frontend/bindings/github.com/MaimoryLab/BootAgent/internal/app/models.ts
@@ -133,6 +133,12 @@ export interface DesktopAgentStatus {
      */
     "manualInstall"?: boolean;
     "home"?: string;
+
+    /**
+     * Unofficial reports that the publisher is not the vendor whose model the app
+     * drives, so the UI can say so instead of calling it the official application.
+     */
+    "unofficial"?: boolean;
 }
 
 export interface DetectedConfig {

--- a/frontend/src/components/icons/agents.test.tsx
+++ b/frontend/src/components/icons/agents.test.tsx
@@ -31,7 +31,9 @@ describe("AgentIcon", () => {
     const assetIds = AGENT_ICON_IDS.filter((id) => agentMarkKind(id) === "asset");
     // chatgpt-desktop is a desktop Agent rather than a CLI, and it reuses the
     // OpenAI mark because it is OpenAI's own product sharing Codex's config.
-    expect(assetIds.sort()).toEqual(["chatgpt-desktop", "claude-code", "codex", "dsh", "hermes", "kilo-cli", "kimi-code", "openclaw", "opencode", "pi"]);
+    // dsh-desktop reuses the DeepSeek mark for the same reason: it drives
+    // DeepSeek, though anywhere-labs rather than DeepSeek publishes it.
+    expect(assetIds.sort()).toEqual(["chatgpt-desktop", "claude-code", "codex", "dsh", "dsh-desktop", "hermes", "kilo-cli", "kimi-code", "openclaw", "opencode", "pi"]);
     for (const id of assetIds) {
       const rights = agentMarkRights(id);
       expect(agentMarkKind(id)).toBe("asset");
@@ -115,6 +117,7 @@ describe("AgentIcon", () => {
       codex: "0 0 24 24",
       "chatgpt-desktop": "0 0 24 24",
       dsh: "0 0 24 24",
+      "dsh-desktop": "0 0 24 24",
       opencode: "0 0 24 24",
       "claude-code": "0 0 24 24",
       "kilo-cli": "0 0 24 24",
@@ -201,7 +204,7 @@ describe("AgentIcon", () => {
   // Every Agent the app can show needs a mark it was actually given, so a new one
   // does not quietly land on the unknown-Agent fallback.
   it("registers a mark for every Agent and desktop Agent", () => {
-    for (const id of [...ALL, "chatgpt-desktop", "workbuddy"]) {
+    for (const id of [...ALL, "chatgpt-desktop", "dsh-desktop", "workbuddy"]) {
       expect(agentMarkKind(id), `${id} has no registered mark`).not.toBe("fallback");
     }
   });

--- a/frontend/src/components/icons/agents.tsx
+++ b/frontend/src/components/icons/agents.tsx
@@ -132,6 +132,21 @@ const MARKS: Record<string, Mark> = {
     source: assetRightsManifest.assets.dsh.source,
     rights: assetRightsManifest.assets.dsh,
   },
+  // DSH Desktop reuses the CLI Harness mark: both drive DeepSeek, and the whale
+  // is what identifies whose model is behind them. Keyed by desktop Agent id
+  // because the desktop card looks itself up by id, as with chatgpt-desktop
+  // above -- without this entry the card fell back to the generic Bot glyph.
+  //
+  // Unlike chatgpt-desktop, this is not the vendor's own app: anywhere-labs
+  // publishes it. The mark still says DeepSeek because that is the model it
+  // talks to, so the Definition carries Unofficial and the UI states the
+  // publisher rather than letting the mark imply it.
+  "dsh-desktop": {
+    kind: "asset",
+    markup: deepseekMark,
+    source: assetRightsManifest.assets.dsh.source,
+    rights: assetRightsManifest.assets.dsh,
+  },
   // Pi's own mark. lobe-icons also carries inflection.svg for Inflection's
   // Pi.ai, a different product with a different drawing -- this is the blocked
   // "pi" wordmark, checked against the logo Pi's own README links to.

--- a/frontend/src/i18n.tsx
+++ b/frontend/src/i18n.tsx
@@ -341,6 +341,7 @@ const english = {
   "与 {name} 共用配置": "Shares configuration with {name}",
   "已安装，可直接应用配置模版": "Installed; a profile can be applied now",
   "安装官方桌面应用": "Install the official desktop application",
+  "第三方桌面应用，非官方出品": "Third-party desktop application, not an official release",
   "需先自行安装，之后可配置": "Install it yourself first, then BootAgent can configure it",
   "检测到本机已有此应用": "This application is already installed",
   "国内版": "China",

--- a/frontend/src/pages/AgentSelectionPage.test.tsx
+++ b/frontend/src/pages/AgentSelectionPage.test.tsx
@@ -37,8 +37,17 @@ const CATALOG: AgentCatalogItem[] = [
   platformNote: "",
 }));
 
-/** Two desktop Agents: one with a registered image mark, one with a generic mark. */
+/**
+ * Three desktop Agents: a third-party build, one with a registered image mark,
+ * and one with a vendor bitmap. DSH Desktop leads, matching the order
+ * desktopapp.Definitions() returns.
+ */
 const DESKTOP_AGENTS = [
+  {
+    id: "dsh-desktop", name: "DSH Desktop", installed: false, supported: true,
+    source: "unknown", version: null, profileAgentId: "dsh", profileId: null, protocol: "openai",
+    unofficial: true,
+  },
   {
     id: "chatgpt-desktop", name: "ChatGPT Desktop", installed: false, supported: true,
     source: "unknown", version: null, profileAgentId: "codex", profileId: null, protocol: "responses",
@@ -150,11 +159,39 @@ describe("AgentSelectionPage", () => {
         kind: row?.querySelector("[data-mark-kind]")?.getAttribute("data-mark-kind") ?? null,
       };
     });
-    // Both rows must resolve through the icon registry rather than a literal:
-    // ChatGPT Desktop to a licensed vector, ZCode to Z.ai's own bitmap.
+    // Every row must resolve through the icon registry rather than a literal:
+    // DSH Desktop and ChatGPT Desktop to licensed vectors, ZCode to Z.ai's own
+    // bitmap. DSH Desktop had no registry entry of its own and fell back to the
+    // generic Bot glyph, which is what "asset" here guards against.
     expect(marks).toEqual([
+      { name: "选择 DSH Desktop", kind: "asset" },
       { name: "选择 ChatGPT Desktop", kind: "asset" },
       { name: "选择 ZCode", kind: "raster" },
+    ]);
+  });
+
+  it("does not advertise a third-party desktop build as the official application", () => {
+    // The mark is DeepSeek's because that is the model the app drives, but
+    // anywhere-labs publishes it. Without the disclaimer the row pairs a vendor
+    // mark with "install the official desktop application", which together read
+    // as a vendor download.
+    renderPage({ desktop: true });
+    const row = screen.getByLabelText("选择 DSH Desktop").closest(".agent-row");
+    expect(row?.textContent).toContain("第三方桌面应用，非官方出品");
+    expect(row?.textContent).not.toContain("安装官方桌面应用");
+    // The vendors' own apps must not pick up the disclaimer.
+    const official = screen.getByLabelText("选择 ChatGPT Desktop").closest(".agent-row");
+    expect(official?.textContent).toContain("安装官方桌面应用");
+  });
+
+  it("puts the desktop downloads in the order the backend returns", () => {
+    // The page must not re-sort: DSH Desktop leads because Definitions() puts it
+    // first, and a client-side sort here would silently override that.
+    renderPage({ desktop: true });
+    expect(screen.getAllByLabelText(/^选择 /).map((radio) => radio.getAttribute("aria-label"))).toEqual([
+      "选择 DSH Desktop",
+      "选择 ChatGPT Desktop",
+      "选择 ZCode",
     ]);
   });
 });

--- a/frontend/src/pages/AgentSelectionPage.tsx
+++ b/frontend/src/pages/AgentSelectionPage.tsx
@@ -93,7 +93,12 @@ export function AgentSelectionPage() {
                     <span className="agent-icon"><AgentIcon agentId={app.id} size={20} /></span>
                     <span className="agent-copy"><span className="agent-name-line"><strong>{app.name}</strong><EditionTag edition={app.edition} /></span><span>{app.installed
                       ? t("已安装，可直接应用配置模版")
-                      : app.manualInstall ? t("需先自行安装，之后可配置") : t("安装官方桌面应用")}</span></span>
+                      : app.manualInstall ? t("需先自行安装，之后可配置")
+                      // Not "官方桌面应用" for a third-party build: the mark is the
+                      // model vendor's, so without this the row would read as if
+                      // the vendor published the download.
+                      : app.unofficial ? t("第三方桌面应用，非官方出品")
+                      : t("安装官方桌面应用")}</span></span>
                     <StatusBadge tone={app.installed ? "success" : app.supported ? "warning" : "neutral"}>{app.installed ? t("已安装") : app.supported ? t("待安装") : t("不支持")}</StatusBadge>
                   </label>;
                 })}

--- a/internal/app/desktopapp.go
+++ b/internal/app/desktopapp.go
@@ -42,6 +42,9 @@ type DesktopAgentStatus struct {
 	// which is a button that cannot do what it says.
 	ManualInstall bool   `json:"manualInstall,omitempty"`
 	Home          string `json:"home,omitempty"`
+	// Unofficial reports that the publisher is not the vendor whose model the app
+	// drives, so the UI can say so instead of calling it the official application.
+	Unofficial bool `json:"unofficial,omitempty"`
 }
 
 // DesktopAgentProfileResult is the non-secret result of applying a saved
@@ -290,6 +293,7 @@ func (u *UseCases) publicDesktopAgentStatus(value desktopapp.Status) DesktopAgen
 	status.ProfileAgentID = definition.ProfileAgentID
 	status.Protocol = definition.Protocol
 	status.ManualInstall = definition.ManualInstall
+	status.Unofficial = definition.Unofficial
 	status.Home = definition.Home
 	status.Edition = definition.Edition
 	if binding, err := u.profiles.ReadAgentBinding(status.ProfileAgentID); err == nil && binding != nil && binding.ProfileRef != "" {

--- a/internal/app/testdata/status-empty-linux-arm64.json
+++ b/internal/app/testdata/status-empty-linux-arm64.json
@@ -544,6 +544,19 @@
   "environmentError": null,
   "desktopAgents": [
     {
+      "home": "https://dshdesktop.cn",
+      "id": "dsh-desktop",
+      "installed": false,
+      "name": "DSH Desktop",
+      "profileAgentId": "dsh",
+      "profileId": null,
+      "protocol": "openai",
+      "source": "unknown",
+      "supported": false,
+      "unofficial": true,
+      "version": null
+    },
+    {
       "configPath": "${HOME}/.codex/config.toml",
       "configSharedWith": "Codex",
       "id": "chatgpt-desktop",
@@ -586,18 +599,6 @@
       "installed": false,
       "name": "ZCode",
       "profileAgentId": "zcode",
-      "profileId": null,
-      "protocol": "openai",
-      "source": "unknown",
-      "supported": false,
-      "version": null
-    },
-    {
-      "home": "https://dshdesktop.cn",
-      "id": "dsh-desktop",
-      "installed": false,
-      "name": "DSH Desktop",
-      "profileAgentId": "dsh",
       "profileId": null,
       "protocol": "openai",
       "source": "unknown",

--- a/internal/desktopapp/desktopapp_test.go
+++ b/internal/desktopapp/desktopapp_test.go
@@ -201,8 +201,18 @@ func TestDSHURLUsesTheNPMMirrorPreference(t *testing.T) {
 
 func TestDesktopDefinitionsExposeIndependentProducts(t *testing.T) {
 	definitions := Definitions()
-	if len(definitions) < 2 || definitions[0].ID != ChatGPTDesktopID || definitions[1].ID != WorkBuddyID {
+	// DSH Desktop leads the list because the UI renders it in this order.
+	if len(definitions) < 3 || definitions[0].ID != DSHDesktopID || definitions[1].ID != ChatGPTDesktopID || definitions[2].ID != WorkBuddyID {
 		t.Fatalf("desktop definitions = %#v", definitions)
+	}
+	// Only the third-party build carries the flag; claiming it for a vendor's own
+	// app would put a false disclaimer on the row.
+	dsh, ok := DefinitionFor(DSHDesktopID)
+	if !ok || !dsh.Unofficial {
+		t.Fatalf("DSH definition = %#v, found=%v", dsh, ok)
+	}
+	if chatGPT, ok := DefinitionFor(ChatGPTDesktopID); !ok || chatGPT.Unofficial {
+		t.Fatalf("ChatGPT must not be marked unofficial: %#v, found=%v", chatGPT, ok)
 	}
 	chatGPT, ok := DefinitionFor(ChatGPTDesktopID)
 	if !ok || chatGPT.ProfileAgentID != CodexAgentID || chatGPT.SharedConfigAgentID != CodexAgentID {

--- a/internal/desktopapp/registry.go
+++ b/internal/desktopapp/registry.go
@@ -42,6 +42,12 @@ type Definition struct {
 	// Edition distinguishes regional builds of the same product, which install
 	// side by side and are separate Agents here. Empty for single-build products.
 	Edition string
+	// Unofficial marks an app that is not published by the vendor whose model it
+	// drives, so the UI must not offer it as "the official desktop application".
+	// The mark is the vendor's, because it identifies which product the app talks
+	// to; the publisher is a third party, and conflating the two would tell the
+	// user this download came from that vendor.
+	Unofficial bool
 }
 
 type implementation struct {
@@ -51,7 +57,21 @@ type implementation struct {
 	open    func(context.Context, Options) error
 }
 
+// First entry first in the UI: the list is rendered in this order, and DSH
+// Desktop leads it.
 var implementations = []implementation{
+	{
+		Definition: Definition{
+			ID: DSHDesktopID, Name: DSHDesktopName, ProfileAgentID: "dsh",
+			ConfigPath: ".dsh/settings.yaml", ConfigAdapter: ConfigAdapterDSH,
+			Protocol: "openai", Home: DSHDesktopHome,
+			// anywhere-labs builds this, not DeepSeek.
+			Unofficial: true,
+		},
+		inspect: inspectDSH,
+		install: installDSH,
+		open:    openDSH,
+	},
 	{
 		Definition: Definition{
 			ID:                  ChatGPTDesktopID,
@@ -112,16 +132,6 @@ var implementations = []implementation{
 		inspect: inspectZCode,
 		install: installZCode,
 		open:    openZCode,
-	},
-	{
-		Definition: Definition{
-			ID: DSHDesktopID, Name: DSHDesktopName, ProfileAgentID: "dsh",
-			ConfigPath: ".dsh/settings.yaml", ConfigAdapter: ConfigAdapterDSH,
-			Protocol: "openai", Home: DSHDesktopHome,
-		},
-		inspect: inspectDSH,
-		install: installDSH,
-		open:    openDSH,
 	},
 }
 


### PR DESCRIPTION
## Summary

- DSH Desktop moves to the front of `desktopapp.Definitions()`, which is the order the desktop download list renders in. No client-side sort was added; the page already follows backend order.
- DSH Desktop reuses the DeepSeek Harness mark. Both drive DeepSeek, so the whale identifies the model behind them. It had no icon-registry entry of its own and was falling back to the generic Bot glyph.
- The mark alone would read as if DeepSeek published the download, so `Definition` gains `Unofficial` and the row reads "third-party desktop application, not an official release" instead of "install the official desktop application". anywhere-labs publishes it.

`Unofficial` follows the existing `ManualInstall` precedent: a bool on `Definition`, surfaced through the `DesktopAgentStatus` DTO, driving the row copy. Bindings regenerated; `frontend/src/types/api.ts` derives `DesktopAgentStatus` from them, so it needed no manual edit.

Both READMEs gained DSH Desktop in the Supported Agents table, which had been missing it since the app was added, plus a note on the publisher/mark distinction.

## Test plan

- [x] `go test ./...` — pass. Golden fixture `status-empty-linux-arm64.json` updated for the new order and field; `TestDesktopDefinitionsExposeIndependentProducts` now asserts DSH leads and that only the third-party build carries the flag.
- [x] `go vet ./...`, `staticcheck ./...` — clean
- [x] `pnpm run test` — 53 files / 411 tests pass (+2: the third-party copy, and the backend-order assertion)
- [x] `pnpm run build`, `task build` — pass
- [x] `python3 scripts/check-docs.py` — ok, 66 markdown files
- [x] Verified in a real browser via the server-mode Wails binary: row order came back `["DSH Desktop","ChatGPT Desktop","WorkBuddy","WorkBuddy AI","ZCode"]` and the first row's mark resolved to `asset` rather than the fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)