### PR TITLE
feat: auto-dismiss the launch notice, and finish a web-app Agent's launch in the browser

### DIFF
--- a/cmd/bootagent-desktop/main_wails.go
+++ b/cmd/bootagent-desktop/main_wails.go
@@ -255,13 +255,17 @@ func main() {
 	core := newDesktopUseCases()
 	var quitting atomic.Bool
 	var startupSyncOnce sync.Once
-	services := binding.NewServicesWithOptions(core, func(url string) error {
+	openInBrowser := func(url string) error {
 		current := application.Get()
 		if current == nil || current.Browser == nil {
 			return oneerrors.New(oneerrors.InternalError, "Desktop browser is not ready")
 		}
 		return current.Browser.OpenURL(url)
-	}, binding.ServicesOptions{
+	}
+	// Launching a web-app Agent ends in the browser, so the core needs the same
+	// opener the Provider pages use.
+	core.SetURLOpener(openInBrowser)
+	services := binding.NewServicesWithOptions(core, openInBrowser, binding.ServicesOptions{
 		Autostart: binding.AutostartCallbacks{
 			IsEnabled: func() (bool, error) {
 				if appInstance == nil || appInstance.Autostart == nil {

--- a/frontend/bindings/github.com/MaimoryLab/BootAgent/internal/catalog/models.ts
+++ b/frontend/bindings/github.com/MaimoryLab/BootAgent/internal/catalog/models.ts
@@ -14,6 +14,14 @@ export interface CatalogItem {
      * cannot misread beats a string it can compare against the wrong literal.
      */
     "selectsModel": boolean;
+
+    /**
+     * WebApp is true when launching this Agent ends in the browser rather than in
+     * a terminal window. The UI uses it to skip the launch-directory prompt: the
+     * Agent serves a local web app and picks its own workspace, so a directory
+     * asked for there would be collected and then ignored.
+     */
+    "webApp": boolean;
     "guideOnly": boolean;
     "lockedVersion": string | null;
     "protocol": string | null;

--- a/frontend/src/components/AgentManageRow.test.tsx
+++ b/frontend/src/components/AgentManageRow.test.tsx
@@ -28,7 +28,7 @@ const catalogAgent: AgentCatalogItem = {
   name: "Codex",
   group: "auto",
   configMode: "auto",
-  selectsModel: true, guideOnly: false,
+  selectsModel: true, webApp: false, guideOnly: false,
   lockedVersion: "0.145.0",
   protocol: "responses",
   platforms: ["macos", "linux", "windows"],
@@ -212,6 +212,24 @@ describe("AgentManageRow", () => {
   it("offers no launch for an Agent that is not installed", () => {
     renderRow({ installed: false, version: null });
     expect(screen.queryByRole("button", { name: /启动/ })).toBeNull();
+  });
+
+  // A web-app Agent serves a local page and picks its own workspace, so the
+  // directory prompt would collect an answer nothing goes on to use.
+  it("launches a web-app Agent without asking for a directory", async () => {
+    renderRow({}, "团队 PPIO", { webApp: true });
+    await userEvent.click(screen.getByRole("button", { name: /启动/ }));
+    await waitFor(() => expect(launchAgent).toHaveBeenCalledWith("codex", ""));
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  // The prompt is dropped for the web-app case only; every other Agent still runs
+  // in a directory the user chooses.
+  it("still asks a terminal Agent where to start", async () => {
+    renderRow();
+    await userEvent.click(screen.getByRole("button", { name: /启动/ }));
+    expect(screen.getByRole("dialog")).toBeTruthy();
+    expect(launchAgent).not.toHaveBeenCalled();
   });
 
   it("reports a launch failure in the row instead of failing silently", async () => {

--- a/frontend/src/components/AgentManageRow.tsx
+++ b/frontend/src/components/AgentManageRow.tsx
@@ -161,7 +161,26 @@ export function AgentManageRow({
   const canLaunch = status.installed;
   const offer = updateOffer(catalog, status);
 
+  const startLaunch = async (directory: string) => {
+    setDirectoryDialog(false);
+    setLaunching(true);
+    setFailure("");
+    try {
+      await api.launchAgent(agentId, directory);
+    } catch (error) {
+      setFailure(describeFailure(error, t("无法启动 Agent"), t).message);
+    } finally {
+      setLaunching(false);
+    }
+  };
+  // A web-app Agent serves a local page and chooses its own workspace, so asking
+  // where to start it would collect an answer nothing then uses. It launches
+  // straight away instead.
   const launch = () => {
+    if (catalog?.webApp) {
+      void startLaunch("");
+      return;
+    }
     const stored = localStorage.getItem(`bootagent:launch-directory:${agentId}`);
     setLaunchDirectory(stored || defaultDirectory || "");
     setRememberDirectory(Boolean(stored));
@@ -178,16 +197,7 @@ export function AgentManageRow({
     if (!launchDirectory.trim()) return;
     if (rememberDirectory) localStorage.setItem(`bootagent:launch-directory:${agentId}`, launchDirectory.trim());
     else localStorage.removeItem(`bootagent:launch-directory:${agentId}`);
-    setDirectoryDialog(false);
-    setLaunching(true);
-    setFailure("");
-    try {
-      await api.launchAgent(agentId, launchDirectory.trim());
-    } catch (error) {
-      setFailure(describeFailure(error, t("无法启动 Agent"), t).message);
-    } finally {
-      setLaunching(false);
-    }
+    await startLaunch(launchDirectory.trim());
   };
   const update = async () => {
     if (!startTask({

--- a/frontend/src/components/DesktopAppSection.test.tsx
+++ b/frontend/src/components/DesktopAppSection.test.tsx
@@ -142,6 +142,70 @@ describe("DesktopAppSection", () => {
     expect(screen.getByTitle("版本").textContent).toBe("26.727.51351");
   });
 
+  it("retires the launch notice on its own", async () => {
+    // It used to stay until the user launched again or navigated away, which
+    // unmounted the row -- so on the page where you launch from, it never left.
+    vi.useFakeTimers();
+    try {
+      bridge.openDesktopAgent.mockResolvedValue(undefined);
+      render(
+        <TaskCenterProvider>
+          <DesktopAppSection app={app({ installed: true })} onChanged={vi.fn()} />
+        </TaskCenterProvider>,
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "启动" }));
+      await vi.waitFor(() => expect(screen.queryByText("Example Desktop 已打开")).toBeTruthy());
+      // Still there a moment later: it is readable, not a flash.
+      await act(async () => { await vi.advanceTimersByTimeAsync(1000); });
+      expect(screen.queryByText("Example Desktop 已打开")).toBeTruthy();
+
+      await act(async () => { await vi.advanceTimersByTimeAsync(3000); });
+      expect(screen.queryByText("Example Desktop 已打开")).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("restarts the countdown when the app is launched again", async () => {
+    // The second launch repeats the same message. If the reset to "" did not
+    // land between the two, the effect would not re-run and the notice would
+    // still vanish on the first launch's schedule.
+    vi.useFakeTimers();
+    try {
+      bridge.openDesktopAgent.mockResolvedValue(undefined);
+      render(
+        <TaskCenterProvider>
+          <DesktopAppSection app={app({ installed: true })} onChanged={vi.fn()} />
+        </TaskCenterProvider>,
+      );
+
+      // Settle the launch before reading the clock: the notice is set after an
+      // awaited call, so advancing first would arm the timer mid-advance and
+      // measure from the wrong instant.
+      const launch = async () => {
+        fireEvent.click(screen.getByRole("button", { name: "启动" }));
+        await act(async () => { await vi.advanceTimersByTimeAsync(0); });
+      };
+
+      await launch();
+      expect(screen.queryByText("Example Desktop 已打开")).toBeTruthy();
+      await act(async () => { await vi.advanceTimersByTimeAsync(3000); });
+
+      await launch();
+      expect(bridge.openDesktopAgent).toHaveBeenCalledTimes(2);
+      // 3s of the first window had already elapsed; the notice outliving another
+      // 2s proves the clock restarted rather than carried over.
+      await act(async () => { await vi.advanceTimersByTimeAsync(2000); });
+      expect(screen.queryByText("Example Desktop 已打开")).toBeTruthy();
+
+      await act(async () => { await vi.advanceTimersByTimeAsync(2000); });
+      expect(screen.queryByText("Example Desktop 已打开")).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("keeps the bar and reports the outcome across a navigation mid-download", async () => {
     // The download outlives this row: the user can leave the page while it runs.
     // The bar and the final verdict used to hang off local useState, so

--- a/frontend/src/components/DesktopAppSection.tsx
+++ b/frontend/src/components/DesktopAppSection.tsx
@@ -1,5 +1,5 @@
 import { AppWindow, Download, History, Play, Plus, RefreshCw, SlidersHorizontal, TriangleAlert } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { api, describeFailure } from "../backend/api";
 import { useI18n } from "../i18n";
@@ -25,6 +25,16 @@ interface DesktopAppSectionProps {
 
 type Action = "install" | "open";
 
+/**
+ * How long "{name} 已打开" stays on screen.
+ *
+ * Long enough to be read, short enough that it does not become furniture. This
+ * only bounds the launch confirmation: an install outcome lives in the Task
+ * Center until the user dismisses it, and a failure stays until the next
+ * attempt, because both carry something still worth acting on.
+ */
+const LAUNCH_NOTICE_MS = 4000;
+
 export function DesktopAppSection({ app: desktopApp, onChanged, onSetup, onConfigure, profile, providerName, model, showUninstalled = true, showHeading = true }: DesktopAppSectionProps) {
   const { t } = useI18n();
   const { startTask, finishTask, setTaskCanceller, taskFor } = useTaskCenter();
@@ -46,6 +56,15 @@ export function DesktopAppSection({ app: desktopApp, onChanged, onSetup, onConfi
   const busy = Boolean(pending) || downloading;
   const notice = localNotice || (installTask?.state === "success" ? installTask.message : "");
   const failure = localFailure || (!localNotice && installTask?.state === "failure" ? installTask.message : "");
+
+  // Launching an app says everything it has to say the moment it appears, so it
+  // retires itself. Previously nothing cleared it: it sat there until the user
+  // launched again or navigated away, which unmounted the row.
+  useEffect(() => {
+    if (!localNotice) return;
+    const timer = setTimeout(() => setLocalNotice(""), LAUNCH_NOTICE_MS);
+    return () => clearTimeout(timer);
+  }, [localNotice]);
 
   const run = async (action: Action) => {
     const downloads = action === "install";

--- a/frontend/src/pages/AgentProfilePage.test.tsx
+++ b/frontend/src/pages/AgentProfilePage.test.tsx
@@ -49,7 +49,7 @@ function statusWith(profiles: ProfileSummary[]): StatusResponse {
       },
     },
     catalog: [{
-      id: "codex", name: "Codex", group: "auto", configMode: "auto", selectsModel: true,
+      id: "codex", name: "Codex", group: "auto", configMode: "auto", selectsModel: true, webApp: false,
       guideOnly: false, lockedVersion: "1.0.0", protocol: "responses",
       platforms: ["macos"], platformNote: "", rank: 1,
     }],

--- a/frontend/src/pages/AgentSelectionPage.test.tsx
+++ b/frontend/src/pages/AgentSelectionPage.test.tsx
@@ -21,12 +21,12 @@ let mockState: {
 
 /** The real ranks, so a regression in ordering shows up as the real symptom. */
 const CATALOG: AgentCatalogItem[] = [
-  { rank: 1, id: "codex", name: "Codex", group: "auto", configMode: "auto", selectsModel: true, guideOnly: false },
-  { rank: 2, id: "claude-code", name: "Claude Code", group: "auto", configMode: "auto", selectsModel: true, guideOnly: false },
-  { rank: 3, id: "opencode", name: "OpenCode", group: "auto", configMode: "auto", selectsModel: true, guideOnly: false },
-  { rank: 4, id: "kilo-cli", name: "Kilo CLI", group: "auto", configMode: "auto", selectsModel: true, guideOnly: false },
-  { rank: 5, id: "aider", name: "Aider", group: "auto", configMode: "auto", selectsModel: true, guideOnly: false },
-  { rank: 6, id: "openclaw", name: "OpenClaw", group: "auto", configMode: "auto", selectsModel: true, guideOnly: false },
+  { rank: 1, id: "codex", name: "Codex", group: "auto", configMode: "auto", selectsModel: true, webApp: false, guideOnly: false },
+  { rank: 2, id: "claude-code", name: "Claude Code", group: "auto", configMode: "auto", selectsModel: true, webApp: false, guideOnly: false },
+  { rank: 3, id: "opencode", name: "OpenCode", group: "auto", configMode: "auto", selectsModel: true, webApp: false, guideOnly: false },
+  { rank: 4, id: "kilo-cli", name: "Kilo CLI", group: "auto", configMode: "auto", selectsModel: true, webApp: false, guideOnly: false },
+  { rank: 5, id: "aider", name: "Aider", group: "auto", configMode: "auto", selectsModel: true, webApp: false, guideOnly: false },
+  { rank: 6, id: "openclaw", name: "OpenClaw", group: "auto", configMode: "auto", selectsModel: true, webApp: false, guideOnly: false },
 ].map((item) => ({
   ...item,
   group: item.group as AgentCatalogItem["group"],
@@ -72,7 +72,7 @@ function renderPage({ desktop = false }: { desktop?: boolean } = {}) {
           {
             installed: false,
             configured: false,
-            selectsModel: true, guideOnly: item.guideOnly,
+            selectsModel: true, webApp: false, guideOnly: item.guideOnly,
             config: "/c",
             version: null,
             lockedVersion: item.lockedVersion,

--- a/frontend/src/pages/EnvironmentOverviewPage.test.tsx
+++ b/frontend/src/pages/EnvironmentOverviewPage.test.tsx
@@ -29,7 +29,7 @@ function status(): StatusResponse {
   const agent = (installed: boolean, profileId: string | null) => ({
     installed,
     configured: installed,
-    selectsModel: true, guideOnly: false,
+    selectsModel: true, webApp: false, guideOnly: false,
     config: "/config",
     version: installed ? "1.0.0" : null,
     lockedVersion: "1.0.0",
@@ -49,8 +49,8 @@ function status(): StatusResponse {
     capabilities: { canInstall: {}, missingRuntime: {}, supportedAgentIds: [] },
     agents: { codex: agent(true, "team"), opencode: agent(false, null) },
     catalog: [
-      { id: "opencode", name: "OpenCode", group: "auto", configMode: "auto", selectsModel: true, guideOnly: false, lockedVersion: "1.0.0", protocol: "openai", platforms: ["macos"], platformNote: "", rank: 4 },
-      { id: "codex", name: "Codex", group: "auto", configMode: "auto", selectsModel: true, guideOnly: false, lockedVersion: "1.0.0", protocol: "responses", platforms: ["macos"], platformNote: "", rank: 1 },
+      { id: "opencode", name: "OpenCode", group: "auto", configMode: "auto", selectsModel: true, webApp: false, guideOnly: false, lockedVersion: "1.0.0", protocol: "openai", platforms: ["macos"], platformNote: "", rank: 4 },
+      { id: "codex", name: "Codex", group: "auto", configMode: "auto", selectsModel: true, webApp: false, guideOnly: false, lockedVersion: "1.0.0", protocol: "responses", platforms: ["macos"], platformNote: "", rank: 1 },
     ],
     groups: [],
     providers: { ppio: { name: "PPIO", home: "https://ppio.com/", base_url: "https://api.ppio.com/openai" } },

--- a/frontend/src/pages/ProfilesPage.test.tsx
+++ b/frontend/src/pages/ProfilesPage.test.tsx
@@ -49,7 +49,7 @@ function statusWith(profiles: ProfileSummary[]): StatusResponse {
         id: "codex",
         name: "Codex",
         group: "auto",
-        configMode: "auto", selectsModel: true,
+        configMode: "auto", selectsModel: true, webApp: false,
         guideOnly: false,
         lockedVersion: "1.0.0",
         protocol: "responses",

--- a/frontend/src/pages/ProvidersPage.test.tsx
+++ b/frontend/src/pages/ProvidersPage.test.tsx
@@ -29,7 +29,7 @@ function statusWith(agents: Record<string, string | null>): StatusResponse {
         {
           installed: true,
           configured: Boolean(provider),
-          selectsModel: true, guideOnly: false,
+          selectsModel: true, webApp: false, guideOnly: false,
           config: "/c",
           version: "1.0.0",
           lockedVersion: "1.0.0",
@@ -49,7 +49,7 @@ function statusWith(agents: Record<string, string | null>): StatusResponse {
       name: id === "claude-code" ? "Claude Code" : id,
       group: "auto" as const,
       configMode: "auto" as const,
-      selectsModel: true, guideOnly: false,
+      selectsModel: true, webApp: false, guideOnly: false,
       lockedVersion: "1.0.0",
       latestVersion: null,
       protocol: "openai" as const,

--- a/frontend/src/state/ranking.test.ts
+++ b/frontend/src/state/ranking.test.ts
@@ -8,7 +8,7 @@ function item(id: string, rank: number): AgentCatalogItem {
     id,
     name: id,
     group: "auto",
-    configMode: "auto", selectsModel: true,
+    configMode: "auto", selectsModel: true, webApp: false,
     guideOnly: false,
     lockedVersion: null,
     protocol: null,

--- a/frontend/src/state/wizardReducer.test.ts
+++ b/frontend/src/state/wizardReducer.test.ts
@@ -404,6 +404,7 @@ describe("wizardNeedsModel", () => {
     group: "auto" as const,
     configMode: "auto" as const,
     selectsModel,
+    webApp: false,
     guideOnly: false,
     lockedVersion: null,
     protocol: "openai" as const,

--- a/internal/app/launch.go
+++ b/internal/app/launch.go
@@ -3,8 +3,11 @@ package app
 import (
 	"context"
 	"fmt"
+	"net"
+	"net/url"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/MaimoryLab/BootAgent/internal/catalog"
 	oneerrors "github.com/MaimoryLab/BootAgent/internal/errors"
@@ -20,7 +23,11 @@ type LaunchAgentResult struct {
 	// Terminal is the terminal that actually opened. It can differ from the
 	// stored preference when that terminal is no longer installed, so the caller
 	// can say which one ran instead of leaving the substitution invisible.
+	// Empty when the Agent's server was already serving and no window was needed.
 	Terminal string `json:"terminal"`
+	// WebURL is the address opened in the browser, set only for Agents whose
+	// interface is a local web app.
+	WebURL string `json:"web_url,omitempty"`
 }
 
 // LaunchAgent opens a terminal window running one configured Agent. It reuses
@@ -79,6 +86,16 @@ func (u *UseCases) LaunchAgent(ctx context.Context, agentID string, directories 
 	if err != nil {
 		return LaunchAgentResult{}, err
 	}
+	// A web-app Agent that is already serving needs no second server: starting one
+	// would only fail to bind the port and leave a terminal window whose whole
+	// content is that error. The page is the destination either way.
+	address, servingAlready := u.webUIAddress(agent)
+	if servingAlready {
+		if err := u.openWebUI(agent); err != nil {
+			return LaunchAgentResult{}, err
+		}
+		return LaunchAgentResult{Agent: agentID, Command: line, WebURL: agent.WebURL}, nil
+	}
 	// The window resolves the Agent the same way status said it could: an Agent
 	// CLI under the managed global prefix is only on PATH once the managed
 	// directories are prepended, and a shell started before that install would
@@ -90,7 +107,100 @@ func (u *UseCases) LaunchAgent(ctx context.Context, agentID string, directories 
 			oneerrors.WithStatus(500), oneerrors.WithRetryable(true), oneerrors.WithCause(err),
 		)
 	}
-	return LaunchAgentResult{Agent: agentID, Command: line, Terminal: terminal}, nil
+	if address != "" {
+		// The server was just asked to start, so the port is not up yet. Waiting
+		// avoids handing the browser an address that would answer "connection
+		// refused"; the wait is bounded so a server that never binds delays the
+		// launch rather than hanging it.
+		u.waitForWebUI(ctx, address)
+		if err := u.openWebUI(agent); err != nil {
+			return LaunchAgentResult{}, err
+		}
+	}
+	return LaunchAgentResult{Agent: agentID, Command: line, Terminal: terminal, WebURL: agent.WebURL}, nil
+}
+
+// webUIDialTimeout bounds one connection attempt, and webUIWaitTimeout the whole
+// wait for a server that was just started. The total is short enough that a
+// launch still feels like a launch if the server never binds.
+const (
+	webUIDialTimeout = 300 * time.Millisecond
+	webUIWaitTimeout = 15 * time.Second
+	webUIPollEvery   = 150 * time.Millisecond
+)
+
+// webUIAddress returns the host:port to probe for a web-app Agent, and whether
+// something is already serving there. Both are empty/false for the ordinary
+// terminal Agents, which is what keeps their launch path unchanged.
+func (u *UseCases) webUIAddress(agent catalog.Agent) (string, bool) {
+	if u == nil || agent.WebURL == "" {
+		return "", false
+	}
+	parsed, err := url.Parse(agent.WebURL)
+	if err != nil || parsed.Host == "" {
+		return "", false
+	}
+	address := parsed.Host
+	if parsed.Port() == "" {
+		// Only the two schemes a local web app would use; anything else is a
+		// manifest mistake rather than something to guess a port for.
+		switch parsed.Scheme {
+		case "http":
+			address = net.JoinHostPort(parsed.Hostname(), "80")
+		case "https":
+			address = net.JoinHostPort(parsed.Hostname(), "443")
+		default:
+			return "", false
+		}
+	}
+	return address, u.dialWebUI(address)
+}
+
+func (u *UseCases) dialWebUI(address string) bool {
+	if u.status.DialWebUI != nil {
+		return u.status.DialWebUI(address)
+	}
+	connection, err := net.DialTimeout("tcp", address, webUIDialTimeout)
+	if err != nil {
+		return false
+	}
+	_ = connection.Close()
+	return true
+}
+
+// waitForWebUI blocks until the address answers, the deadline passes, or the
+// caller gives up. It reports nothing: a timeout still opens the browser, since
+// the user asked for the page and a late server is better served by a reload
+// than by BootAgent deciding the launch failed.
+func (u *UseCases) waitForWebUI(ctx context.Context, address string) {
+	deadline := time.Now().Add(webUIWaitTimeout)
+	for {
+		if u.dialWebUI(address) {
+			return
+		}
+		if time.Now().After(deadline) {
+			return
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(webUIPollEvery):
+		}
+	}
+}
+
+func (u *UseCases) openWebUI(agent catalog.Agent) error {
+	if u.status.OpenURL == nil {
+		return oneerrors.New(oneerrors.InternalError, "Desktop browser is not configured", oneerrors.WithStatus(501))
+	}
+	if err := u.status.OpenURL(agent.WebURL); err != nil {
+		return oneerrors.New(
+			oneerrors.InternalError,
+			"Cannot open "+agent.Name+" at "+agent.WebURL,
+			oneerrors.WithStatus(500), oneerrors.WithRetryable(true), oneerrors.WithCause(err),
+		)
+	}
+	return nil
 }
 
 func launchInDirectory(osID, directory, line string) string {

--- a/internal/app/launch_test.go
+++ b/internal/app/launch_test.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"errors"
 	"slices"
 	"strings"
 	"testing"
@@ -42,6 +43,43 @@ func launchCore(t *testing.T, osID string, runner process.Runner) *UseCases {
 		Runner:      runner,
 		Lookup:      runner.LookPath,
 		Environment: map[string]string{"PATH": "/usr/bin"},
+	})
+}
+
+// webUIProbe stands in for the port and the browser. readyAfter is how many dials
+// happen before the address answers, so a test can model a server that is already
+// up (0) or one that binds shortly after its window opens.
+type webUIProbe struct {
+	readyAfter int
+	dials      int
+	dialed     []string
+	opened     []string
+	openErr    error
+}
+
+func (p *webUIProbe) dial(address string) bool {
+	p.dials++
+	p.dialed = append(p.dialed, address)
+	return p.dials > p.readyAfter
+}
+
+func (p *webUIProbe) open(url string) error {
+	p.opened = append(p.opened, url)
+	return p.openErr
+}
+
+// launchWebCore is launchCore with the port and browser stubbed. Agents without a
+// web_url never reach either hook, which is why the other tests need no probe.
+func launchWebCore(t *testing.T, osID string, runner process.Runner, probe *webUIProbe) *UseCases {
+	t.Helper()
+	return NewUseCases(StatusOptions{
+		Home:        t.TempDir(),
+		Platform:    platform.For(osID, "amd64"),
+		Runner:      runner,
+		Lookup:      runner.LookPath,
+		Environment: map[string]string{"PATH": "/usr/bin"},
+		OpenURL:     probe.open,
+		DialWebUI:   probe.dial,
 	})
 }
 
@@ -99,7 +137,9 @@ func TestLaunchAgentUsesCmdOnWindows(t *testing.T) {
 // in a real terminal, a bare command would open a window only to print an error.
 func TestLaunchAgentGivesDSHABootableProfile(t *testing.T) {
 	runner := &launchRunner{paths: map[string]string{"x-terminal-emulator": "/usr/bin/x-terminal-emulator"}}
-	core := launchCore(t, "linux", runner)
+	// Not yet serving, then up on the next poll: the window it just opened is what
+	// binds the port.
+	core := launchWebCore(t, "linux", runner, &webUIProbe{readyAfter: 1})
 	result, err := core.LaunchAgent(context.Background(), "dsh")
 	if err != nil {
 		t.Fatal(err)
@@ -113,6 +153,112 @@ func TestLaunchAgentGivesDSHABootableProfile(t *testing.T) {
 		return strings.Contains(argument, "dsh web")
 	}) {
 		t.Fatalf("terminal argv = %#v", runner.started)
+	}
+}
+
+// dsh's interface is a local web app, so the terminal is only how the server gets
+// started: the launch is not finished until the page is open in the browser.
+func TestLaunchAgentOpensTheWebUIAfterStartingItsServer(t *testing.T) {
+	runner := &launchRunner{paths: map[string]string{"x-terminal-emulator": "/usr/bin/x-terminal-emulator"}}
+	probe := &webUIProbe{readyAfter: 1}
+	core := launchWebCore(t, "linux", runner, probe)
+	result, err := core.LaunchAgent(context.Background(), "dsh")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(runner.started) != 1 {
+		t.Fatalf("expected one terminal window, started = %#v", runner.started)
+	}
+	if want := []string{"http://127.0.0.1:3080"}; !slices.Equal(probe.opened, want) {
+		t.Fatalf("opened = %#v, want %#v", probe.opened, want)
+	}
+	if result.WebURL != "http://127.0.0.1:3080" {
+		t.Fatalf("result.WebURL = %q", result.WebURL)
+	}
+	// The port, not the URL, is what gets dialled.
+	if len(probe.dialed) == 0 || probe.dialed[0] != "127.0.0.1:3080" {
+		t.Fatalf("dialed = %#v", probe.dialed)
+	}
+}
+
+// A second window would only fail to bind the port and show that error, so a
+// server that is already up is joined rather than duplicated.
+func TestLaunchAgentSkipsTheTerminalWhenTheWebUIIsAlreadyServing(t *testing.T) {
+	runner := &launchRunner{paths: map[string]string{"x-terminal-emulator": "/usr/bin/x-terminal-emulator"}}
+	probe := &webUIProbe{readyAfter: 0}
+	core := launchWebCore(t, "linux", runner, probe)
+	result, err := core.LaunchAgent(context.Background(), "dsh")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(runner.started) != 0 {
+		t.Fatalf("expected no terminal window, started = %#v", runner.started)
+	}
+	if want := []string{"http://127.0.0.1:3080"}; !slices.Equal(probe.opened, want) {
+		t.Fatalf("opened = %#v, want %#v", probe.opened, want)
+	}
+	// No window ran, so naming one would be a claim about something that did not
+	// happen.
+	if result.Terminal != "" {
+		t.Fatalf("result.Terminal = %q, want empty", result.Terminal)
+	}
+}
+
+// The ordinary terminal Agents have no web_url, and must not gain a browser hop
+// or a port probe because one Agent does.
+func TestLaunchAgentLeavesTerminalAgentsUntouched(t *testing.T) {
+	runner := &launchRunner{}
+	probe := &webUIProbe{}
+	core := launchWebCore(t, "darwin", runner, probe)
+	result, err := core.LaunchAgent(context.Background(), "codex")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(probe.opened) != 0 || len(probe.dialed) != 0 {
+		t.Fatalf("codex touched the web path: opened = %#v, dialed = %#v", probe.opened, probe.dialed)
+	}
+	if result.WebURL != "" {
+		t.Fatalf("result.WebURL = %q, want empty", result.WebURL)
+	}
+	if result.Terminal == "" {
+		t.Fatal("expected a terminal for an ordinary Agent")
+	}
+}
+
+// A browser that will not open is worth reporting: the page is what the user
+// asked for, and the terminal window alone does not deliver it.
+func TestLaunchAgentReportsABrowserThatCannotOpen(t *testing.T) {
+	runner := &launchRunner{paths: map[string]string{"x-terminal-emulator": "/usr/bin/x-terminal-emulator"}}
+	probe := &webUIProbe{readyAfter: 0, openErr: errors.New("no browser")}
+	core := launchWebCore(t, "linux", runner, probe)
+	if _, err := core.LaunchAgent(context.Background(), "dsh"); err == nil {
+		t.Fatal("expected a failing browser to surface")
+	}
+}
+
+// The wait must not outlive the caller: a cancelled launch stops polling instead
+// of holding the request open for the full timeout.
+func TestLaunchAgentStopsWaitingForTheWebUIWhenCancelled(t *testing.T) {
+	runner := &launchRunner{paths: map[string]string{"x-terminal-emulator": "/usr/bin/x-terminal-emulator"}}
+	// Never answers, so only cancellation can end the wait.
+	probe := &webUIProbe{readyAfter: 1 << 30}
+	core := launchWebCore(t, "linux", runner, probe)
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+	start := time.Now()
+	if _, err := core.LaunchAgent(ctx, "dsh"); err != nil {
+		t.Fatal(err)
+	}
+	if elapsed := time.Since(start); elapsed >= webUIWaitTimeout {
+		t.Fatalf("wait ignored cancellation, took %s", elapsed)
+	}
+	// The browser still opens: the user asked for the page, and a late server is
+	// better answered by a reload than by BootAgent calling the launch a failure.
+	if len(probe.opened) != 1 {
+		t.Fatalf("opened = %#v", probe.opened)
 	}
 }
 

--- a/internal/app/status.go
+++ b/internal/app/status.go
@@ -42,6 +42,12 @@ type StatusOptions struct {
 	FileSystem  *securefs.Store
 	Runner      process.Runner
 	Environment map[string]string
+	// OpenURL hands an address to the user's default browser. The desktop entry
+	// point supplies the Wails implementation; tests record the call instead.
+	OpenURL func(string) error
+	// DialWebUI reports whether something is already accepting connections at a
+	// host:port. Injectable so a launch can be tested without binding a port.
+	DialWebUI func(address string) bool
 }
 
 type UseCases struct {
@@ -99,6 +105,15 @@ func (u *UseCases) DraftState() (bool, string) {
 func (u *UseCases) SetRuntimeDownloader(client install.Doer) {
 	if u != nil {
 		u.httpDoer = client
+	}
+}
+
+// SetURLOpener supplies the browser used to open a web-app Agent. The desktop
+// entry point builds its opener from the Wails application, which only exists
+// once the app is running, so this is set after construction.
+func (u *UseCases) SetURLOpener(open func(string) error) {
+	if u != nil {
+		u.status.OpenURL = open
 	}
 }
 

--- a/internal/app/testdata/status-empty-linux-arm64.json
+++ b/internal/app/testdata/status-empty-linux-arm64.json
@@ -222,7 +222,8 @@
       ],
       "protocol": "openai",
       "rank": 1,
-      "selectsModel": false
+      "selectsModel": false,
+      "webApp": true
     },
     {
       "configMode": "auto",
@@ -241,7 +242,8 @@
       ],
       "protocol": "responses",
       "rank": 2,
-      "selectsModel": true
+      "selectsModel": true,
+      "webApp": false
     },
     {
       "configMode": "auto",
@@ -260,7 +262,8 @@
       ],
       "protocol": "anthropic",
       "rank": 3,
-      "selectsModel": true
+      "selectsModel": true,
+      "webApp": false
     },
     {
       "configMode": "auto",
@@ -279,7 +282,8 @@
       ],
       "protocol": "openai",
       "rank": 4,
-      "selectsModel": true
+      "selectsModel": true,
+      "webApp": false
     },
     {
       "configMode": "auto",
@@ -298,7 +302,8 @@
       ],
       "protocol": "openai",
       "rank": 5,
-      "selectsModel": true
+      "selectsModel": true,
+      "webApp": false
     },
     {
       "configMode": "auto",
@@ -317,7 +322,8 @@
       ],
       "protocol": "openai",
       "rank": 6,
-      "selectsModel": true
+      "selectsModel": true,
+      "webApp": false
     },
     {
       "configMode": "auto",
@@ -336,7 +342,8 @@
       ],
       "protocol": "openai",
       "rank": 7,
-      "selectsModel": true
+      "selectsModel": true,
+      "webApp": false
     },
     {
       "configMode": "auto",
@@ -355,7 +362,8 @@
       ],
       "protocol": "openai",
       "rank": 8,
-      "selectsModel": true
+      "selectsModel": true,
+      "webApp": false
     },
     {
       "configMode": "auto",
@@ -374,7 +382,8 @@
       ],
       "protocol": "openai",
       "rank": 9,
-      "selectsModel": true
+      "selectsModel": true,
+      "webApp": false
     },
     {
       "configMode": "auto",
@@ -393,7 +402,8 @@
       ],
       "protocol": "openai",
       "rank": 10,
-      "selectsModel": true
+      "selectsModel": true,
+      "webApp": false
     }
   ],
   "groups": [

--- a/internal/catalog/catalog_test.go
+++ b/internal/catalog/catalog_test.go
@@ -219,6 +219,36 @@ func TestPublicProjectionDoesNotExposeFallbackModel(t *testing.T) {
 	}
 }
 
+// One manifest entry drives both halves of the web-app behaviour: Go opens the
+// address after launching, and the UI drops the launch-directory prompt. The
+// projection is what carries the second half, so a web_url that never became a
+// webApp flag would silently leave the prompt in place.
+func TestWebAppProjectionFollowsTheManifestURL(t *testing.T) {
+	manifest, err := LoadEmbedded()
+	if err != nil {
+		t.Fatal(err)
+	}
+	items := PublicCatalog(manifest, "darwin")
+	seenWebApp := false
+	for _, item := range items {
+		agent := manifest.Agents[item.ID]
+		if want := agent.WebURL != ""; item.WebApp != want {
+			t.Fatalf("agent %q: WebApp = %v, want %v (web_url = %q)", item.ID, item.WebApp, want, agent.WebURL)
+		}
+		if item.WebApp {
+			seenWebApp = true
+		}
+	}
+	// Without this the loop above passes on a manifest where the field was dropped
+	// everywhere, which is the regression most worth catching.
+	if !seenWebApp {
+		t.Fatal("no Agent is marked as a web app; dsh should be")
+	}
+	if url := manifest.Agents["dsh"].WebURL; url != "http://127.0.0.1:3080" {
+		t.Fatalf("dsh web_url = %q", url)
+	}
+}
+
 func TestParseRejectsInvalidManifest(t *testing.T) {
 	for _, data := range []string{
 		`{"schema_version":2,"agents":{}}`,

--- a/internal/catalog/public.go
+++ b/internal/catalog/public.go
@@ -18,6 +18,14 @@ func AgentSelectsModel(agent Agent) bool {
 	return agent.ModelSelection != ModelSelectionAgent
 }
 
+// AgentIsWebApp reports whether the Agent's interface is a local web app rather
+// than a terminal session. Derived from WebURL so one manifest entry drives both
+// halves of the behaviour: Go opens the address after launching, and the UI drops
+// the prompts that only make sense for a command in a shell.
+func AgentIsWebApp(agent Agent) bool {
+	return agent.WebURL != ""
+}
+
 var adapterProtocols = map[string]string{
 	"codex":       ProtocolResponses,
 	"claude-code": ProtocolAnthropic,
@@ -150,6 +158,7 @@ func PublicCatalog(manifest Manifest, platformID string) []CatalogItem {
 			Group:          agent.Group,
 			ConfigMode:     agent.ConfigMode,
 			SelectsModel:   AgentSelectsModel(agent),
+			WebApp:         AgentIsWebApp(agent),
 			GuideOnly:      agent.ConfigMode == "guide",
 			LockedVersion:  nil,
 			Protocol:       protocol,

--- a/internal/catalog/types.go
+++ b/internal/catalog/types.go
@@ -39,7 +39,13 @@ type Agent struct {
 	// wizard skips the model step instead of collecting an answer it would drop
 	// on the floor. Named rather than a bool because the wizard has to *explain*
 	// the skip, and "the Agent chooses" is the explanation.
-	ModelSelection       string   `json:"model_selection,omitempty"`
+	ModelSelection string `json:"model_selection,omitempty"`
+	// WebURL is set when the Agent's interface is a local web app rather than a
+	// terminal session. Launching such an Agent starts its server and then opens
+	// this address in the user's browser, because the terminal window is only the
+	// means and the page is the actual destination. It lives here rather than in
+	// code so the address stays with the rest of the Agent's facts.
+	WebURL               string   `json:"web_url,omitempty"`
 	Package              *Package `json:"package"`
 	VersionArgs          []string `json:"version_args"`
 	Platforms            []string `json:"platforms"`
@@ -68,7 +74,12 @@ type CatalogItem struct {
 	// wizard can skip that step. Derived from Agent.ModelSelection rather than
 	// exposed raw: the UI needs the decision, not the vocabulary, and a bool it
 	// cannot misread beats a string it can compare against the wrong literal.
-	SelectsModel  bool     `json:"selectsModel"`
+	SelectsModel bool `json:"selectsModel"`
+	// WebApp is true when launching this Agent ends in the browser rather than in
+	// a terminal window. The UI uses it to skip the launch-directory prompt: the
+	// Agent serves a local web app and picks its own workspace, so a directory
+	// asked for there would be collected and then ignored.
+	WebApp        bool     `json:"webApp"`
 	GuideOnly     bool     `json:"guideOnly"`
 	LockedVersion *string  `json:"lockedVersion"`
 	Protocol      *string  `json:"protocol"`

--- a/manifests/agents.lock.json
+++ b/manifests/agents.lock.json
@@ -263,6 +263,7 @@
       "config_adapter": "dsh",
       "model_selection": "agent",
       "config_path": ".dsh/settings.yaml",
+      "web_url": "http://127.0.0.1:3080",
       "package": {
         "manager": "npm",
         "name": "@deepseek-ai/dsh",


### PR DESCRIPTION
三个独立提交，可分开审。

## 1. 桌面 Agent 的绿色提示自动消失

`{name} 已打开` 写进组件本地 state，**没有任何东西清它** —— 没有定时器，状态刷新也不碰它。唯一的出口是「再次启动」和「组件卸载」，而卸载就意味着切走页面。于是在你启动的那一页上，它永远不走。

改为 4 秒后自行退场。安装结果与失败提示不动：前者留在任务中心等你手动关，后者留到下次尝试，两者都还带着待处理的信息。

## 2. dsh 启动后自动打开浏览器

排查中的关键发现：`nextStep` 早就返回 `dsh web` 了（[agent.go:340](internal/app/agent.go:340)），所以**服务一直在启**，只是启完就停在那儿，让用户自己记住地址再去开浏览器。所以这个改动比看起来小得多 —— 补的是最后一跳，不是整条链路。

按讨论确认的流程：

- **端口已在服务** → 不开第二个窗口（第二个 `dsh web` 只会绑不上端口，然后用那条错误填满一个终端），直接开浏览器
- **端口没起来** → 开终端起服务 → 轮询端口直到可连 → 开浏览器

等待有 15 秒上限并响应 context 取消。**超时也照样开浏览器**：你要的是那个页面，服务来晚了刷新一下比 BootAgent 判定启动失败更合理。

地址放进 manifest 的 `web_url` 而不是写死在代码里 —— `internal/catalog/types.go` 开头就写了 catalog 的存在意义是「不让运行时代码自己编 URL」。顺带地，将来第二个 web 类 Agent 不需要加分支。

## 3. dsh 不再询问启动目录

启动目录这个提问是为终端 Agent 服务的 —— 让它在你要的项目里打开。web 类 Agent 用不上这个答案：它服务一个本地页面、自己决定工作区，所以目录被收集完就被丢掉。dsh 得先回答一个无意义的问题才能启动。

catalog 投影新增 `webApp`，由**同一个** `web_url` 派生，因此一条 manifest 记录同时驱动两件事（Go 开浏览器、UI 去掉提问），UI 不需要自己维护一份 Agent 名单。这里跟着现成的 `SelectsModel` 先例走：注释写明「UI 需要的是结论，不是词汇表」。其余 Agent 的提问照旧。

DTO 变了，所以按 AGENTS.md 重新生成了 `frontend/bindings`（生成 diff 只多了那一个字段，已核对）。

## 验证

- `go test ./...`、`go test -race`（app + catalog）、`go vet ./...` 全过
- 前端 **433 passed / 56 files**，`pnpm run build`（含 `tsc --noEmit`）通过
- `scripts/check-docs.py`、`generate_third_party_licenses.py --check` 通过
- **真实二进制核对**：本机装了 dsh，实跑 `dsh web` 确认它打印 `http://127.0.0.1:3080`；并用真实 `net.DialTimeout`（非 stub）验证默认拨号路径 —— 无服务时 false、服务起来后 true
- 新增测试都做了变异验证（抽掉实现后确认失败），不是走过场的断言：
  - 提示自愈 / 重启后重新计时 —— 两条都失败
  - web 类 Agent 跳过目录对话框 —— 失败
- `TestWebAppProjectionFollowsTheManifestURL` 同时防两个方向：投影与 `web_url` 不一致会失败，字段被整体删掉（无任何 Agent 为 web app）也会失败

### 没能验证到的部分

需求 1 和 3 我**没能在真实浏览器里点一遍**。桌面/命令行 Agent 的「启动」按钮只在已安装时渲染，而 e2e harness 用临时 HOME + stub runner，所有 Agent 都是「待安装」，按钮不存在。我确认过 dsh 在目录里列出来了，但拿不到可点的启动按钮。

这两处是靠单元测试 + 变异验证覆盖的，不是靠肉眼确认。需求 2 的服务端行为由 Go 测试覆盖，Wails 的 `Browser.OpenURL` 在 server 模式下本身也不可用。