### PR TITLE
fix: execute marketplace recommendation agent by resolved path

### DIFF
--- a/frontend/e2e/wails.spec.ts
+++ b/frontend/e2e/wails.spec.ts
@@ -249,7 +249,9 @@ test("Marketplace multi-type filters narrow unique results without shifting cont
   expect(after?.x).toBeCloseTo(before!.x, 0);
   expect(clearBox!.x + clearBox!.width).toBeLessThanOrEqual(after!.x);
 
-  await page.getByLabel(/插件|Plugins/, { exact: true }).check();
+  const pluginFilter = page.getByLabel(/插件|Plugins/, { exact: true });
+  if (!(await pluginFilter.isChecked())) await pluginFilter.check();
+  await expect(pluginFilter).toBeChecked();
   const afterSecondType = await page.locator(".marketplace-card").count();
   expect(afterSecondType).toBeLessThanOrEqual(afterFirstType);
 

--- a/frontend/e2e/wails.spec.ts
+++ b/frontend/e2e/wails.spec.ts
@@ -234,7 +234,12 @@ test("Marketplace multi-type filters narrow unique results without shifting cont
   const initialCount = await page.locator(".marketplace-card").count();
 
   await typeButton.click();
-  await page.getByLabel("Skill", { exact: true }).check();
+  const skillFilter = page.getByLabel("Skill", { exact: true });
+  // The filter state is URL-backed and can be restored by the server between
+  // navigations. `check()` requires a transition and flakes when the restored
+  // value is already true; assert the desired state instead.
+  if (!(await skillFilter.isChecked())) await skillFilter.check();
+  await expect(skillFilter).toBeChecked();
   const afterFirstType = await page.locator(".marketplace-card").count();
   expect(afterFirstType).toBeLessThanOrEqual(initialCount);
 

--- a/frontend/e2e/wails.spec.ts
+++ b/frontend/e2e/wails.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Locator } from "@playwright/test";
 
 // Every test addresses a route directly. "/" is a decision, not a page: on a
 // home without ~/.bootagent it opens onboarding, so landing there would make
@@ -235,11 +235,7 @@ test("Marketplace multi-type filters narrow unique results without shifting cont
 
   await typeButton.click();
   const skillFilter = page.getByLabel("Skill", { exact: true });
-  // The filter state is URL-backed and can be restored by the server between
-  // navigations. `check()` requires a transition and flakes when the restored
-  // value is already true; assert the desired state instead.
-  if (!(await skillFilter.isChecked())) await skillFilter.check();
-  await expect(skillFilter).toBeChecked();
+  await checkMarketplaceFilter(skillFilter);
   const afterFirstType = await page.locator(".marketplace-card").count();
   expect(afterFirstType).toBeLessThanOrEqual(initialCount);
 
@@ -250,8 +246,7 @@ test("Marketplace multi-type filters narrow unique results without shifting cont
   expect(clearBox!.x + clearBox!.width).toBeLessThanOrEqual(after!.x);
 
   const pluginFilter = page.getByLabel(/插件|Plugins/, { exact: true });
-  if (!(await pluginFilter.isChecked())) await pluginFilter.check();
-  await expect(pluginFilter).toBeChecked();
+  await checkMarketplaceFilter(pluginFilter);
   const afterSecondType = await page.locator(".marketplace-card").count();
   expect(afterSecondType).toBeLessThanOrEqual(afterFirstType);
 
@@ -261,3 +256,18 @@ test("Marketplace multi-type filters narrow unique results without shifting cont
   expect(itemIDs.every(Boolean)).toBe(true);
   expect(new Set(itemIDs).size).toBe(itemIDs.length);
 });
+
+async function checkMarketplaceFilter(filter: Locator) {
+  // URL-backed controlled inputs can be replaced while the catalog snapshot is
+  // refreshed. Retry only when the desired state was not committed, and fail
+  // with Playwright's normal assertion if it remains unavailable.
+  for (let attempt = 0; attempt < 3 && !(await filter.isChecked()); attempt += 1) {
+    try {
+      await filter.check({ timeout: 2_000 });
+    } catch (error) {
+      if (attempt === 2) throw error;
+    }
+    if (!(await filter.isChecked())) await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  await expect(filter).toBeChecked();
+}

--- a/internal/app/marketplace_recommend.go
+++ b/internal/app/marketplace_recommend.go
@@ -112,7 +112,8 @@ func (u *UseCases) RecommendMarketplace(ctx context.Context, request Marketplace
 		return MarketplaceRecommendResult{}, err
 	}
 	runtime := u.installRuntime(nil)
-	if _, present := runtime.Runner.LookPath(adapter.Command); !present {
+	executable, present := runtime.Runner.LookPath(adapter.Command)
+	if !present || executable == "" {
 		return MarketplaceRecommendResult{}, oneerrors.New(oneerrors.PrerequisiteMissing, "The selected recommendation Agent is not installed")
 	}
 	prompt, err := marketplaceRecommendationPrompt(request.Need, request.Locale, items)
@@ -120,6 +121,11 @@ func (u *UseCases) RecommendMarketplace(ctx context.Context, request Marketplace
 		return MarketplaceRecommendResult{}, oneerrors.New(oneerrors.InternalError, "Could not prepare marketplace knowledge", oneerrors.WithCause(err))
 	}
 	argv := append([]string(nil), adapter.Argv...)
+	// Resolve once and execute the same path that made the Agent appear in the
+	// picker. Desktop apps can inherit a different PATH between command
+	// discovery and child execution (notably launchd/macOS shell startup), so
+	// passing only the bare command name can produce a misleading "not found".
+	argv[0] = executable
 	if adapter.ID == "codex" {
 		workingDirectory, err := os.MkdirTemp("", "bootagent-marketplace-recommend-")
 		if err != nil {

--- a/internal/app/marketplace_recommend_test.go
+++ b/internal/app/marketplace_recommend_test.go
@@ -101,6 +101,43 @@ func TestRecommendMarketplaceValidatesModelOutputAgainstKnowledgeIDs(t *testing.
 	}
 }
 
+func TestRecommendMarketplaceExecutesResolvedAgentPath(t *testing.T) {
+	runner := &marketplaceRecommendationRunner{
+		available: map[string]bool{"codex": true},
+		result:    process.Result{ExitCode: 0, Stdout: `{"recommendations":[{"item_id":"skill-safe","reason":"matches"}]}`},
+	}
+	core := recommendationCore(t, runner)
+	// The fake normally returns the command name; make the lookup return an
+	// absolute path to model a desktop PATH that is only available at discovery.
+	runnerPath := "/private/runtime/bin/codex"
+	runner.available = map[string]bool{"codex": true}
+	// A path-aware runner is used below so the assertion covers argv[0].
+	pathRunner := &marketplaceRecommendationRunnerWithPath{marketplaceRecommendationRunner: *runner, path: runnerPath}
+	core = recommendationCoreWithRunner(t, pathRunner)
+	if _, err := core.RecommendMarketplace(context.Background(), MarketplaceRecommendRequest{
+		AgentID: "codex", Need: "find a tool", Items: []MarketplaceKnowledgeItem{{ID: "skill-safe", Name: "Safe", Description: "Useful", Category: "skill"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if pathRunner.argv[0] != runnerPath {
+		t.Fatalf("argv[0] = %q, want resolved executable %q", pathRunner.argv[0], runnerPath)
+	}
+}
+
+type marketplaceRecommendationRunnerWithPath struct {
+	marketplaceRecommendationRunner
+	path string
+}
+
+func (r *marketplaceRecommendationRunnerWithPath) LookPath(command string) (string, bool) {
+	return r.path, r.available[command]
+}
+
+func recommendationCoreWithRunner(t *testing.T, runner process.Runner) *UseCases {
+	t.Helper()
+	return NewUseCases(StatusOptions{Home: t.TempDir(), Platform: platform.For("linux", "amd64"), Runner: runner, Environment: map[string]string{"PATH": "/usr/bin"}})
+}
+
 func argumentValue(argv []string, name string) string {
 	for index := 0; index+1 < len(argv); index++ {
 		if argv[index] == name {

--- a/internal/app/marketplace_recommend_test.go
+++ b/internal/app/marketplace_recommend_test.go
@@ -106,14 +106,13 @@ func TestRecommendMarketplaceExecutesResolvedAgentPath(t *testing.T) {
 		available: map[string]bool{"codex": true},
 		result:    process.Result{ExitCode: 0, Stdout: `{"recommendations":[{"item_id":"skill-safe","reason":"matches"}]}`},
 	}
-	core := recommendationCore(t, runner)
 	// The fake normally returns the command name; make the lookup return an
 	// absolute path to model a desktop PATH that is only available at discovery.
 	runnerPath := "/private/runtime/bin/codex"
 	runner.available = map[string]bool{"codex": true}
 	// A path-aware runner is used below so the assertion covers argv[0].
 	pathRunner := &marketplaceRecommendationRunnerWithPath{marketplaceRecommendationRunner: *runner, path: runnerPath}
-	core = recommendationCoreWithRunner(t, pathRunner)
+	core := recommendationCoreWithRunner(t, pathRunner)
 	if _, err := core.RecommendMarketplace(context.Background(), MarketplaceRecommendRequest{
 		AgentID: "codex", Need: "find a tool", Items: []MarketplaceKnowledgeItem{{ID: "skill-safe", Name: "Safe", Description: "Useful", Category: "skill"}},
 	}); err != nil {


### PR DESCRIPTION
Fixes marketplace recommendations failing when desktop PATH differs between Agent discovery and subprocess execution. The recommendation command now uses the resolved executable path and includes a regression test.