### PR TITLE
ci: retain only current release line on Gitee

### DIFF
--- a/.github/workflows/sync-release.yml
+++ b/.github/workflows/sync-release.yml
@@ -19,18 +19,34 @@ jobs:
     name: Sync Releases to Gitee
     runs-on: ubuntu-latest
     if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
-    env:
-      RELEASE_VERSION: ${{ github.event_name == 'workflow_dispatch' && inputs.version || github.event.workflow_run.head_branch }}
     steps:
       - name: Check out release policy
         uses: actions/checkout@v4
+
+      - name: Resolve release version
+        id: release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MANUAL_VERSION: ${{ inputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
+            version="$MANUAL_VERSION"
+          else
+            # workflow_run.head_branch is "main" for tag-triggered runs. The
+            # completed build has just published the newest release, so resolve
+            # the tag from GitHub's release feed instead of trusting that field.
+            version="$(gh release list --repo MaimoryLab/BootAgent --limit 1 --json tagName --jq '.[0].tagName')"
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Validate release version
         shell: bash
         run: |
           set -euo pipefail
-          [[ "$RELEASE_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
-            echo "release version must match vX.Y.Z: $RELEASE_VERSION" >&2
+          [[ "${{ steps.release.outputs.version }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+            echo "release version must match vX.Y.Z: ${{ steps.release.outputs.version }}" >&2
             exit 1
           }
 
@@ -39,7 +55,7 @@ jobs:
       - name: Retain current Gitee release line
         env:
           GITEE_TOKEN: ${{ secrets.GITEE_TOKEN }}
-        run: python3 scripts/retain_gitee_release_line.py --version "$RELEASE_VERSION" --apply
+        run: python3 scripts/retain_gitee_release_line.py --version "${{ steps.release.outputs.version }}" --apply
 
       - name: Sync GitHub Release to Gitee
         uses: trustedinster/sync-release-gitee@v1.3

--- a/.github/workflows/sync-release.yml
+++ b/.github/workflows/sync-release.yml
@@ -2,6 +2,11 @@ name: Sync Releases to Gitee
 
 on:
   workflow_dispatch:
+    inputs:
+      version:
+        description: Release version to mirror (for example v0.8.5)
+        required: true
+        type: string
   workflow_run:
     workflows: [Build artifacts]
     types: [completed]
@@ -13,7 +18,29 @@ jobs:
   sync:
     name: Sync Releases to Gitee
     runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    env:
+      RELEASE_VERSION: ${{ github.event_name == 'workflow_dispatch' && inputs.version || github.event.workflow_run.head_branch }}
     steps:
+      - name: Check out release policy
+        uses: actions/checkout@v4
+
+      - name: Validate release version
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$RELEASE_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+            echo "release version must match vX.Y.Z: $RELEASE_VERSION" >&2
+            exit 1
+          }
+
+      # Gitee counts release attachments cumulatively. Remove only releases
+      # from older MAJOR.MINOR lines; Git tags and the current line remain.
+      - name: Retain current Gitee release line
+        env:
+          GITEE_TOKEN: ${{ secrets.GITEE_TOKEN }}
+        run: python3 scripts/retain_gitee_release_line.py --version "$RELEASE_VERSION" --apply
+
       - name: Sync GitHub Release to Gitee
         uses: trustedinster/sync-release-gitee@v1.3
         with:
@@ -25,4 +52,3 @@ jobs:
           gitee_upload_retry_times: 3
           debug: false
   
-

--- a/scripts/retain_gitee_release_line.py
+++ b/scripts/retain_gitee_release_line.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Retain only the current MAJOR.MINOR release line in Gitee.
+
+Gitee's release attachment quota is cumulative. The Git tags remain in the
+repository, but old Gitee Release objects (and their OTA attachments) are
+removed before the next release is mirrored. The script is intentionally
+opt-in: without --apply it only prints the releases that would be deleted.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+TAG_RE = re.compile(r"^v(\d+)\.(\d+)\.(\d+)$")
+API_ROOT = "https://gitee.com/api/v5"
+
+
+def release_line(tag: str) -> tuple[int, int] | None:
+    match = TAG_RE.fullmatch(tag.strip())
+    return (int(match.group(1)), int(match.group(2))) if match else None
+
+
+class GiteeAPI:
+    def __init__(self, token: str, owner: str, repo: str) -> None:
+        self.token = token
+        self.base = f"{API_ROOT}/repos/{urllib.parse.quote(owner)}/{urllib.parse.quote(repo)}"
+
+    def request(self, method: str, path: str) -> object:
+        url = self.base + path
+        request = urllib.request.Request(
+            url,
+            method=method,
+            headers={"Authorization": f"token {self.token}", "Accept": "application/json"},
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                payload = response.read()
+        except urllib.error.HTTPError as error:
+            body = error.read().decode("utf-8", errors="replace")
+            raise RuntimeError(f"Gitee API {method} {path} failed ({error.code}): {body[:500]}") from error
+        if not payload:
+            return None
+        return json.loads(payload)
+
+    def releases(self) -> list[dict[str, object]]:
+        result: list[dict[str, object]] = []
+        page = 1
+        while True:
+            payload = self.request("GET", f"/releases?per_page=100&page={page}")
+            if not isinstance(payload, list):
+                raise RuntimeError("Gitee releases response was not a list")
+            result.extend(item for item in payload if isinstance(item, dict))
+            if len(payload) < 100:
+                return result
+            page += 1
+
+    def delete_release(self, release_id: int) -> None:
+        self.request("DELETE", f"/releases/{release_id}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--version", required=True, help="release tag, for example v0.8.5")
+    parser.add_argument("--owner", default="maimory")
+    parser.add_argument("--repo", default="BootAgent")
+    parser.add_argument("--apply", action="store_true", help="delete old releases; default is dry-run")
+    args = parser.parse_args()
+
+    line = release_line(args.version)
+    if line is None:
+        print("version must match vX.Y.Z", file=sys.stderr)
+        return 2
+    token = os.environ.get("GITEE_TOKEN", "").strip()
+    if not token:
+        print("GITEE_TOKEN is required", file=sys.stderr)
+        return 2
+
+    api = GiteeAPI(token, args.owner, args.repo)
+    stale: list[tuple[int, str]] = []
+    for release in api.releases():
+        tag = str(release.get("tag_name", ""))
+        release_id = release.get("id")
+        if isinstance(release_id, int) and release_line(tag) not in (None, line):
+            stale.append((release_id, tag))
+
+    if not stale:
+        print(f"Gitee release line v{line[0]}.{line[1]} already retained; nothing to delete")
+        return 0
+    action = "would delete" if not args.apply else "deleting"
+    for release_id, tag in sorted(stale, key=lambda item: item[1]):
+        print(f"{action} Gitee release {tag} (id={release_id})")
+        if args.apply:
+            api.delete_release(release_id)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_retain_gitee_release_line.py
+++ b/scripts/test_retain_gitee_release_line.py
@@ -1,0 +1,31 @@
+import os
+import sys
+import unittest
+from unittest.mock import call, patch
+
+sys.path.insert(0, os.path.dirname(__file__))
+import retain_gitee_release_line as policy  # noqa: E402
+
+
+class RetainGiteeReleaseLineTests(unittest.TestCase):
+    def test_release_line(self):
+        self.assertEqual(policy.release_line("v0.8.4"), (0, 8))
+        self.assertIsNone(policy.release_line("0.8.4"))
+        self.assertIsNone(policy.release_line("v0.8"))
+
+    @patch.dict(os.environ, {"GITEE_TOKEN": "test-token"})
+    @patch.object(policy.GiteeAPI, "delete_release")
+    @patch.object(policy.GiteeAPI, "releases", return_value=[
+        {"id": 1, "tag_name": "v0.7.3"},
+        {"id": 2, "tag_name": "v0.8.0"},
+        {"id": 3, "tag_name": "v0.9.0"},
+        {"id": 4, "tag_name": "draft"},
+    ])
+    def test_apply_deletes_only_older_release_lines(self, _releases, delete):
+        with patch.object(sys, "argv", ["retain", "--version", "v0.8.4", "--apply"]):
+            self.assertEqual(policy.main(), 0)
+        self.assertEqual(delete.call_args_list, [call(1), call(3)])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- remove stale Gitee release lines before mirroring a release
- resolve workflow_run release version from the published GitHub Release
- keep the current MAJOR.MINOR line and all Git tags

## Validation
- python3 -m unittest scripts/test_retain_gitee_release_line.py
- git diff --check