### PR TITLE
fix: DSH Desktop mirror download fails with HTTP 400

### DIFF
--- a/internal/desktopapp/desktopapp.go
+++ b/internal/desktopapp/desktopapp.go
@@ -677,9 +677,12 @@ func downloadFile(ctx context.Context, options Options, url, destination, target
 	request.Header.Set("Accept", "application/octet-stream")
 	client := options.Downloader
 	if client == nil {
-		// http.DefaultClient sets no Timeout, which is what we want here: the
-		// stall check below is the limit on the body transfer.
-		client = http.DefaultClient
+		// Like http.DefaultClient this sets no Timeout, which is what we want
+		// here: the stall check below is the limit on the body transfer. What it
+		// adds is a redirect hook that repairs an unencoded space in the target,
+		// without which the mirror's final CDN hop is rejected -- see
+		// downloadRedirectClient.
+		client = downloadRedirectClient
 	}
 	response, err := client.Do(request)
 	if err != nil {

--- a/internal/desktopapp/download_client.go
+++ b/internal/desktopapp/download_client.go
@@ -1,0 +1,51 @@
+package desktopapp
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// maxDownloadRedirects matches net/http's own default. Setting CheckRedirect
+// replaces that default, so the limit has to be restated or a redirect loop
+// would follow forever.
+const maxDownloadRedirects = 10
+
+// downloadRedirectClient follows redirects the way an installer download needs.
+//
+// The mirror for DSH Desktop redirects to ModelScope, which redirects again to a
+// presigned CDN URL whose query carries the asset's own file name:
+//
+//	?filename=DSH Desktop-2.0.1-universal.dmg&...&auth_key=...
+//
+// That space is unencoded in the Location header. net/http keeps URL.RawQuery
+// verbatim when it writes the request target, so the space goes out inside the
+// request line, where HTTP has no way to read it as anything but the end of the
+// target. The CDN's Tengine answered "400 Bad Request" and every mirror install
+// failed at the last hop -- reported as "download returned HTTP 400", which
+// looked like a network or region problem and so survived being tried with and
+// without a VPN. curl escapes the space before sending, which is why the same
+// URL reproduced fine by hand.
+//
+// Repairing the redirect target rather than the parsed URL keeps this to the one
+// thing that is wrong: the path already survives, because URL.String escapes it.
+var downloadRedirectClient = &http.Client{
+	CheckRedirect: func(request *http.Request, via []*http.Request) error {
+		if len(via) >= maxDownloadRedirects {
+			return fmt.Errorf("stopped after %d redirects", maxDownloadRedirects)
+		}
+		request.URL.RawQuery = encodeQuerySpaces(request.URL.RawQuery)
+		return nil
+	},
+}
+
+// encodeQuerySpaces percent-encodes spaces a server left raw in a redirect
+// target. Only spaces are touched: they are what terminates the request target,
+// and rebuilding the whole query would re-encode the signature bytes a
+// presigned URL is validated on.
+func encodeQuerySpaces(query string) string {
+	if !strings.Contains(query, " ") {
+		return query
+	}
+	return strings.ReplaceAll(query, " ", "%20")
+}

--- a/internal/desktopapp/download_client_test.go
+++ b/internal/desktopapp/download_client_test.go
@@ -1,0 +1,129 @@
+package desktopapp
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/MaimoryLab/BootAgent/internal/platform"
+)
+
+// The mirror's last hop is a presigned CDN URL whose query holds the asset file
+// name with a raw space in it. Left alone, net/http writes that space into the
+// request line and the CDN answers 400, which is the failure users hit on every
+// mirror install.
+func TestDownloadFollowsRedirectWithUnencodedSpaceInQuery(t *testing.T) {
+	var servedTarget string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/downloads/mac":
+			// Written straight to the header so the space survives, exactly as
+			// the real redirect delivers it.
+			w.Header()["Location"] = []string{"/cdn/object?filename=DSH Desktop-2.0.1-universal.dmg&auth_key=abc"}
+			w.WriteHeader(http.StatusFound)
+		case "/cdn/object":
+			servedTarget = r.RequestURI
+			if r.URL.Query().Get("auth_key") != "abc" {
+				http.Error(w, "signature lost", http.StatusForbidden)
+				return
+			}
+			_, _ = w.Write([]byte("installer bytes"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	destination := filepath.Join(t.TempDir(), "dsh.dmg")
+	// Downloader stays nil so this exercises the client the production path uses.
+	if err := downloadFile(context.Background(), Options{}, server.URL+"/api/downloads/mac", destination, DSHDesktopID); err != nil {
+		t.Fatalf("download through a redirect with a raw space: %v", err)
+	}
+	if strings.Contains(servedTarget, " ") {
+		t.Errorf("request target still carries a raw space: %q", servedTarget)
+	}
+	if !strings.Contains(servedTarget, "auth_key=abc") {
+		t.Errorf("presigned query did not survive the repair: %q", servedTarget)
+	}
+	body, err := os.ReadFile(destination)
+	if err != nil || string(body) != "installer bytes" {
+		t.Fatalf("downloaded file = %q, %v", body, err)
+	}
+}
+
+func TestEncodeQuerySpacesLeavesSignedQueriesAlone(t *testing.T) {
+	// Byte-for-byte identity matters: a presigned URL is validated on the exact
+	// query it was signed with, so anything beyond the space must not be touched.
+	signed := "filename=plain.dmg&auth_key=1787118319-d6da049f-0-6a1a4258&tag=model"
+	if got := encodeQuerySpaces(signed); got != signed {
+		t.Errorf("encodeQuerySpaces rewrote a query with no spaces:\n got %q\nwant %q", got, signed)
+	}
+	if got, want := encodeQuerySpaces("filename=A B C.dmg&k=v"), "filename=A%20B%20C.dmg&k=v"; got != want {
+		t.Errorf("encodeQuerySpaces = %q, want %q", got, want)
+	}
+}
+
+// macOS ships one universal .dmg. Requiring "arm64" in the name matched no
+// release that has ever been published, so the official GitHub route was dead on
+// macOS and the mirror was the only way in.
+func TestDSHAssetMatchesPublishedReleaseNames(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		ext     string
+		macOS   bool
+		matches bool
+	}{
+		{"DSH.Desktop-2.0.1-universal.dmg", ".dmg", true, true},
+		{"DSH-Desktop-2.0.1-arm64.dmg", ".dmg", true, true},
+		{"DSH-Desktop-2.0.1-x64-Setup.exe", ".exe", false, true},
+		{"DSH-Desktop-2.0.1-x64-Setup.exe", ".dmg", true, false},
+		{"DSH.Desktop-2.0.1-universal.dmg", ".exe", false, false},
+		// An Intel-only build is refused; dshURL's arch guard is what keeps an
+		// Intel Mac from getting this far, but the name must not claim it either.
+		{"DSH-Desktop-2.0.1-x64.dmg", ".dmg", true, false},
+	} {
+		if got := dshAssetMatches(test.name, test.ext, test.macOS); got != test.matches {
+			t.Errorf("dshAssetMatches(%q, %q, macOS=%v) = %v, want %v", test.name, test.ext, test.macOS, got, test.matches)
+		}
+	}
+}
+
+// The official lookup has to resolve on macOS, since it is both the non-mirror
+// route and the fallback a mirror failure depends on.
+func TestDSHURLResolvesTheUniversalAssetFromGitHub(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"assets":[
+			{"name":"DSH-Desktop-2.0.1-x64-Setup.exe","browser_download_url":"https://github.com/anywhere-labs/deepseek-harness-desktop/releases/download/v2.0.1/DSH-Desktop-2.0.1-x64-Setup.exe"},
+			{"name":"DSH.Desktop-2.0.1-universal.dmg","browser_download_url":"https://github.com/anywhere-labs/deepseek-harness-desktop/releases/download/v2.0.1/DSH.Desktop-2.0.1-universal.dmg"}
+		]}`))
+	}))
+	defer server.Close()
+
+	options := Options{Platform: platform.For("macos", "arm64"), Downloader: releaseAPIClient{base: server.URL}}
+	got, err := dshURL(context.Background(), options)
+	if err != nil {
+		t.Fatalf("official macOS dsh URL: %v", err)
+	}
+	if !strings.HasSuffix(got, "DSH.Desktop-2.0.1-universal.dmg") {
+		t.Errorf("official macOS dsh URL = %q, want the universal .dmg", got)
+	}
+}
+
+// releaseAPIClient answers the release API from a test server while leaving the
+// host allowlist in approvedDownloadURL to judge the real asset URLs.
+type releaseAPIClient struct{ base string }
+
+func (c releaseAPIClient) Do(request *http.Request) (*http.Response, error) {
+	if request.URL.String() == DSHDesktopReleaseAPI {
+		redirected, err := http.NewRequestWithContext(request.Context(), request.Method, c.base, nil)
+		if err != nil {
+			return nil, err
+		}
+		return http.DefaultClient.Do(redirected)
+	}
+	return http.DefaultClient.Do(request)
+}

--- a/internal/desktopapp/dsh.go
+++ b/internal/desktopapp/dsh.go
@@ -68,11 +68,34 @@ func dshURL(ctx context.Context, options Options) (string, error) {
 		ext = ".exe"
 	}
 	for _, asset := range release.Assets {
-		if strings.HasSuffix(strings.ToLower(asset.Name), ext) && strings.Contains(strings.ToLower(asset.Name), "arm64") == (options.Platform.OS == "macos") {
+		if dshAssetMatches(asset.Name, ext, options.Platform.OS == "macos") {
 			return approvedDownloadURL(asset.URL, "github.com")
 		}
 	}
 	return "", fmt.Errorf("GitHub release has no %s %s asset", DSHDesktopName, ext)
+}
+
+// dshAssetMatches picks the release asset for this platform.
+//
+// The extension is what identifies the platform's package; on macOS the build is
+// a single universal .dmg. An earlier form of this also required "arm64" in the
+// name on macOS, which no release has ever carried -- the asset is published as
+// "DSH.Desktop-<version>-universal.dmg" -- so the GitHub path always ended in
+// "GitHub release has no DSH Desktop .dmg asset". That left the mirror as the
+// only route that could work on macOS, and hid it: the fallback in downloadDSH
+// returns the mirror's error when the official lookup fails, so a mirror failure
+// reported the mirror's status and never mentioned that the fallback had found
+// nothing either. Only the arch guard in dshURL keeps an Intel Mac out, which is
+// where that check belongs.
+func dshAssetMatches(name, ext string, macOS bool) bool {
+	lower := strings.ToLower(name)
+	if !strings.HasSuffix(lower, ext) {
+		return false
+	}
+	if !macOS {
+		return true
+	}
+	return strings.Contains(lower, "universal") || strings.Contains(lower, "arm64")
 }
 
 func inspectDSH(ctx context.Context, options Options) Status {


### PR DESCRIPTION
Installing DSH Desktop failed with `download returned HTTP 400` for every user on the mirror, with or without a VPN. Two separate bugs, one hiding the other.

## An unencoded space in the redirect target

The mirror's third hop is a presigned ModelScope CDN URL whose query carries the asset's own file name, and the `Location` header leaves the space in it raw:

```
www.dshdesktop.cn/api/downloads/mac
  → modelscope.cn/.../DSH%20Desktop-2.0.1-universal.dmg
  → cdn-lfs-cn-1.modelscope.cn/...?filename=DSH Desktop-2.0.1-universal.dmg&auth_key=...
```

`net/http` writes `URL.RawQuery` verbatim into the request target, so the space went out inside the request line — where HTTP can only read it as the end of the target. Tengine answered `400 Bad Request`.

`curl` escapes the space before sending, which is why the URL always reproduced fine by hand and the failure looked like a network or region problem. That is what sent users through the VPN, which could never have helped.

Downloads now follow redirects through a client that percent-encodes spaces in the target. Only spaces are touched: a presigned URL is validated on the exact query it was signed with, so rebuilding the query would break `auth_key`.

## A macOS matcher that matched no release

The asset matcher required `arm64` in the name on macOS, which no release has ever carried — the build is published as `DSH.Desktop-<version>-universal.dmg`. The official GitHub route was therefore dead on macOS.

That concealed the first bug. `downloadDSH` returns the mirror's error when the official lookup fails, so users saw the mirror's 400 and never learned the fallback had found nothing either. Matching accepts `universal` or `arm64` now; keeping an Intel Mac out is the arch guard's job in `dshURL`, where it already happens.

## Testing

- `go build ./...` clean, `go vet ./internal/desktopapp/` clean.
- `go test ./...` — 17 packages pass, no failures.
- Both tests were verified to fail without their fix, reproducing the reported `download returned HTTP 400` and `GitHub release has no DSH Desktop .dmg asset`.
- End-to-end against the live mirror: `/api/downloads/mac` → 200, 278 MB; `/api/downloads/windows` → 200, 209 MB.

## Note

`zcode.go` and `workbuddy.go` resolve `options.Downloader` the same way and both call `downloadFile`, so they pick this up too. The repair lives on the fallback client, so a future caller that injects its own `http.Client` would need to carry the `CheckRedirect` hook — nothing does today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)