### PR TITLE
fix: OTA mirror failures silently stop updates

### DIFF
--- a/cmd/bootagent-desktop/main_wails.go
+++ b/cmd/bootagent-desktop/main_wails.go
@@ -38,8 +38,55 @@ type updateProvider struct {
 
 func (p updateProvider) Name() string { return "bootagent-release" }
 
+// Check asks the preferred source, and falls back to the official one when the
+// mirror could not answer.
+//
+// The mirror needs the fallback because it fails in ways the official source does
+// not. Fetching SHA256SUMS from Gitee answered 403 on roughly a third of
+// consecutive attempts, and the mirror is missing ota-BootAgent-windows-arm64.zip
+// altogether, which is a permanent "no asset for windows/arm64". Neither reaches
+// the user as a failure: the automatic check treats any error as "no update"
+// (AppUpdater), so before this a mirror user simply stopped being offered
+// updates, silently and with nothing to retry.
+//
+// The fallback only runs mirror -> official, never the reverse. Runtime archives
+// can try both hosts in either order because runtimes.lock.json pins each
+// artifact's SHA256, so a bad mirror can only fail rather than substitute
+// anything (see install.downloadSources). An OTA release carries no such
+// out-of-band pin -- the digest comes from the same host as the artifact -- so
+// sending a user who did not choose the mirror to the mirror would widen the
+// trust boundary instead of just improving availability. Falling back toward the
+// authoritative source only ever narrows it.
 func (p updateProvider) Check(ctx context.Context, request updater.CheckRequest) (*updater.Release, error) {
 	mirror := p.preferMirror(ctx)
+	release, err := p.check(ctx, request, mirror)
+	if err == nil || !mirror {
+		return release, err
+	}
+	// A cancelled check is the caller's decision, not a source that failed;
+	// retrying elsewhere would reopen exactly the request that was abandoned.
+	if ctx.Err() != nil {
+		return release, err
+	}
+	slog.Warn("BootAgent mirror update check failed; trying the official source", "error", err)
+	fallbackRelease, fallbackErr := p.check(ctx, request, false)
+	if fallbackErr != nil {
+		// Both errors are kept: the mirror's is what the user's configured route
+		// did, and joining preserves the sentinels updateError matches on.
+		return nil, errors.Join(err, fallbackErr)
+	}
+	return fallbackRelease, nil
+}
+
+// check runs one source and records which one answered, so Download goes back to
+// the host the release was resolved from.
+//
+// A nil release with a nil error means that source has nothing newer, which is an
+// answer rather than a failure and so is returned as-is. A mirror that lags a
+// release behind therefore delays the update until it syncs; that is the cost of
+// honouring the preference, and the alternative -- querying both hosts on every
+// check -- spends the slow link the preference exists to avoid.
+func (p updateProvider) check(ctx context.Context, request updater.CheckRequest, mirror bool) (*updater.Release, error) {
 	provider := p.official
 	if mirror {
 		provider = p.mirror

--- a/cmd/bootagent-desktop/main_wails_test.go
+++ b/cmd/bootagent-desktop/main_wails_test.go
@@ -16,11 +16,21 @@ import (
 
 type updateProviderFake struct {
 	checks, downloads int
+	// checkErr fails Check, and noRelease answers "nothing newer" -- the two
+	// outcomes the fallback has to tell apart.
+	checkErr  error
+	noRelease bool
 }
 
 func (p *updateProviderFake) Name() string { return "fake" }
 func (p *updateProviderFake) Check(context.Context, updater.CheckRequest) (*updater.Release, error) {
 	p.checks++
+	if p.checkErr != nil {
+		return nil, p.checkErr
+	}
+	if p.noRelease {
+		return nil, nil
+	}
 	return &updater.Release{}, nil
 }
 func (p *updateProviderFake) Download(context.Context, *updater.Release, io.Writer, func(int64, int64)) error {
@@ -43,6 +53,100 @@ func TestUpdateProviderKeepsCheckedSourceForDownload(t *testing.T) {
 	}
 	if mirror.checks != 1 || mirror.downloads != 1 || official.checks != 0 || official.downloads != 0 {
 		t.Fatalf("official checks/downloads = %d/%d, mirror = %d/%d", official.checks, official.downloads, mirror.checks, mirror.downloads)
+	}
+}
+
+// Gitee answered 403 on roughly a third of consecutive SHA256SUMS fetches and is
+// missing the windows/arm64 OTA asset outright. Both surfaced as a Check error,
+// which the automatic updater treats as "no update", so mirror users silently
+// stopped being offered releases.
+func TestUpdateCheckFallsBackToOfficialWhenTheMirrorFails(t *testing.T) {
+	mirrorErr := errors.New("checksum sidecar HTTP 403")
+	official, mirror := &updateProviderFake{}, &updateProviderFake{checkErr: mirrorErr}
+	provider := updateProvider{official: official, mirror: mirror, preferMirror: func(context.Context) bool { return true }}
+
+	release, err := provider.Check(context.Background(), updater.CheckRequest{})
+	if err != nil {
+		t.Fatalf("Check() after a mirror failure = %v, want the official result", err)
+	}
+	if mirror.checks != 1 || official.checks != 1 {
+		t.Fatalf("mirror checks = %d, official checks = %d, want 1 and 1", mirror.checks, official.checks)
+	}
+	// The download has to follow the host that answered, or it would look for the
+	// official asset on the mirror.
+	if err := provider.Download(context.Background(), release, &bytes.Buffer{}, func(int64, int64) {}); err != nil {
+		t.Fatal(err)
+	}
+	if official.downloads != 1 || mirror.downloads != 0 {
+		t.Fatalf("official downloads = %d, mirror downloads = %d, want 1 and 0", official.downloads, mirror.downloads)
+	}
+}
+
+func TestUpdateCheckReportsBothFailuresWhenNeitherSourceAnswers(t *testing.T) {
+	mirrorErr, officialErr := errors.New("mirror is unreachable"), errors.New("official is unreachable")
+	official, mirror := &updateProviderFake{checkErr: officialErr}, &updateProviderFake{checkErr: mirrorErr}
+	provider := updateProvider{official: official, mirror: mirror, preferMirror: func(context.Context) bool { return true }}
+
+	release, err := provider.Check(context.Background(), updater.CheckRequest{})
+	if release != nil {
+		t.Fatalf("Check() release = %#v, want nil when both sources fail", release)
+	}
+	// Joined rather than replaced: the mirror's failure is what the user's
+	// configured route did, and updateError matches sentinels through the join.
+	for _, want := range []error{mirrorErr, officialErr} {
+		if !errors.Is(err, want) {
+			t.Errorf("Check() error = %v, want it to wrap %v", err, want)
+		}
+	}
+}
+
+// A source that answers "nothing newer" has answered. Retrying elsewhere would
+// query both hosts on every check, spending the slow link the mirror preference
+// exists to avoid.
+func TestUpdateCheckAcceptsNoUpdateFromTheMirror(t *testing.T) {
+	official, mirror := &updateProviderFake{}, &updateProviderFake{noRelease: true}
+	provider := updateProvider{official: official, mirror: mirror, preferMirror: func(context.Context) bool { return true }}
+
+	release, err := provider.Check(context.Background(), updater.CheckRequest{})
+	if release != nil || err != nil {
+		t.Fatalf("Check() = %#v, %v, want nil, nil", release, err)
+	}
+	if official.checks != 0 {
+		t.Errorf("official checks = %d, want 0: the mirror already answered", official.checks)
+	}
+}
+
+// Cancelling is the caller's decision. Falling back would reopen the request that
+// was just abandoned, and the task centre's cancel button would not stick.
+func TestUpdateCheckDoesNotFallBackAfterCancellation(t *testing.T) {
+	official, mirror := &updateProviderFake{}, &updateProviderFake{checkErr: context.Canceled}
+	provider := updateProvider{official: official, mirror: mirror, preferMirror: func(context.Context) bool { return true }}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if _, err := provider.Check(ctx, updater.CheckRequest{}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Check() error = %v, want context.Canceled", err)
+	}
+	if official.checks != 0 {
+		t.Errorf("official checks = %d, want 0 after cancellation", official.checks)
+	}
+}
+
+// The official source is never abandoned for the mirror. Runtime archives may try
+// both hosts in either order because runtimes.lock.json pins each SHA256; an OTA
+// release has no such out-of-band pin, so the digest arrives from whichever host
+// served the artifact. Falling back to the mirror would put a user who never
+// chose it inside the mirror's trust boundary.
+func TestUpdateCheckNeverFallsBackToTheMirror(t *testing.T) {
+	officialErr := errors.New("official is unreachable")
+	official, mirror := &updateProviderFake{checkErr: officialErr}, &updateProviderFake{}
+	provider := updateProvider{official: official, mirror: mirror, preferMirror: func(context.Context) bool { return false }}
+
+	if _, err := provider.Check(context.Background(), updater.CheckRequest{}); !errors.Is(err, officialErr) {
+		t.Fatalf("Check() error = %v, want %v", err, officialErr)
+	}
+	if mirror.checks != 0 {
+		t.Errorf("mirror checks = %d, want 0: falling back to the mirror would widen the trust boundary", mirror.checks)
 	}
 }
 

--- a/frontend/src/components/AppUpdater.test.tsx
+++ b/frontend/src/components/AppUpdater.test.tsx
@@ -12,12 +12,13 @@ import { TaskCenter } from "./TaskCenter";
 
 const mocks = vi.hoisted(() => ({
   question: vi.fn(),
+  warning: vi.fn(),
   checkUpdate: vi.fn(),
   downloadUpdate: vi.fn(),
   restartUpdate: vi.fn(),
 }));
 
-vi.mock("@wailsio/runtime", () => ({ Dialogs: { Question: mocks.question } }));
+vi.mock("@wailsio/runtime", () => ({ Dialogs: { Question: mocks.question, Warning: mocks.warning } }));
 vi.mock("../backend/api", async () => {
   const errors = await import("../backend/errors");
   return {
@@ -77,6 +78,7 @@ describe("AppUpdater", () => {
   beforeEach(() => {
     localStorage.setItem(LOCALE_STORAGE_KEY, "en");
     mocks.question.mockReset().mockResolvedValue("Not now");
+    mocks.warning.mockReset().mockResolvedValue(undefined);
     mocks.checkUpdate.mockReset().mockResolvedValue("");
     mocks.downloadUpdate.mockReset();
     mocks.restartUpdate.mockReset();
@@ -96,7 +98,26 @@ describe("AppUpdater", () => {
     await waitFor(() => expect(mocks.checkUpdate).toHaveBeenCalledTimes(1));
     expect(mocks.question).not.toHaveBeenCalled();
     expect(mocks.downloadUpdate).not.toHaveBeenCalled();
+    // A check that could not reach a source stays silent: the user did not ask,
+    // and a startup dialog about a transient network failure is noise.
+    expect(mocks.warning).not.toHaveBeenCalled();
     expect(screen.queryByText("Update BootAgent")).toBeNull();
+  });
+
+  // The backend only reaches its location check once a newer release exists, so
+  // this code means an update is waiting that this installation can never apply.
+  // Silence would end updates for good with nothing said.
+  it("warns when the installation cannot be updated in place", async () => {
+    mocks.checkUpdate.mockRejectedValue(
+      new BootAgentApiError("BootAgent is running from a disk image.", "UPDATE_LOCATION_BLOCKED", false, 409),
+    );
+    mount();
+    await waitFor(() => expect(mocks.warning).toHaveBeenCalledTimes(1));
+    const message = String(mocks.warning.mock.calls[0][0].Message);
+    // The hint carries the instruction, so it has to reach the dialog.
+    expect(message).toContain("Applications");
+    expect(mocks.question).not.toHaveBeenCalled();
+    expect(mocks.downloadUpdate).not.toHaveBeenCalled();
   });
 
   it("does nothing when the OTA task is already running", async () => {

--- a/frontend/src/components/AppUpdater.tsx
+++ b/frontend/src/components/AppUpdater.tsx
@@ -27,7 +27,22 @@ export function AppUpdater() {
       let version: string;
       try {
         version = await api.checkUpdate();
-      } catch {
+      } catch (error) {
+        // Staying silent is right for a check that merely could not reach a
+        // source -- the user did not ask, and a startup dialog about a transient
+        // network failure is noise. UPDATE_LOCATION_BLOCKED is the exception: the
+        // backend only reaches that check once a newer release exists, so it
+        // means an update is waiting and this installation can never apply it.
+        // Left silent, the app stops updating for good with nothing said, and the
+        // only place the reason appears is a settings page the user has no reason
+        // to open.
+        const failure = describeFailure(error, t("检查更新失败"), t);
+        if (active.current && failure.code === "UPDATE_LOCATION_BLOCKED") {
+          void Dialogs.Warning({
+            Title: t("BootAgent 更新"),
+            Message: failure.hint ? `${failure.message}\n\n${failure.hint}` : failure.message,
+          }).catch(() => {});
+        }
         return;
       }
       if (!active.current || !version || latest.current.isTaskRunning(OTA_TASK_ID)) return;


### PR DESCRIPTION
Found while auditing the self-update path after #215 routed updates through Gitee.

## The mirror fails in ways that never reach the user

Fetching `SHA256SUMS` from Gitee answered 403 on roughly a third of consecutive attempts:

```
403 200 200 403 403 200 200 200 200 200
```

This happens inside `Check`, before anything is downloaded. And the release was missing `ota-BootAgent-windows-arm64.zip`, giving those users a permanent `release v0.7.2 has no asset for windows/arm64`.

Both arrive as a `Check` error, which [AppUpdater.tsx:30](frontend/src/components/AppUpdater.tsx:30) swallowed whole:

```typescript
try {
  version = await api.checkUpdate();
} catch {
  return;          // ← nothing shown, nothing to retry
}
```

So the app stopped offering updates with no indication why. A machine set to Chinese gets the mirror by default (`looksChinese` → `PreferMirror`), so this was the default path for those users. The only surface that reported it was the settings page, which a user has no reason to open.

## The fallback is deliberately one-way

`Check` now tries the official source when the mirror could not answer — mirror → official, never the reverse.

Runtime archives already try both hosts in either order ([`downloadSources`](internal/install/bootstrap.go:364)), and that is safe because `runtimes.lock.json` pins each artifact's SHA256 out of band, so a bad mirror can only fail rather than substitute anything. An OTA release has no such pin: `ChecksumAsset: "SHA256SUMS"` means the digest comes from whichever host served the artifact. Sending a user who never chose the mirror to the mirror would widen that trust boundary instead of just improving availability.

Two cases are intentionally not fallbacks:

- **"Nothing newer" is an answer.** A lagging mirror delays an update rather than causing a second request on every check. Querying both hosts always would spend the slow link the preference exists to avoid.
- **Cancellation is the caller's decision.** Falling back would reopen the request that was just abandoned, and the task centre's cancel button would not stick.

## The frontend keeps its silence, with one exception

An error from `Check` now means both sources failed — genuinely offline — where silence is right. `UPDATE_LOCATION_BLOCKED` is different: the backend only reaches that check once a newer release exists, so it means an update is waiting that this installation can never apply, and it does not resolve on its own. That one gets a dialog carrying the existing hint.

## Testing

- `go test ./...` — 17 packages pass. `go test -tags wails ./cmd/bootagent-desktop/` passes.
- `npx vitest run` — 54 files, 422 tests pass. `npx tsc --noEmit` clean. `go vet` clean, including under `-tags wails`.
- Every new test was verified to fail without its fix.
- Live endpoints with the mirror preferred: `darwin/arm64` hit a real 403 and resolved `via=official`; `windows/amd64`, `windows/arm64` and `linux/arm64` resolved `via=mirror`; checksum verification intact on all four.

## Notes

- `ota-BootAgent-windows-arm64.zip` was uploaded to Gitee while this was being written (16 → 17 assets), so that specific gap is closed. The fallback still matters: the 403 rate is ongoing, and a future missing asset no longer means updates stop silently.
- `Download` keeps its pinned source deliberately. The release metadata holds a URL and a digest from the host that answered `Check`, so switching hosts mid-download would mix a digest from one source with bytes from another. A `Download` failure is also already visible to the user as a failed task, unlike the check.
- Two findings from the audit are left alone as tradeoffs rather than defects: same-source checksums (the mirror is trusted for both artifact and digest), and no version-alignment check between the two sources. Both are worth a decision but neither is silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)