### PR TITLE
fix: quit when the user asks, instead of only from the tray menu

### DIFF
--- a/cmd/bootagent-desktop/main_wails.go
+++ b/cmd/bootagent-desktop/main_wails.go
@@ -158,6 +158,25 @@ func configureUpdater(appInstance *application.App, core *app.UseCases) binding.
 	return appInstance.Updater
 }
 
+// acceptQuit answers a quit request, and records that one was made.
+//
+// Wails asks this only when the user has actually asked the app to quit: the
+// Dock's Quit, Cmd+Q, the app menu, or a logout. It used to answer "no" unless
+// the tray's own Quit item had run first, which made every one of those routes a
+// no-op -- on macOS a false answer becomes NSTerminateCancel, so the Dock
+// reported the quit as cancelled and the process stayed alive. A logout is
+// refused the same way.
+//
+// Staying resident when the window is closed is a separate question, and it is
+// already answered by the WindowClosing hook, which hides the window instead of
+// closing it. Recording the intent here is what lets that hook tell a real quit
+// from a window close, so on the way out the window closes rather than being
+// hidden while the process is already terminating.
+func acceptQuit(quitting *atomic.Bool) bool {
+	quitting.Store(true)
+	return true
+}
+
 type quitAwareUpdater struct {
 	binding.UpdateBackend
 	quitting   *atomic.Bool
@@ -337,7 +356,7 @@ func main() {
 			DisableLogging: true,
 		},
 		Mac:        application.MacOptions{ApplicationShouldTerminateAfterLastWindowClosed: false},
-		ShouldQuit: func() bool { return quitting.Load() },
+		ShouldQuit: func() bool { return acceptQuit(&quitting) },
 	})
 	appInstance.OnShutdown(func() { _ = core.CloseConversion() })
 	updateBackend := configureUpdater(appInstance, core)

--- a/cmd/bootagent-desktop/main_wails_test.go
+++ b/cmd/bootagent-desktop/main_wails_test.go
@@ -161,6 +161,32 @@ func (b *restartBackend) Restart(context.Context) error {
 	return b.err
 }
 
+// The Dock's Quit, Cmd+Q, the app menu and a logout all arrive here. Answering
+// false turns into NSTerminateCancel on macOS, which is why the Dock's Quit left
+// the process running: the flag it gated on was only ever set by the tray's own
+// Quit item.
+func TestQuitIsAcceptedWhateverAskedForIt(t *testing.T) {
+	var quitting atomic.Bool
+	if !acceptQuit(&quitting) {
+		t.Fatal("a quit request was refused; the Dock and Cmd+Q cannot quit the app")
+	}
+	// The WindowClosing hook reads this to tell a real quit from a window close,
+	// so without it the window would be hidden mid-shutdown instead of closing.
+	if !quitting.Load() {
+		t.Fatal("quit intent was not recorded")
+	}
+}
+
+// The tray's Quit sets the flag before asking, and a restart sets it too; asking
+// again must not undo either.
+func TestQuitStaysAcceptedWhenAlreadyQuitting(t *testing.T) {
+	var quitting atomic.Bool
+	quitting.Store(true)
+	if !acceptQuit(&quitting) || !quitting.Load() {
+		t.Fatal("an in-flight quit was reversed")
+	}
+}
+
 func TestQuitAwareUpdater(t *testing.T) {
 	for _, test := range []struct {
 		name string


### PR DESCRIPTION
## 现象

在 Dock 里右键 BootAgent → 退出，进程不会结束。

## 根因

```go
ShouldQuit: func() bool { return quitting.Load() },
```

`quitting` 初始为 `false`，而设置它的**唯一**入口是托盘菜单的「退出 BootAgent」（以及 updater 重启）。Wails 只在用户**真的请求退出**时才询问这个钩子，链路是：

`applicationShouldTerminate:` → `shouldQuitApplication()` → `App.shouldQuit()` → `options.ShouldQuit()`

而 Wails 的 macOS delegate 里：

```objc
- (NSApplicationTerminateReply)applicationShouldTerminate:(NSApplication *)sender {
    if( ! shouldQuitApplication() ) {
        return NSTerminateCancel;
    }
```

答 `false` 就是 `NSTerminateCancel`。所以除托盘菜单外，**每一条**退出路径都被拒绝：

- Dock 右键 → 退出（本次报告）
- 应用菜单 → Quit BootAgent
- Cmd+Q
- **注销 / 重启 / 关机** —— `NSTerminateCancel` 同样会拒绝，可以阻塞系统注销

最后只有 SIGTERM 能结束它。

## 为什么会写成这样

设计意图本身是对的：BootAgent 要常驻托盘。这由两处共同实现 ——
`ApplicationShouldTerminateAfterLastWindowClosed: false`，以及 WindowClosing 钩子：

```go
window.RegisterHook(events.Common.WindowClosing, func(event *application.WindowEvent) {
    if quitting.Load() { return }
    event.Cancel()
    window.Hide()
})
```

「关窗口不退出」已经被这个钩子完整处理了。问题在于 `ShouldQuit` 又被拿来做同一件事 —— 但它回答的是**「该不该退出」**，不是**「窗口该不该关」**。两个问题被混为一谈，代价是除了一条路以外全都退不掉。

## 改动

`ShouldQuit` 一律放行，并在请求到达处记录意图。后者不是多余的：WindowClosing 钩子靠它区分「真退出」和「关窗口」，否则退出过程中窗口会被隐藏而不是关闭。

抽成具名函数是为了能测 —— 原来是内联在 `main()` 里的闭包。

## 复现与验证

都在打包后的 `.app`（`task package`，已签名）上做的，不是裸二进制。

**复现（修复前）**：
```
$ osascript -e 'tell application "BootAgent" to quit'
32:36: execution error: “BootAgent”遇到一个错误：用户已取消。 (-128)
after quit event: pid=86375   ← 存活
```
`-128` 是 `userCanceledErr`，正是 `NSTerminateCancel` 的产物。这是 Dock 右键退出发出的同一个 Apple Event。

**修复后**：

| 操作 | 结果 |
|---|---|
| Apple Event quit（= Dock 右键退出） | 干净退出，无错误 |
| 应用菜单 → Quit BootAgent | 进程结束 |
| Cmd+W / 关窗口 | 窗口隐藏，进程存活（托盘行为不变） |
| 隐藏后重新启动 | 窗口恢复，**同一个 pid**，无重复实例 |

Cmd+Q 我没能可靠验证 —— System Events 按键受焦点影响，对照测试显示同一时刻连已知有效的 Cmd+W 也没送达，所以那次测量无效，我不把它当结论。它与已验证的应用菜单 Quit 走完全相同的 `applicationShouldTerminate:` 路径，由同一处修复覆盖。

**门禁**：`go test ./...`、`go test -tags wails ./cmd/...`、`go vet`（含 `-tags wails`）、`staticcheck ./...` 全过。

## 一个附带观察（未修，不在本 PR 范围）

窗口隐藏后，回来的路只有托盘菜单「显示 BootAgent」和重新启动 app（`OnSecondInstanceLaunch` → `activateMainWindow`）。代码里没有 macOS `applicationShouldHandleReopen` 的处理，也就是点 Dock 图标这条路没有接。我没有实际点击 Dock 图标验证过，所以只作为观察提出，不确定是否是有意设计。如果需要，可以另开一个 PR 补 reopen 处理。