### PR TITLE
fix: add introduction docs to every marketplace item

### DIFF
--- a/frontend/src/data/marketplace-adapters.test.ts
+++ b/frontend/src/data/marketplace-adapters.test.ts
@@ -13,6 +13,7 @@ import { normalizeShowcaseSkill, type ShowcaseSkill } from "./useMarketplaceCata
 import { validateMarketplaceCatalog } from "./marketplace-validation";
 import { STATIC_CATALOG } from "./marketplace-catalog";
 import { ecosystemItems } from "./ecosystem-catalog";
+import type { MarketplaceItem } from "../types/marketplace";
 
 // ── live showcase payload normalisation (需求4) ───────────────────────────────
 
@@ -141,6 +142,17 @@ describe("GitHub adapter", () => {
 describe("marketplace catalog metadata", () => {
   it("has complete metadata for every discoverable item", () => {
     expect(validateMarketplaceCatalog(STATIC_CATALOG.items)).toEqual([]);
+  });
+
+  it("rejects a source-only item without an introduction document", () => {
+    const sourceOnly = {
+      id: "source-only", category: "plugin", type: "plugin", name: "Source only",
+      description: "A test entry", icon: "Puzzle", iconColor: "oklch(55% 0.15 160)",
+      tags: ["测试"], scene: "integration", source: "community", sourceUrl: "https://example.com",
+    } satisfies MarketplaceItem;
+    expect(validateMarketplaceCatalog([sourceOnly])).toEqual([
+      expect.objectContaining({ issue: "missing-introduction-document" }),
+    ]);
   });
 
   it("includes first-party registries and package ecosystems as traceable sources", () => {

--- a/frontend/src/data/marketplace-validation.ts
+++ b/frontend/src/data/marketplace-validation.ts
@@ -6,7 +6,8 @@ export type MarketplaceValidationIssue =
   | "missing-scene"
   | "missing-source"
   | "category-type-mismatch"
-  | "missing-detail-link";
+  | "missing-detail-link"
+  | "missing-introduction-document";
 
 /** Validates the metadata required for reliable discovery and filtering. */
 export function validateMarketplaceItem(item: MarketplaceItem): MarketplaceValidationIssue[] {
@@ -24,6 +25,11 @@ export function validateMarketplaceItem(item: MarketplaceItem): MarketplaceValid
 
   const hasDetailLink = Boolean(item.installPrompt || item.readmeUrl || item.documentationUrl || item.externalUrl || item.sourceUrl);
   if (!hasDetailLink) issues.push("missing-detail-link");
+  // SkillHub README is fetched through its slug binding; all other entries
+  // must expose a stable documentation or README URL in the catalog.
+  if (!item.documentationUrl && !item.readmeUrl && item.source !== "skillhub") {
+    issues.push("missing-introduction-document");
+  }
   return issues;
 }
 

--- a/frontend/src/data/mcpservers-adapter.ts
+++ b/frontend/src/data/mcpservers-adapter.ts
@@ -70,6 +70,9 @@ export const mcpserversItems: MarketplaceItem[] = (mcpRaw as MCPServerEntry[]).m
   requiresApiKey: entry.config != null && JSON.stringify(entry.config).toLowerCase().includes("token"),
   sourceLabel: "MCP Servers",
   sourceUrl: entry.pageUrl,
+  // The registry page is the canonical introduction when the server does not
+  // publish a public GitHub README (e.g. Ahrefs, Docker Toolkit, Stack Overflow).
+  documentationUrl: entry.pageUrl,
   installPrompt: buildInstallPrompt(entry),
   targetHint: "粘贴到任意命令行 Agent 对话框执行，它会自动完成 MCP 配置",
   externalUrl: entry.github ?? undefined,


### PR DESCRIPTION
## 变更

- 审计市场目录并识别 3 个缺少介绍文档的 MCP 条目：Ahrefs、Docker Toolkit、Stack Overflow
- 为 MCP 适配器统一补充官方详情页 documentationUrl
- 将目录校验从任意详情链接升级为至少一个 README 或介绍文档
- 增加缺失文档回归测试，防止后续新增 source-only 条目

## 验证

- pnpm run test -- --run（64 files / 484 tests）
- pnpm run build
- task build:desktop
- 本地桌面二进制已启动，PID 53216