### PR TITLE
docs: improve README onboarding and discoverability

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,74 +3,157 @@
   <h1>BootAgent</h1>
   <p><strong>Many Agents. One place to manage them.</strong></p>
   <p>
-    <a href="https://github.com/MaimoryLab/BootAgent/releases/latest"><img src="https://img.shields.io/github/v/release/MaimoryLab/BootAgent?display_name=tag&sort=semver" alt="Latest release"></a>
+    <a href="https://github.com/MaimoryLab/BootAgent/releases/latest"><img src="https://img.shields.io/github/v/release/MaimoryLab/BootAgent?display_name=tag&amp;sort=semver" alt="Latest release"></a>
     <a href="https://github.com/MaimoryLab/BootAgent/actions/workflows/ci.yml"><img src="https://github.com/MaimoryLab/BootAgent/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
     <a href="https://github.com/MaimoryLab/BootAgent/stargazers"><img src="https://img.shields.io/github/stars/MaimoryLab/BootAgent?style=flat" alt="GitHub stars"></a>
     <a href="LICENSE"><img src="https://img.shields.io/github/license/MaimoryLab/BootAgent" alt="License"></a>
   </p>
-  <a href="https://www.producthunt.com/products/bootagent?embed=true&amp;utm_source=badge-featured&amp;utm_medium=badge&amp;utm_campaign=badge-bootagent" target="_blank" rel="noopener noreferrer"><img alt="BootAgent - Bootstrap and manage all your favorite agents in one place | Product Hunt" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1225464&amp;theme=light&amp;t=1787018185057"></a>
-  <p><a href="README_ZH.md">简体中文</a></p>
+  <p>
+    <a href="https://github.com/MaimoryLab/BootAgent/releases/latest">Download the latest release</a>
+    · <a href="docs/ai-agent-kit/en/00-start-here.md">Start in five minutes</a>
+    · <a href="README_ZH.md">简体中文</a>
+  </p>
 </div>
 
-BootAgent is a local desktop workspace for AI coding Agents. It turns a fresh machine into a usable, repeatable setup without asking you to edit several tool-specific config files by hand.
+<p align="center">
+  <a href="https://www.producthunt.com/products/bootagent?embed=true&amp;utm_source=badge-featured&amp;utm_medium=badge&amp;utm_campaign=badge-bootagent" target="_blank" rel="noopener noreferrer"><img alt="BootAgent on Product Hunt" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1225464&amp;theme=light&amp;t=1787018185057"></a>
+</p>
 
-## What it does
+BootAgent is a local desktop workspace for AI coding Agents. It helps you detect what is
+already on your machine, connect a Provider, configure an Agent, and get to a first
+successful request without editing several tool-specific files by hand.
 
-- Detects, installs, updates, and launches supported CLI and desktop Agents. The terminal used to launch CLI Agents can be chosen in Settings; the platform's built-in terminal remains the default.
-- Keeps configuration and launch actions directly available in Environment overview while each installed Agent card groups its supported low-frequency actions under a More menu. npm-managed CLI Agents can be updated or uninstalled there; uninstall removes only the program and preserves Profiles, Providers, configuration files, and conversations.
-- Migrates existing Codex and ChatGPT Desktop conversations into BootAgent's `bootagent` provider bucket from their Agent rows. This operation intentionally creates no history backup.
-- Connects Agents to built-in or custom Providers, with model selection and protocol-aware connection checks.
-- Saves reusable Profiles. An Agent's own configuration screen is where you pick the Profile it uses, and where its model can be changed directly.
-- Carries a Profile's reasoning effort (`off`, `low`, `medium`, `high`, `max`) into every Agent whose own config format documents a place for it, translating the scale to what each one accepts. Agents with no documented depth setting are left alone rather than given invented keys.
-- Bootstraps required runtimes such as Node.js, uv, and Aider's managed Python when needed.
-- Keeps long-running installs visible and cancellable in the Task Center.
-- Provides local API format conversion and an optional launch-at-login setting; both are off by default, and enabling conversion offers to enable launch at login.
-- Imports and exports Providers, Profiles, and selected MCP servers. API keys and MCP secrets are excluded by default; password-encrypted or explicitly confirmed plaintext export is also available.
-- Discovers MCP servers from initialized Claude Code, Codex, OpenCode, Kilo CLI, and Hermes installations, and applies selected servers across them from the MCP Registry. Scanning runs in the background; edits are explicit and local.
-- Discovers Skills, MCP servers, plugins, standalone AI products, prompt collections, and workflow templates in the Marketplace. Each source has a bundled fallback, while sources with a supported public feed can refresh independently.
-- Marketplace entries can belong to multiple tool types. Multiple type selections require every selected type, then combine with source, use-case, and API-key filters.
-- Can ask an installed Codex or Claude Code CLI to shortlist Marketplace tools from a stated need. Only the need and public catalog metadata enter the prompt; the recommendation run receives no install or file-write tools, and returned IDs are checked against the catalog before display.
-- Saves successful Marketplace recommendations locally with the request, Agent, catalog version, and result snapshots. History can be reopened, deleted, or cleared; it is never uploaded as telemetry.
-- Creates backups, writes atomically, and keeps credentials in private local storage. The latest three historical versions are kept per Profile, Provider, MCP, Agent configuration target, and Skill; backups live under `~/.bootagent/backup` and the per-target count can be changed in Settings.
-- Checks for BootAgent updates and installs release artifacts through the built-in updater. When the domestic mirror setting is enabled, update checks and downloads use the Gitee mirror; otherwise they use GitHub.
+## Start here
+
+| You want to... | Start with... |
+| --- | --- |
+| Try an Agent for the first time | [Download a release](https://github.com/MaimoryLab/BootAgent/releases/latest), then follow the [AI Agent Kit](docs/ai-agent-kit/en/00-start-here.md) |
+| Keep existing Agents in one place | Open **Environment overview** and let BootAgent scan the machine |
+| Find a Skill, MCP server, plugin, or AI product | Open **Marketplace**, search or filter, then open an item for its details and upstream links |
+| Move a setup to another machine | Open **Settings > Import and export** and choose a v1 JSON file or a v2 bundle |
+| Fix an install or update | Open **Task Center** for the source, progress, and diagnostic output |
+
+The shortest first-run path is:
+
+```text
+Launch BootAgent
+→ Choose or add a Provider
+→ Create an API Key in that Provider's official account page
+→ Choose an Agent and a Profile
+→ Run setup
+→ Send a first request
+```
+
+## What you can do
+
+### Manage Agents
+
+- Detect, install, update, launch, and uninstall supported CLI and desktop Agents.
+- Detect Agents installed outside BootAgent when their command or known installation path is available.
+- See long-running install and update tasks in Task Center, including progress, source, and cancellable steps.
+- Uninstall selected installation instances while keeping Profiles, Providers, configuration files, and conversations.
+
+### Connect Providers and Profiles
+
+- Use built-in Providers or add an OpenAI-compatible or Anthropic-compatible endpoint.
+- Check an endpoint using the protocol that the selected Agent actually uses.
+- Save reusable Profiles and select the Profile and model from an Agent's configuration screen.
+- Keep API Keys in private local storage; they are not placed in ordinary summaries or recommendation prompts.
+
+### Manage Skills and MCP servers
+
+- Keep a local Skill library, scan Skills already present on supported Agents, and choose which Agents receive each Skill.
+- Discover MCP servers from initialized Claude Code, Codex, OpenCode, Kilo CLI, and Hermes installations.
+- Store MCP servers in a local user-level Registry, select sync targets explicitly, and apply changes only when you are ready.
+
+### Local utilities
+
+- Bootstrap Node.js, uv, and Aider's managed Python runtime when an Agent needs them.
+- Optionally run local API format conversion and launch BootAgent at login; both features are off by default.
+- Migrate existing Codex and ChatGPT Desktop conversations into BootAgent's local provider bucket. This migration intentionally creates no history backup.
+
+### Discover tools in Marketplace
+
+- Browse Skills, MCP servers, plugins, standalone AI products, prompt collections, and workflow templates.
+- Combine category, source, use-case, API-key, and multi-type filters. An item can belong to more than one type.
+- Refresh supported public sources independently. A source failure keeps the bundled catalog available instead of blanking the market.
+- Open a detail page for the description, install guidance, README when the source provides one, and upstream links.
+- Ask an installed Codex or Claude Code CLI to shortlist tools for a stated need. Returned IDs are checked against the current catalog before display.
+- Save recommendation requests and result snapshots locally so a previous search can be reopened later. Recommendation history is never uploaded as telemetry.
+
+### Keep setups portable
+
+- Import and export Providers, Profiles, selected MCP servers, and Skills.
+- Legacy v1 JSON files remain importable. The v2 portable bundle separates configuration JSON from a Skills ZIP.
+- Skills first enter BootAgent's managed library; you choose target Agents from the Skills page afterward.
+- Preview new, overwritten, and conflicting resources before applying an import. Writes use snapshots and rollback on failure.
+- API Keys and MCP secrets are omitted by default. Password-encrypted export or explicitly confirmed plaintext export is available.
 
 ## Supported Agents
 
-| CLI Agents | Desktop Agents |
+BootAgent supports detection, configuration, launch, or installation guidance according to each Agent's upstream contract. An entry below does not mean that BootAgent redistributes the Agent package; the detail page shows the available install source.
+
+| CLI and local Agents | Desktop Agents |
 | --- | --- |
-| Codex · Claude Code | DSH Desktop · Claude Desktop（macOS/Windows） |
-| Kilo CLI · Aider · OpenCode | ChatGPT Desktop（macOS/Windows） |
-| Hermes Agent · OpenClaw | WorkBuddy · WorkBuddy AI（macOS/Windows） |
-| Kimi Code · DeepSeek Harness | ZCode（macOS/Windows） |
+| Codex · Claude Code · OpenCode | DSH Desktop · Claude Desktop |
+| Kilo CLI · Aider · OpenClaw | ChatGPT Desktop · WorkBuddy |
+| Hermes Agent · Kimi Code · Pi | WorkBuddy AI · ZCode |
+| DeepSeek Harness (local web app) | |
 
-DSH Desktop heads the desktop list. It is published by anywhere-labs rather than by DeepSeek, so the download row labels it a third-party application; the DeepSeek mark beside it identifies the model it drives, not its publisher.
+Claude Desktop can be detected and launched on macOS and Windows, but it must be installed by the user from the [official download page](https://claude.com/download). BootAgent writes compatible configuration and does not download or proxy Claude Desktop.
 
-Claude Desktop is detected and launched on macOS and Windows, but its installation remains manual. After writing the configuration, BootAgent directs the user to the [official download page](https://claude.com/download). BootAgent writes and selects a BootAgent-owned 3P profile for direct Anthropic-compatible endpoints; it does not download Claude Desktop, proxy requests, or provide a restore-to-1P action. The selected model ID must contain `claude` (case-insensitive).
+DeepSeek Harness can use its shipped DeepSeek route or a configured compatible Provider. It opens a local web app after installation; its own onboarding commands remain the source of truth.
 
-JieKou.AI, PPIO, Novita, DeepSeek and Moonshot are built in, listed in that order. Any OpenAI-compatible or Anthropic-compatible Provider can be added from the Provider page. BootAgent probes the protocol an Agent actually uses; an endpoint that only exposes a different API is rejected before configuration is written.
-
-DeepSeek Harness can also be activated against DeepSeek's own official route, which its shipped configuration already defines, instead of going through a generic OpenAI-compatible endpoint.
-
-The MCP Registry is user-level only and stored locally. It supports stdio, HTTP, and SSE servers for Claude Code, Codex, OpenCode, Kilo CLI, and Hermes. Select sync targets explicitly and apply changes when ready; clearing all targets removes the server from Agent configs but keeps it in the Registry. Deleting a server removes it from Agent configs first and from the Registry only after the application succeeds. MCP exports are selected per server and carry no Agent bindings, so they can be imported on another machine before choosing local targets.
+JieKou.AI, PPIO, Novita, DeepSeek, and Moonshot are built-in Providers. Custom OpenAI-compatible and Anthropic-compatible Providers can be added from the Provider page.
 
 ## Download
 
-Download the latest macOS, Windows, or Linux package from [GitHub Releases](https://github.com/MaimoryLab/BootAgent/releases/latest). Linux releases provide `deb`, `rpm`, AppImage, and OTA `zip` packages for amd64 and arm64. Release artifacts include SHA-256 checksums. macOS artifacts are signed with Developer ID and notarized; the release channel remains `technical-preview-unsigned` while Wails is in Alpha.
+Download the latest package from [GitHub Releases](https://github.com/MaimoryLab/BootAgent/releases/latest).
 
-BootAgent does not redistribute Agent packages and does not bundle Node.js, Git, WebView, or API keys. Missing prerequisites are reported with a link to the official installation instructions.
+| Platform | Recommended package | Architectures |
+| --- | --- | --- |
+| macOS | DMG | Intel and Apple Silicon |
+| Windows | NSIS installer | x64 and ARM64 |
+| Linux | AppImage, deb, or rpm | amd64 and arm64 |
+
+Linux also provides an OTA ZIP archive. Release artifacts include `SHA256SUMS`. macOS packages are Developer ID signed and notarized. The release channel is still a Wails Alpha technical preview: Windows and Linux packages are currently unsigned and may require an operating-system approval on first launch.
+
+BootAgent does not redistribute Agent packages and does not bundle Node.js, Git, WebView, or API Keys. Missing prerequisites are reported with a link to the relevant official installation instructions.
+
+## Data, privacy, and recovery
+
+- BootAgent is local-first. Provider credentials, configuration, recommendation history, and backups stay on the machine by default.
+- Recommendation prompts contain the stated need and public catalog metadata only; the recommendation process receives no install or file-write tools.
+- The latest three historical versions are kept for each Profile, Provider, MCP, Agent configuration target, and Skill by default. Backups live under `~/.bootagent/backup`; retention can be changed in Settings.
+- Uninstall removes the selected program instance, not the user's Profiles, Providers, configuration files, or conversations.
+- BootAgent is not a VPN, proxy, shared-key service, or Agent package distributor. Downloads use official sources, authorized mirrors, or documented manual installation paths.
+
+## Troubleshooting
+
+| Symptom | First check |
+| --- | --- |
+| Agent is not listed | Refresh Environment overview, check that the command is on `PATH`, or use the Agent's documented manual install path. |
+| Provider connection check fails | Confirm the endpoint and model match the Agent's protocol; an endpoint that exposes only another API is rejected before writing configuration. |
+| Marketplace looks incomplete | Check the source status and refresh. A bundled snapshot remains available when an online source is unavailable. |
+| Import reports a conflict | Review the preview, choose skip or overwrite, and apply only after checking the affected resource names. |
+| BootAgent cannot check for an update | In Settings, switch between GitHub and the domestic Gitee mirror, then retry. Existing installation files are not replaced by a failed check. |
+| The Agent will not download | Follow the official install page or install manually, then return to BootAgent to detect the local installation. BootAgent does not bypass network restrictions. |
 
 ## Build from source
 
-Requirements: Go, Node.js, pnpm 11.21.0, and the target platform's WebView dependencies. Linux builds use GTK4 and WebKitGTK 6.0; GTK3 is not supported.
+For users, the release packages above are the supported installation path. For development, you need Go (the version declared in `go.mod`), Node.js, pnpm `11.21.0`, and the target platform's WebView dependencies. Linux builds use GTK4 and WebKitGTK 6.0.
 
 ```text
 git clone https://github.com/MaimoryLab/BootAgent.git
 cd BootAgent
-cd frontend && pnpm install --frozen-lockfile && pnpm run build && cd ..
+cd frontend
+pnpm install --frozen-lockfile
+pnpm run build
+cd ..
 go run -tags wails ./cmd/bootagent-desktop
 ```
 
-For the usual development loop, install [Task](https://taskfile.dev/) and run `task dev`. Useful checks:
+For a production binary on the current host, use `task build:desktop`. Useful checks are:
 
 ```text
 go test ./...
@@ -81,19 +164,17 @@ cd frontend && pnpm run test && pnpm run build
 
 ## Project links
 
-- [AI Agent Kit](docs/ai-agent-kit/README.md): set up an Agent environment step by step
+- [AI Agent Kit](docs/ai-agent-kit/README.md): guided setup for a first request
 - [Documentation](docs/): specifications and architecture decisions
+- [Security policy](SECURITY.md)
+- [Contributing](CONTRIBUTING.md)
 - [Public site repository](https://github.com/MaimoryLab/BootAgent-site)
 - [Issues and feature requests](https://github.com/MaimoryLab/BootAgent/issues)
 
 ## Star History
 
 <a href="https://www.star-history.com/?repos=MaimoryLab%2FBootAgent&type=date&legend=top-left">
- <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=MaimoryLab/BootAgent&type=date&theme=dark&legend=top-left&sealed_token=wiOLSOTugmyFse5tBQ7xZAHS9_V3irdr9ft2xDkbPA2rgy4SNDmm09LA6m0Umxjop30R4kn8yj675c_d5Q5NHGecjs3fB2FwpnKxVTDGomAZsz2OxbfN5ND7comOV52I39nuTN1T-zShOiDil29DAq92aduIm30ekevoULQV9mSaMacoTpsSo0O0tPPS" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=MaimoryLab/BootAgent&type=date&legend=top-left&sealed_token=wiOLSOTugmyFse5tBQ7xZAHS9_V3irdr9ft2xDkbPA2rgy4SNDmm09LA6m0Umxjop30R4kn8yj675c_d5Q5NHGecjs3fB2FwpnKxVTDGomAZsz2OxbfN5ND7comOV52I39nuTN1T-zShOiDil29DAq92aduIm30ekevoULQV9mSaMacoTpsSo0O0tPPS" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=MaimoryLab/BootAgent&type=date&legend=top-left&sealed_token=wiOLSOTugmyFse5tBQ7xZAHS9_V3irdr9ft2xDkbPA2rgy4SNDmm09LA6m0Umxjop30R4kn8yj675c_d5Q5NHGecjs3fB2FwpnKxVTDGomAZsz2OxbfN5ND7comOV52I39nuTN1T-zShOiDil29DAq92aduIm30ekevoULQV9mSaMacoTpsSo0O0tPPS" />
- </picture>
+  <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=MaimoryLab/BootAgent&type=Date">
 </a>
 
 ## Sponsors

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -3,74 +3,155 @@
   <h1>BootAgent</h1>
   <p><strong>Agent 很多，管理只需一个。</strong></p>
   <p>
-    <a href="https://github.com/MaimoryLab/BootAgent/releases/latest"><img src="https://img.shields.io/github/v/release/MaimoryLab/BootAgent?display_name=tag&sort=semver" alt="最新版本"></a>
+    <a href="https://github.com/MaimoryLab/BootAgent/releases/latest"><img src="https://img.shields.io/github/v/release/MaimoryLab/BootAgent?display_name=tag&amp;sort=semver" alt="最新版本"></a>
     <a href="https://github.com/MaimoryLab/BootAgent/actions/workflows/ci.yml"><img src="https://github.com/MaimoryLab/BootAgent/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
     <a href="https://github.com/MaimoryLab/BootAgent/stargazers"><img src="https://img.shields.io/github/stars/MaimoryLab/BootAgent?style=flat" alt="GitHub Stars"></a>
     <a href="LICENSE"><img src="https://img.shields.io/github/license/MaimoryLab/BootAgent" alt="许可证"></a>
   </p>
-  <a href="https://www.producthunt.com/products/bootagent?embed=true&amp;utm_source=badge-featured&amp;utm_medium=badge&amp;utm_campaign=badge-bootagent" target="_blank" rel="noopener noreferrer"><img alt="BootAgent - Bootstrap and manage all your favorite agents in one place | Product Hunt" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1225464&amp;theme=light&amp;t=1787018185057"></a>
-  <p><a href="README.md">English</a></p>
+  <p>
+    <a href="https://github.com/MaimoryLab/BootAgent/releases/latest">下载最新版本</a>
+    · <a href="docs/ai-agent-kit/zh/00-start-here.md">五分钟开始使用</a>
+    · <a href="README.md">English</a>
+  </p>
 </div>
 
-BootAgent 是一个本地桌面工作台，用来统一管理 AI 编程 Agent。它把检测、安装、模型服务配置和日常维护放进一条清晰的流程，不必再手动修改多个工具各自的配置文件。
+<p align="center">
+  <a href="https://www.producthunt.com/products/bootagent?embed=true&amp;utm_source=badge-featured&amp;utm_medium=badge&amp;utm_campaign=badge-bootagent" target="_blank" rel="noopener noreferrer"><img alt="BootAgent on Product Hunt" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1225464&amp;theme=light&amp;t=1787018185057"></a>
+</p>
 
-## 核心能力
+BootAgent 是一个本地桌面工作台，用来统一管理 AI 编程 Agent。它可以检测电脑上已有的工具，连接模型服务，配置 Agent，并帮助你完成第一次成功的请求，不必手动修改多个工具各自的配置文件。
 
-- 检测、安装、更新并启动支持的 CLI 和桌面 Agent。启动 CLI Agent 使用的终端可在“设置”中选择，默认沿用系统自带终端。
-- 环境总览仍直接提供配置和启动操作；每个已安装 Agent 卡片会把自身支持的低频操作收进“更多”菜单。npm 管理的 CLI Agent 可在其中更新或卸载；卸载只移除程序，Profile、Provider、配置文件和对话都会保留。
-- 可从 Codex 与 ChatGPT Desktop 的 Agent 行把现有对话迁入 BootAgent 的 `bootagent` Provider 分桶；此操作按设计不创建历史备份。
-- 连接内置或自定义模型服务（Provider），选择模型，并按 Agent 实际协议检查连接。
-- 保存可复用的配置模版（Profile）。在某个 Agent 的配置页选择要用的模版，模型也可以在同一页直接改。
-- 把 Profile 上的思考深度（`off`、`low`、`medium`、`high`、`max`）写入每个自身配置格式有对应位置的 Agent，并按各自接受的取值做换算。没有文档化深度设置的 Agent 保持原样，不会被塞进自造的字段。
-- 按需准备 Node.js、uv，以及 Aider 所需的托管 Python 运行时。
-- 长时间安装任务在任务中心持续可见，并且可以取消。
-- 提供本地 API 格式转换和可选的开机自启动；两者默认关闭，启用格式转换时会询问是否同时开机自启动。
-- 导入和导出 Provider、Profile 以及选中的 MCP 服务器；默认不导出 API Key 和 MCP 秘密，也支持密码加密或明确确认后的明文导出。
-- 从已初始化的 Claude Code、Codex、OpenCode、Kilo CLI 和 Hermes 中发现 MCP 服务器，并在 MCP Registry 页面选择同步目标。扫描在后台进行，编辑必须显式应用并只写入本机。
-- 在工具市场发现 Skills、MCP 服务器、插件、独立 AI 产品、提示词集合和工作流模板。每个来源都有内置快照，可用的公开数据源可以单独在线刷新，某一个来源失败不会清空整个目录。
-- 市场条目可以同时属于多个工具类型；类型多选只保留同时满足全部所选类型的条目，再与来源、使用场景和 API Key 条件组合筛选。
-- 可以让已安装的 Codex 或 Claude Code CLI 根据用户需求筛选市场工具。上下文只包含用户输入和公开目录元数据，推荐进程没有安装或写文件工具；展示前还会把返回 ID 与当前目录逐项核对。
-- 成功的工具推荐会保存在本机，记录需求、使用的 Agent、目录版本和结果快照；可重新查看、删除或清空，绝不会作为遥测上传。
-- 创建备份、原子写入，并将凭据保存在本机私有存储中。Profile、Provider、MCP、Agent 配置目标和 Skill 分别保留最近 3 个历史版本；备份统一放在 `~/.bootagent/backup`，可在“设置”中修改每个目标的保留数量。
-- 检查 BootAgent 更新，并通过内置更新器安装发行包。开启国内镜像设置时，更新检查和下载使用 Gitee 镜像；否则使用 GitHub。
+## 从这里开始
+
+| 你想做什么 | 从哪里开始 |
+| --- | --- |
+| 第一次尝试 Agent | [下载发行版](https://github.com/MaimoryLab/BootAgent/releases/latest)，再阅读 [AI Agent Kit](docs/ai-agent-kit/zh/00-start-here.md) |
+| 把已有 Agent 集中管理 | 打开“环境总览”，让 BootAgent 扫描本机 |
+| 查找 Skill、MCP、插件或独立 AI 产品 | 打开“工具市场”，搜索或筛选后进入详情页查看安装说明和上游链接 |
+| 把环境迁移到另一台电脑 | 打开“设置 > 导入导出”，选择 v1 JSON 或 v2 压缩包 |
+| 排查安装或更新问题 | 打开“任务中心”，查看来源、进度和诊断日志 |
+
+第一次使用可以按这条最短路径操作：
+
+```text
+启动 BootAgent
+→ 选择或添加 Provider
+→ 在 Provider 官方账号页面创建 API Key
+→ 选择 Agent 和 Profile
+→ 开始配置
+→ 发起第一次请求
+```
+
+## 你可以用 BootAgent 做什么
+
+### 管理 Agent
+
+- 检测、安装、更新、启动和卸载支持的 CLI 与桌面 Agent。
+- 只要命令或已知安装路径可发现，也可以识别不是由 BootAgent 安装的 Agent。
+- 在任务中心查看长时间安装和更新任务的进度、来源及可取消步骤。
+- 选择具体安装实例卸载，同时保留 Profile、Provider、配置文件和对话。
+
+### 连接 Provider 与 Profile
+
+- 使用内置 Provider，或添加 OpenAI 兼容、Anthropic 兼容的服务端点。
+- 按所选 Agent 实际使用的协议检查连接，避免把错误协议写进配置。
+- 保存可复用的 Profile，并在 Agent 配置页选择 Profile 和模型。
+- API Key 保存在本机私有存储中，不会出现在普通摘要或推荐提示词里。
+
+### 管理 Skills 和 MCP 服务器
+
+- 在本机维护 Skill 管理库，扫描支持的 Agent 已有的 Skill，并选择每个 Skill 要同步到哪些 Agent。
+- 从已初始化的 Claude Code、Codex、OpenCode、Kilo CLI 和 Hermes 中发现 MCP 服务器。
+- 使用本机用户级 Registry 保存 MCP 服务器，明确选择同步目标，并在确认后再应用改动。
+
+### 本地工具
+
+- 当 Agent 需要时，按需准备 Node.js、uv 和 Aider 所需的托管 Python 运行时。
+- 可选启用本地 API 格式转换和开机启动；两项功能默认关闭。
+- 将已有 Codex 和 ChatGPT Desktop 对话迁移到 BootAgent 的本地 Provider 分桶；此迁移按设计不创建历史备份。
+
+### 在工具市场发现工具
+
+- 浏览 Skill、MCP 服务器、插件、独立 AI 产品、提示词集合和工作流模板。
+- 组合工具类型、来源、使用场景、API Key 和多类型条件进行筛选；一个条目可以同时属于多个类型。
+- 支持的公开来源可以分别刷新；某个在线来源失败时，内置目录仍然保留，不会让整个市场变空。
+- 详情页展示介绍、安装指南、来源提供的 README 和上游链接。
+- 可以让本机的 Codex 或 Claude Code CLI 根据需求筛选工具；展示前会逐项核对返回的工具 ID。
+- 推荐请求和结果快照保存在本机，之后可以重新打开历史记录；推荐历史不会作为遥测上传。
+
+### 安全迁移和统一管理
+
+- 导入导出 Provider、Profile、选中的 MCP 服务器和 Skill。
+- 继续兼容旧版 v1 JSON；v2 便携压缩包把配置 JSON 与 Skills ZIP 分开保存。
+- Skill 会先导入 BootAgent 的管理库，之后在 Skills 页面选择要同步的 Agent，不会直接覆盖 Agent 目录。
+- 导入前可以预览新增、覆盖和冲突资源；写入使用快照，失败时自动回滚。
+- 默认不导出 API Key 和 MCP 秘密，也支持密码加密导出或明确确认后的明文导出。
 
 ## 支持的 Agent
 
-| CLI Agent | 桌面 Agent |
+BootAgent 会根据每个 Agent 的官方约定提供检测、配置、启动、安装或安装指引。出现在列表中不代表 BootAgent 会重新分发该工具包，详情页会显示实际可用的安装来源。
+
+| CLI 和本地 Agent | 桌面 Agent |
 | --- | --- |
-| Codex · Claude Code | DSH Desktop · Claude Desktop（macOS/Windows） |
-| Kilo CLI · Aider · OpenCode | ChatGPT Desktop（macOS/Windows） |
-| Hermes Agent · OpenClaw | WorkBuddy · WorkBuddy AI（macOS/Windows） |
-| Kimi Code · DeepSeek Harness | ZCode（macOS/Windows） |
+| Codex · Claude Code · OpenCode | DSH Desktop · Claude Desktop |
+| Kilo CLI · Aider · OpenClaw | ChatGPT Desktop · WorkBuddy |
+| Hermes Agent · Kimi Code · Pi | WorkBuddy AI · ZCode |
+| DeepSeek Harness（本地 Web 应用） | |
 
-DSH Desktop 排在桌面 Agent 列表首位。它由 anywhere-labs 发布，而不是 DeepSeek，所以下载行会标注它是第三方应用；旁边的 DeepSeek 标识表示它驱动的模型，不代表发布方。
+Claude Desktop 可以在 macOS 和 Windows 上被检测和启动，但需要用户从[官方下载页面](https://claude.com/download)自行安装。BootAgent 只写入兼容配置，不下载也不代理 Claude Desktop。
 
-BootAgent 可在 macOS 和 Windows 上检测并启动 Claude Desktop，但仍需用户自行安装。配置写入后，BootAgent 会引导用户前往[官方下载页面](https://claude.com/download)。BootAgent 会为 Anthropic 兼容直连端点写入并选择一个自有的 3P Profile；它不会下载 Claude Desktop、代理请求，也不提供恢复到 1P 的操作。所选模型 ID 必须包含 `claude`（不区分大小写）。
+DeepSeek Harness 可以使用自带的 DeepSeek 官方线路，也可以使用已配置的兼容 Provider。安装后它会打开本地 Web 应用，具体引导命令以其官方文档为准。
 
-内置 JieKou.AI、PPIO、Novita、DeepSeek 和 Moonshot，顺序如此；也可以在模型服务页面添加任意 OpenAI 兼容或 Anthropic 兼容服务。BootAgent 会按 Agent 真正使用的协议探测；如果端点只支持另一种 API，会在写入配置前拒绝它。
-
-DeepSeek Harness 除了走通用的 OpenAI 兼容端点，也可以直接激活到 DeepSeek 自己的官方线路——该线路由它出厂配置本身定义。
-
-MCP Registry 只管理用户级配置并保存在本机，支持 Claude Code、Codex、OpenCode、Kilo CLI 和 Hermes 的 stdio、HTTP、SSE 服务器。用户可以单独选择同步目标并显式应用；清空所有同步目标只会从 Agent 配置中移除服务器，仍保留在 Registry 中。点击删除后，会先从 Agent 配置中移除，应用成功后才从 Registry 中删除。MCP 导出按服务器选择且不携带 Agent 绑定，导入其他机器后可重新选择本机同步目标。
+内置 Provider 包括 JieKou.AI、PPIO、Novita、DeepSeek 和 Moonshot；也可以在 Provider 页面添加自定义的 OpenAI 兼容或 Anthropic 兼容服务。
 
 ## 下载
 
-从 [GitHub Releases](https://github.com/MaimoryLab/BootAgent/releases/latest) 下载最新的 macOS、Windows 或 Linux 包。Linux 发行包为 amd64 和 arm64 提供 `deb`、`rpm`、AppImage 以及 OTA `zip`。发行包附带 SHA-256 校验文件。macOS 发行包使用 Developer ID 签名并经过公证；由于 Wails 仍处于 Alpha，当前发布渠道仍为 `technical-preview-unsigned`。
+从 [GitHub Releases](https://github.com/MaimoryLab/BootAgent/releases/latest) 下载最新版本。
 
-BootAgent 不重新分发 Agent 包，也不捆绑 Node.js、Git、WebView 或 API Key。缺少前置条件时，应用会给出明确错误和官方安装指引。
+| 平台 | 推荐包 | 架构 |
+| --- | --- | --- |
+| macOS | DMG | Intel 和 Apple Silicon |
+| Windows | NSIS 安装包 | x64 和 ARM64 |
+| Linux | AppImage、deb 或 rpm | amd64 和 arm64 |
+
+Linux 还提供 OTA ZIP。发行附件包含 `SHA256SUMS` 校验文件。macOS 包使用 Developer ID 签名并经过公证。当前发布渠道仍处于 Wails Alpha 技术预览阶段：Windows 和 Linux 包暂未签名，首次启动时可能需要在系统中手动允许。
+
+BootAgent 不重新分发 Agent 包，也不捆绑 Node.js、Git、WebView 或 API Key。缺少前置条件时，应用会给出对应的官方安装指引。
+
+## 数据、隐私与恢复
+
+- BootAgent 以本地存储为主。Provider 凭据、配置、推荐历史和备份默认只保存在本机。
+- 推荐提示词只包含用户提出的需求和公开目录元数据；推荐进程没有安装或写文件工具。
+- 每个 Profile、Provider、MCP、Agent 配置目标和 Skill 默认保留最近 3 个历史版本。备份位于 `~/.bootagent/backup`，可在“设置”中修改保留数量。
+- 卸载只移除选中的程序实例，不会删除用户的 Profile、Provider、配置文件或对话。
+- BootAgent 不是 VPN、代理、共享 Key 服务或 Agent 软件包分发平台。下载使用官方来源、授权镜像或文档化的手动安装路径。
+
+## 常见问题
+
+| 现象 | 先检查什么 |
+| --- | --- |
+| 找不到 Agent | 刷新“环境总览”，确认命令在 `PATH` 中，或按 Agent 官方指引手动安装后再次检测。 |
+| Provider 连接检查失败 | 确认端点和模型与 Agent 使用的协议一致；只支持另一种 API 的端点会在写入前被拒绝。 |
+| 工具市场内容不完整 | 查看来源状态并点击刷新；在线来源不可用时仍会显示内置目录。 |
+| 导入提示冲突 | 查看导入预览，选择跳过或覆盖，并确认受影响的资源名称。 |
+| BootAgent 检查更新失败 | 在“设置”中切换 GitHub 与国内 Gitee 镜像后重试；检查失败不会替换现有安装文件。 |
+| Agent 下载失败 | 打开官方安装页面或手动安装，再回到 BootAgent 检测本机路径。BootAgent 不提供绕过网络限制的方式。 |
 
 ## 从源码构建
 
-需要 Go、Node.js、pnpm 11.21.0，以及目标平台的 WebView 依赖。Linux 构建使用 GTK4 和 WebKitGTK 6.0，不支持 GTK3。
+普通用户建议直接使用上面的发行包。开发需要 Go（版本以 `go.mod` 为准）、Node.js、pnpm `11.21.0` 和目标平台的 WebView 依赖。Linux 构建使用 GTK4 和 WebKitGTK 6.0。
 
 ```text
 git clone https://github.com/MaimoryLab/BootAgent.git
 cd BootAgent
-cd frontend && pnpm install --frozen-lockfile && pnpm run build && cd ..
+cd frontend
+pnpm install --frozen-lockfile
+pnpm run build
+cd ..
 go run -tags wails ./cmd/bootagent-desktop
 ```
 
-日常开发可安装 [Task](https://taskfile.dev/) 后运行 `task dev`。常用检查：
+要在当前主机生成生产二进制，运行 `task build:desktop`。常用检查命令：
 
 ```text
 go test ./...
@@ -81,19 +162,17 @@ cd frontend && pnpm run test && pnpm run build
 
 ## 项目链接
 
-- [AI Agent Kit](docs/ai-agent-kit/zh/README.md)：从零配置 Agent 环境
+- [AI Agent Kit](docs/ai-agent-kit/README.md)：从零完成第一次请求
 - [文档](docs/)：规范与架构决策
+- [安全策略](SECURITY.md)
+- [贡献指南](CONTRIBUTING.md)
 - [公开站仓库](https://github.com/MaimoryLab/BootAgent-site)
 - [Issues 与功能请求](https://github.com/MaimoryLab/BootAgent/issues)
 
 ## Star History
 
 <a href="https://www.star-history.com/?repos=MaimoryLab%2FBootAgent&type=date&legend=top-left">
- <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=MaimoryLab/BootAgent&type=date&theme=dark&legend=top-left&sealed_token=wiOLSOTugmyFse5tBQ7xZAHS9_V3irdr9ft2xDkbPA2rgy4SNDmm09LA6m0Umxjop30R4kn8yj675c_d5Q5NHGecjs3fB2FwpnKxVTDGomAZsz2OxbfN5ND7comOV52I39nuTN1T-zShOiDil29DAq92aduIm30ekevoULQV9mSaMacoTpsSo0O0tPPS" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=MaimoryLab/BootAgent&type=date&legend=top-left&sealed_token=wiOLSOTugmyFse5tBQ7xZAHS9_V3irdr9ft2xDkbPA2rgy4SNDmm09LA6m0Umxjop30R4kn8yj675c_d5Q5NHGecjs3fB2FwpnKxVTDGomAZsz2OxbfN5ND7comOV52I39nuTN1T-zShOiDil29DAq92aduIm30ekevoULQV9mSaMacoTpsSo0O0tPPS" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=MaimoryLab/BootAgent&type=date&legend=top-left&sealed_token=wiOLSOTugmyFse5tBQ7xZAHS9_V3irdr9ft2xDkbPA2rgy4SNDmm09LA6m0Umxjop30R4kn8yj675c_d5Q5NHGecjs3fB2FwpnKxVTDGomAZsz2OxbfN5ND7comOV52I39nuTN1T-zShOiDil29DAq92aduIm30ekevoULQV9mSaMacoTpsSo0O0tPPS" />
- </picture>
+  <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=MaimoryLab/BootAgent&type=Date">
 </a>
 
 ## 赞助


### PR DESCRIPTION
## Summary
- Reorganize README.md and README_ZH.md around first-run goals and clear next steps.
- Document current Marketplace, Skill/MCP transfer, supported Agent boundaries, privacy, updates, and troubleshooting.
- Add platform/package guidance and keep the English and Simplified Chinese structures aligned.

## Verification
- python3 scripts/check-docs.py
- pnpm dlx --package markdownlint-cli2 markdownlint-cli2 README.md README_ZH.md
- Relative link and image path checks
- git diff --check